### PR TITLE
Add mobile app backend rollout config endpoint

### DIFF
--- a/public/api/app-config.json
+++ b/public/api/app-config.json
@@ -1,0 +1,4 @@
+{
+  "backend": "supabase",
+  "rollout_percent": 100
+}


### PR DESCRIPTION
Static JSON endpoint for mobile apps to determine which backend (supabase/firebase) to use and at what rollout percentage. Currently set to 100% Supabase for all users.