### PR TITLE
feat: improve chassis decoder accuracy and add Australian Minis

### DIFF
--- a/app/pages/technical/chassis-decoder.vue
+++ b/app/pages/technical/chassis-decoder.vue
@@ -32,7 +32,16 @@
   // Template ref for smooth scrolling to results
   const decodedResultsSection = ref<HTMLElement>();
 
-  const yearRangeOptions = ['1959-1969', '1969-1974', '1974-1980', '1980', '1980-1985', '1985-1990', '1990-on'];
+  const yearRangeOptions = [
+    '1959-1969',
+    '1969-1974',
+    '1974-1980',
+    '1980',
+    '1980-1985',
+    '1985-1990',
+    '1990-on',
+    '1961-1978 (Australia)',
+  ];
 
   // Get example chassis number for selected year range
   const exampleChassisNumber = computed(() => {

--- a/data/models/decoders.ts
+++ b/data/models/decoders.ts
@@ -525,7 +525,7 @@ export const chassisRanges: ChassisRange[] = [
         2: [
           { value: 'M', name: 'Morris (Morris 850, Mini Deluxe, Mini Minor, Mini-Matic Mk1)' },
           { value: 'K', name: 'Morris Cooper / Cooper S (997cc, 998cc, or 1275cc engines)' },
-          { value: 'J', name: 'Commercial — Van or Utility body (e.g. YJBAV1R)' },
+          { value: 'J', name: 'Commercial — Van or Utility body' },
         ],
         3: [
           { value: 'A', name: 'A-series engine, 800–999cc (848cc or 998cc)' },
@@ -541,8 +541,8 @@ export const chassisRanges: ChassisRange[] = [
           { value: '2', name: 'Mk2: Morris Mini Deluxe (YMA2S2) or Cooper S Mk1 (YKG2S2), 1966–1969' },
           { value: '3', name: 'Mini Minor / Mini 1100 / Deluxe update (YMA2S3), 1969+' },
           { value: '4', name: 'Mini-Matic Mk1 (YMA2S4) or Cooper S Mk2, 1967–1969' },
-          { value: '5', name: 'Mini-Matic Mk2 (YA2S5)' },
-          { value: '8', name: 'Clubman GT (YG2S8)' },
+          { value: '5', name: 'Mini-Matic Mk2' },
+          { value: '8', name: 'Clubman GT' },
         ],
         7: [],
         8: [],

--- a/data/models/decoders.ts
+++ b/data/models/decoders.ts
@@ -3,6 +3,11 @@
   Metro Engine ID Info: https://www.minimania.com/Engine___Metro_engine_identification_data
   Chassis Info: https://www.minimania.com/Mini_Chassis_VIN_and_Commission_Numbers__Part_I__Revised_
   Chassis Info 2: https://www.minimania.com/Mini_Chassis_VIN_and_Commission_Numbers__Part_II
+  Production History: https://www.somerfordmini.co.uk/mini-production-history
+  JoltFreak VIN Guide: https://joltfreak.tripod.com/id13.html
+  Australian Minis: https://eight-fifty.com/identification/australian-minis/
+  Australian ID Plate: https://eight-fifty.com/identification/identification-plate/
+  Victorian Mini Club ID Guide: https://www.mini.org.au/identify-a-classic-mini
 */
 export interface ChassisRange {
   title: string;
@@ -140,19 +145,20 @@ export const chassisRanges: ChassisRange[] = [
       options: {
         1: [{ value: 'X', name: 'This is simply dismissed by the factory as "non-significant"!' }],
         2: [
-          { value: 'A', name: '848cc engine' },
-          { value: 'A', name: '998cc engine' },
-          { value: 'A', name: '1275cc Cooper S and 1275 GT engine' },
+          {
+            value: 'A',
+            name: 'A-series engine (848cc Mini 850, 998cc Mini 1000, or 1275cc Cooper S Mk3 / 1275GT)',
+          },
         ],
         3: [
           {
             value: '2S',
             name: '2-door Saloon (except Mk3 Cooper S and 1275GT). Caution: bureaucratic bungles often misinterpret this as 25',
           },
-          { value: '2W', name: 'Estate (“2-door Dual Purpose”)' },
-          { value: 'D', name: '2-door saloon (Mk3 Cooper S and 1275GT only)' },
-          { value: 'U', name: 'Pick-up. Caution: "U" and "V" can be mistaken one for the other' },
-          { value: 'V', name: 'Panel van. Caution: "U" and "V" can be mistaken one for the other' },
+          { value: '2W', name: 'Estate (“2-door Dual Purpose”). Used on X-A2W2 / X-L2W2 Clubman Estate prefixes' },
+          { value: 'D', name: '2-door saloon (Mk3 Cooper S X-AD1 and 1275GT X-AD2 only)' },
+          { value: 'U', name: 'Pick-up (e.g. X-AU1). Caution: "U" and "V" can be mistaken one for the other' },
+          { value: 'V', name: 'Panel van (e.g. X-AV1). Caution: "U" and "V" can be mistaken one for the other' },
         ],
         4: [
           { value: '', name: 'Mini 850. Produced only in the "round nose" style' },
@@ -215,15 +221,15 @@ export const chassisRanges: ChassisRange[] = [
         3: [
           {
             value: '2D',
-            name: 'Unclear if this was used for chassis numbers in this generation',
+            name: '1275GT 2-door saloon (e.g. X-E2D2 prefix, 1974-1980)',
           },
           {
             value: '2S',
             name: '2-door Saloon (except 1275GT). Bureaucratic bungles often interpret this as 25',
           },
-          { value: '2W', name: 'Estate (“2-door Dual Purpose”)' },
-          { value: 'U', name: 'Pick-up. "U" and "V" can be mistaken one for the other' },
-          { value: 'V', name: 'Panel van. "U" and "V" can be mistaken one for the other' },
+          { value: '2W', name: 'Estate (“2-door Dual Purpose”). Used on X-L2W2 / X-C2W2 Clubman Estate' },
+          { value: 'U', name: 'Pick-up (e.g. X-KU1, X-LU1). "U" and "V" can be mistaken one for the other' },
+          { value: 'V', name: 'Panel van (e.g. X-KV1, X-LV1). "U" and "V" can be mistaken one for the other' },
         ],
         4: [
           {
@@ -236,16 +242,20 @@ export const chassisRanges: ChassisRange[] = [
           },
         ],
         5: [
-          { value: 'A', name: '1970' },
-          { value: 'B', name: '1971' },
-          { value: 'C', name: '1972' },
-          { value: 'D', name: '1973' },
-          { value: 'E', name: '1974' },
-          { value: 'F', name: '1975' },
-          { value: 'G', name: '1976' },
-          { value: 'H', name: '1977' },
-          { value: 'J', name: '1978' },
-          { value: 'L', name: '1979' },
+          {
+            value: 'N',
+            name: 'Standard/Special Deluxe trim (non-North America markets). Most common Rest-of-World value.',
+          },
+          { value: 'A', name: '1970 model year (North America)' },
+          { value: 'B', name: '1971 model year (North America)' },
+          { value: 'C', name: '1972 model year (North America)' },
+          { value: 'D', name: '1973 model year (North America)' },
+          { value: 'E', name: '1974 model year (North America)' },
+          { value: 'F', name: '1975 model year (North America)' },
+          { value: 'G', name: '1976 model year (North America)' },
+          { value: 'H', name: '1977 model year (North America)' },
+          { value: 'J', name: '1978 model year (North America)' },
+          { value: 'L', name: '1979 model year (North America)' },
         ],
         6: [],
         7: [],
@@ -399,11 +409,14 @@ export const chassisRanges: ChassisRange[] = [
           },
         ],
         7: [],
-        8: [{ value: '1', name: 'Round nose, traditional Mini body style.' }],
+        8: [
+          { value: '1', name: 'Round nose, traditional Mini body style (non-catalyst)' },
+          { value: '3', name: 'Round nose, catalyst-equipped (1989+ emissions spec, e.g. X-L2S3N/O/S)' },
+        ],
         9: [
           { value: 'N', name: 'HLE, or Mayfair (right-hand drive)' },
-          { value: 'O', name: 'E, City E' },
-          { value: 'S', name: 'Mayfair (left-hand drive)' },
+          { value: 'O', name: 'E, City, or City E' },
+          { value: 'S', name: 'Mayfair (left-hand drive, Europe)' },
         ],
         10: [
           {
@@ -446,10 +459,11 @@ export const chassisRanges: ChassisRange[] = [
         4: [{ value: 'XN', name: 'Mini 1300' }],
         5: [],
         6: [
-          { value: 'N', name: 'Sport, Cooper, Cabriolet' },
+          { value: 'C', name: 'Cooper / Cooper 1.3i / Cooper MPi (XN-CA prefix, 1990-2000)' },
+          { value: 'N', name: 'Sport, Cabriolet, or similar performance/limited-edition trim' },
           { value: 'V', name: 'Kensington' },
-          { value: 'W', name: 'HLS, Mayfair' },
-          { value: 'Y', name: 'City, Sprite' },
+          { value: 'W', name: 'HLS, Mayfair, Mayfair 1.3i, MPi (XN-WA prefix)' },
+          { value: 'Y', name: 'City, Sprite (XN-YA prefix)' },
         ],
         7: [
           { value: 'A', name: '2-door Saloon' },
@@ -479,6 +493,64 @@ export const chassisRanges: ChassisRange[] = [
         11: [{ value: 'D', name: 'Longbridge' }],
       },
       number: '######',
+      last: [],
+    },
+  },
+  {
+    // Australian-built Minis (BMC / Leyland Australia, Zetland/Enfield, NSW).
+    // Primary 6-character body/type code used on the ID plate, e.g. YMA2S1-####.
+    // References: eight-fifty.com, mini.org.au. Note that later Leyland-era cars
+    // (Mini K, 1100, Clubman GT) dropped the make letter and used a 5-char code
+    // like YG2S1 — that shorter variant is not yet handled here.
+    title: '1961-1978 (Australia)',
+    value: {
+      // YMA2S1-####
+      PrimaryExample: {
+        1: 'Y',
+        2: 'M',
+        3: 'A',
+        4: '2',
+        5: 'S',
+        6: '1',
+        7: '',
+        8: '',
+        9: '',
+        10: '',
+        11: '',
+        numbers: '####',
+        last: '',
+      },
+      options: {
+        1: [{ value: 'Y', name: 'Origin of manufacture: Australia (BMC / Leyland Australia, Zetland NSW)' }],
+        2: [
+          { value: 'M', name: 'Morris (Morris 850, Mini Deluxe, Mini Minor, Mini-Matic Mk1)' },
+          { value: 'K', name: 'Morris Cooper / Cooper S (997cc, 998cc, or 1275cc engines)' },
+          { value: 'J', name: 'Commercial — Van or Utility body (e.g. YJBAV1R)' },
+        ],
+        3: [
+          { value: 'A', name: 'A-series engine, 800–999cc (848cc or 998cc)' },
+          { value: 'G', name: 'A-series engine, 1275cc (Cooper S Mk1, typically YKG2S2)' },
+        ],
+        4: [{ value: '2', name: '2-door body' }],
+        5: [
+          { value: 'S', name: 'Saloon (Sedan)' },
+          { value: 'V', name: 'Van / Commercial body' },
+        ],
+        6: [
+          { value: '1', name: 'Mk1: Morris 850 (YMA2S1) or Morris Cooper (YKA2S1), 1961–1966' },
+          { value: '2', name: 'Mk2: Morris Mini Deluxe (YMA2S2) or Cooper S Mk1 (YKG2S2), 1966–1969' },
+          { value: '3', name: 'Mini Minor / Mini 1100 / Deluxe update (YMA2S3), 1969+' },
+          { value: '4', name: 'Mini-Matic Mk1 (YMA2S4) or Cooper S Mk2, 1967–1969' },
+          { value: '5', name: 'Mini-Matic Mk2 (YA2S5)' },
+          { value: '8', name: 'Clubman GT (YG2S8)' },
+        ],
+        7: [],
+        8: [],
+        9: [],
+        10: [],
+        11: [],
+      },
+      number: '####',
       last: [],
     },
   },

--- a/server/api/decoders/chassis.ts
+++ b/server/api/decoders/chassis.ts
@@ -520,10 +520,10 @@ export default defineEventHandler(async (event): Promise<ChassisDecoderResponse>
       });
     }
 
-    if (body.yearRange.length > 20) {
+    if (body.yearRange.length > 30) {
       throw createError({
         statusCode: 400,
-        statusMessage: 'Year range too long (maximum 20 characters)',
+        statusMessage: 'Year range too long (maximum 30 characters)',
       });
     }
 

--- a/server/mcp/tools/chassis-decoder.ts
+++ b/server/mcp/tools/chassis-decoder.ts
@@ -7,19 +7,19 @@ import { chassisRanges } from '../../../data/models/decoders';
  */
 export default defineMcpTool({
   description:
-    'Decode and validate Classic Mini chassis numbers based on year range. Supports chassis formats from 1959-1969, 1969-1974, 1974-1980, 1980, 1980-1985, 1985-1990, and 1990-on. Provides position-by-position breakdown of chassis number components.',
+    'Decode and validate Classic Mini chassis numbers based on year range. Supports UK chassis formats from 1959-1969, 1969-1974, 1974-1980, 1980, 1980-1985, 1985-1990, and 1990-on, plus Australian-built Minis (1961-1978) using the 6-character YMA2S1-style body/type code. Provides position-by-position breakdown of chassis number components.',
 
   inputSchema: {
     yearRange: z
-      .enum(['1959-1969', '1969-1974', '1974-1980', '1980', '1980-1985', '1985-1990', '1990-on'])
+      .enum(['1959-1969', '1969-1974', '1974-1980', '1980', '1980-1985', '1985-1990', '1990-on', '1961-1978 (Australia)'])
       .describe(
-        'Year range for chassis number format. Each era has a different chassis number structure and decoding rules.'
+        'Year range for chassis number format. Each era has a different chassis number structure and decoding rules. Use "1961-1978 (Australia)" for Australian-built Morris / Cooper Minis.'
       ),
     chassisNumber: z
       .string()
       .min(1)
       .max(50)
-      .describe('Classic Mini chassis number to decode (e.g., "A-A2S7L-123A" for 1959-1969)'),
+      .describe('Classic Mini chassis number to decode (e.g., "A-A2S7L-123A" for 1959-1969, or "YMA2S1-12345" for Australian Morris 850)'),
   },
 
   async handler({ yearRange, chassisNumber }) {

--- a/tests/unit/data/decoders-model.test.ts
+++ b/tests/unit/data/decoders-model.test.ts
@@ -10,8 +10,8 @@ describe('chassisRanges', () => {
     expect(Array.isArray(chassisRanges)).toBe(true);
   });
 
-  it('has exactly 7 entries', () => {
-    expect(chassisRanges).toHaveLength(7);
+  it('has exactly 8 entries', () => {
+    expect(chassisRanges).toHaveLength(8);
   });
 
   it('each entry has a title string', () => {
@@ -182,5 +182,184 @@ describe('chassisRanges spot checks', () => {
     expect(range1985).toBeDefined();
     const option1 = range1985!.value.options['1'];
     expect(option1.some((o) => o.value === 'SAX')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chassisRanges - 1969-1974 consolidation: no duplicate option values
+// ---------------------------------------------------------------------------
+describe('chassisRanges 1969-1974 position 2 consolidation', () => {
+  it('has no duplicate "A" entries in position 2', () => {
+    const range = chassisRanges.find((r) => r.title === '1969-1974');
+    expect(range).toBeDefined();
+    const pos2 = range!.value.options['2'];
+    const aEntries = pos2.filter((o) => o.value === 'A');
+    expect(aEntries).toHaveLength(1);
+  });
+
+  it('position 2 has unique values across all entries', () => {
+    const range = chassisRanges.find((r) => r.title === '1969-1974');
+    expect(range).toBeDefined();
+    const pos2 = range!.value.options['2'];
+    const values = pos2.map((o) => o.value);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chassisRanges - 1974-1980 additions
+// ---------------------------------------------------------------------------
+describe('chassisRanges 1974-1980 additions', () => {
+  it('position 5 includes "N" trim (Special Deluxe / non-North America)', () => {
+    const range = chassisRanges.find((r) => r.title === '1974-1980');
+    expect(range).toBeDefined();
+    const pos5 = range!.value.options['5'];
+    const nEntry = pos5.find((o) => o.value === 'N');
+    expect(nEntry).toBeDefined();
+    expect(nEntry!.name).toMatch(/Special Deluxe|non-North America/i);
+  });
+
+  it('position 3 "2D" entry identifies the 1275GT', () => {
+    const range = chassisRanges.find((r) => r.title === '1974-1980');
+    expect(range).toBeDefined();
+    const pos3 = range!.value.options['3'];
+    const twoD = pos3.find((o) => o.value === '2D');
+    expect(twoD).toBeDefined();
+    expect(twoD!.name).toMatch(/1275GT/);
+    expect(twoD!.name).not.toMatch(/unclear/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chassisRanges - 1985-1990 additions
+// ---------------------------------------------------------------------------
+describe('chassisRanges 1985-1990 additions', () => {
+  it('position 8 includes "3" for catalyst-equipped variants', () => {
+    const range = chassisRanges.find((r) => r.title === '1985-1990');
+    expect(range).toBeDefined();
+    const pos8 = range!.value.options['8'];
+    const catalyst = pos8.find((o) => o.value === '3');
+    expect(catalyst).toBeDefined();
+    expect(catalyst!.name).toMatch(/catalyst/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chassisRanges - 1990-on additions
+// ---------------------------------------------------------------------------
+describe('chassisRanges 1990-on additions', () => {
+  it('position 6 includes "C" for Cooper variants', () => {
+    const range = chassisRanges.find((r) => r.title === '1990-on');
+    expect(range).toBeDefined();
+    const pos6 = range!.value.options['6'];
+    const cooper = pos6.find((o) => o.value === 'C');
+    expect(cooper).toBeDefined();
+    expect(cooper!.name).toMatch(/Cooper/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chassisRanges - Australia (1961-1978) full shape and content
+// ---------------------------------------------------------------------------
+describe('chassisRanges 1961-1978 (Australia)', () => {
+  const getAU = (): ChassisRange => {
+    const r = chassisRanges.find((x) => x.title === '1961-1978 (Australia)');
+    expect(r).toBeDefined();
+    return r!;
+  };
+
+  it('exists in chassisRanges', () => {
+    const titles = chassisRanges.map((r) => r.title);
+    expect(titles).toContain('1961-1978 (Australia)');
+  });
+
+  it('PrimaryExample follows YMA2S1 pattern in positions 1-6', () => {
+    const range = getAU();
+    const ex = range.value.PrimaryExample;
+    expect(ex['1']).toBe('Y');
+    expect(ex['2']).toBe('M');
+    expect(ex['3']).toBe('A');
+    expect(ex['4']).toBe('2');
+    expect(ex['5']).toBe('S');
+    expect(ex['6']).toBe('1');
+  });
+
+  it('PrimaryExample positions 7-11 are empty strings', () => {
+    const range = getAU();
+    const ex = range.value.PrimaryExample;
+    for (const p of ['7', '8', '9', '10', '11'] as const) {
+      expect(ex[p]).toBe('');
+    }
+  });
+
+  it('position 1 has exactly one option "Y" for Australian origin', () => {
+    const range = getAU();
+    const pos1 = range.value.options['1'];
+    expect(pos1).toHaveLength(1);
+    expect(pos1[0].value).toBe('Y');
+    expect(pos1[0].name).toMatch(/Australia/);
+  });
+
+  it('position 2 includes M (Morris), K (Cooper), and J (Commercial)', () => {
+    const range = getAU();
+    const values = range.value.options['2'].map((o) => o.value);
+    expect(values).toEqual(expect.arrayContaining(['M', 'K', 'J']));
+  });
+
+  it('position 3 includes A (800-999cc) and G (1275cc Cooper S)', () => {
+    const range = getAU();
+    const pos3 = range.value.options['3'];
+    const a = pos3.find((o) => o.value === 'A');
+    const g = pos3.find((o) => o.value === 'G');
+    expect(a).toBeDefined();
+    expect(g).toBeDefined();
+    expect(g!.name).toMatch(/1275/);
+  });
+
+  it('position 4 has only "2" for two-door body', () => {
+    const range = getAU();
+    const pos4 = range.value.options['4'];
+    expect(pos4).toHaveLength(1);
+    expect(pos4[0].value).toBe('2');
+  });
+
+  it('position 5 includes S (Saloon) and V (Van/Commercial)', () => {
+    const range = getAU();
+    const values = range.value.options['5'].map((o) => o.value);
+    expect(values).toEqual(expect.arrayContaining(['S', 'V']));
+  });
+
+  it('position 6 covers Mk1 through Clubman GT variants', () => {
+    const range = getAU();
+    const values = range.value.options['6'].map((o) => o.value);
+    // At minimum: Mk1 (1), Mk2 (2), an autotrans variant, and the Clubman GT code (8)
+    expect(values).toEqual(expect.arrayContaining(['1', '2', '8']));
+  });
+
+  it('positions 7-11 are empty arrays (unused for 6-char AU format)', () => {
+    const range = getAU();
+    const opts = range.value.options;
+    expect(opts['7']).toEqual([]);
+    expect(opts['8']).toEqual([]);
+    expect(opts['9']).toEqual([]);
+    expect(opts['10']).toEqual([]);
+    expect(opts['11']).toEqual([]);
+  });
+
+  it('last array is empty (no assembly plant suffix)', () => {
+    const range = getAU();
+    const lastArr = range.value.last as unknown[];
+    expect(Array.isArray(lastArr)).toBe(true);
+    expect(lastArr).toHaveLength(0);
+  });
+
+  it('every option entry has a descriptive name longer than 3 chars', () => {
+    const range = getAU();
+    const opts = range.value.options;
+    for (let i = 1; i <= 6; i++) {
+      for (const entry of opts[String(i) as keyof typeof opts]) {
+        expect(entry.name.length).toBeGreaterThan(3);
+      }
+    }
   });
 });

--- a/tests/unit/server/api/decoders/chassis.test.ts
+++ b/tests/unit/server/api/decoders/chassis.test.ts
@@ -84,9 +84,9 @@ describe('server/api/decoders/chassis', () => {
       }
     });
 
-    it('throws 400 when yearRange is too long (over 20 chars)', async () => {
+    it('throws 400 when yearRange is too long (over 30 chars)', async () => {
       vi.mocked(readBody).mockResolvedValue({
-        yearRange: 'A'.repeat(21),
+        yearRange: 'A'.repeat(31),
         chassisNumber: 'ABC123',
       });
       await expect(handler({})).rejects.toThrow();
@@ -273,6 +273,37 @@ describe('server/api/decoders/chassis', () => {
       expect(result.decodedPositions.length).toBeGreaterThan(0);
     });
 
+    it('accepts N trim in position 5 for non-North America (Special Deluxe)', async () => {
+      // N is the most common rest-of-world value and matches the PrimaryExample
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1974-1980',
+        chassisNumber: 'X-L2S1N-123456A',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.success).toBe(true);
+      expect(result.isValid).toBe(true);
+      const pos5 = result.decodedPositions.find((p: any) => p.position === 5);
+      expect(pos5).toBeTruthy();
+      expect(pos5.value).toBe('N');
+      expect(pos5.matched).toBe(true);
+      expect(pos5.name).toMatch(/Special Deluxe|non-North America/i);
+    });
+
+    it('accepts 2D body code for 1275GT prefixes (e.g. X-E2D2)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1974-1980',
+        chassisNumber: 'X-E2D2N-123456A',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.isValid).toBe(true);
+      const pos3 = result.decodedPositions.find((p: any) => p.position === 3);
+      expect(pos3).toBeTruthy();
+      expect(pos3.value).toBe('2D');
+      expect(pos3.name).toMatch(/1275GT/);
+    });
+
     it('missing assembly plant is inferred for 1974-1980', async () => {
       vi.mocked(readBody).mockResolvedValue({
         yearRange: '1974-1980',
@@ -349,6 +380,21 @@ describe('server/api/decoders/chassis', () => {
       expect(pos13.value).toBe('(missing)');
       expect(pos13.name).toContain('Non-English');
     });
+
+    it('accepts catalyst-equipped code "3" at position 8 (e.g. X-L2S3N)', async () => {
+      // Catalyst-equipped Mini Mayfair 1989-92: SAX-X-L2S3N20-####-A
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1985-1990',
+        chassisNumber: 'SAX-X-L2S3N20-123456A',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.isValid).toBe(true);
+      const pos8 = result.decodedPositions.find((p: any) => p.position === 8);
+      expect(pos8).toBeTruthy();
+      expect(pos8.value).toBe('3');
+      expect(pos8.name).toMatch(/catalyst/i);
+    });
   });
 
   describe('decoding 1990-on chassis numbers', () => {
@@ -379,6 +425,100 @@ describe('server/api/decoders/chassis', () => {
       expect(pos11).toBeTruthy();
       expect(pos11.value).toBe('(missing)');
       expect(pos11.matched).toBe(true);
+    });
+
+    it('accepts Cooper code "C" at position 6 (XN-CA prefix)', async () => {
+      // Mini Cooper 1990-96: SAX-XN-C-A-...  (Cooper 1.3i, MPi etc.)
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1990-on',
+        chassisNumber: 'SAXXN-C-A-Y-B-B-D-123456',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.isValid).toBe(true);
+      const pos6 = result.decodedPositions.find((p: any) => p.position === 6);
+      expect(pos6).toBeTruthy();
+      expect(pos6.value).toBe('C');
+      expect(pos6.name).toMatch(/Cooper/);
+    });
+  });
+
+  describe('decoding 1961-1978 (Australia) chassis numbers', () => {
+    // PrimaryExample: Y M A 2 S 1 - #### (6-char body/type code)
+    // Valid: YMA2S1-12345
+    it('decodes a valid Australian Morris 850 (YMA2S1)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1-12345',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.success).toBe(true);
+      expect(result.yearRange).toBe('1961-1978 (Australia)');
+      expect(result.isValid).toBe(true);
+      // Origin
+      const pos1 = result.decodedPositions.find((p: any) => p.position === 1);
+      expect(pos1?.value).toBe('Y');
+      expect(pos1?.name).toMatch(/Australia/);
+      // Make = Morris
+      const pos2 = result.decodedPositions.find((p: any) => p.position === 2);
+      expect(pos2?.value).toBe('M');
+      expect(pos2?.name).toMatch(/Morris/);
+      // Production number extracted
+      const numberPos = result.decodedPositions.find((p: any) => p.position === 12);
+      expect(numberPos?.value).toBe('12345');
+    });
+
+    it('decodes an Australian Morris Cooper (YKA2S1)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YKA2S1-98765',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.isValid).toBe(true);
+      const pos2 = result.decodedPositions.find((p: any) => p.position === 2);
+      expect(pos2?.value).toBe('K');
+      expect(pos2?.name).toMatch(/Cooper/);
+    });
+
+    it('decodes an Australian Cooper S Mk1 (YKG2S2) with 1275 engine code G', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YKG2S2-5555',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.isValid).toBe(true);
+      const pos3 = result.decodedPositions.find((p: any) => p.position === 3);
+      expect(pos3?.value).toBe('G');
+      expect(pos3?.name).toMatch(/1275/);
+      const pos6 = result.decodedPositions.find((p: any) => p.position === 6);
+      expect(pos6?.value).toBe('2');
+    });
+
+    it('decodes an Australian Mini Deluxe (YMA2S2)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S2-1001',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.isValid).toBe(true);
+      const pos6 = result.decodedPositions.find((p: any) => p.position === 6);
+      expect(pos6?.value).toBe('2');
+      expect(pos6?.name).toMatch(/Mk2|Deluxe/);
+    });
+
+    it('flags an unknown Make letter as invalid (e.g. Z at position 2)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YZA2S1-12345',
+      });
+      const result = await handler({});
+      expect(result.success).toBe(true);
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
     });
   });
 
@@ -493,6 +633,358 @@ describe('server/api/decoders/chassis', () => {
       const result = await handler({});
       expect(result.isValid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ============================================================
+  // Australian range — exhaustive position coverage
+  // ============================================================
+
+  describe('1961-1978 (Australia) — every Make letter (position 2)', () => {
+    const cases: Array<{ marque: 'M' | 'K' | 'J'; chassis: string; match: RegExp }> = [
+      { marque: 'M', chassis: 'YMA2S1-10001', match: /Morris/ },
+      { marque: 'K', chassis: 'YKA2S1-10002', match: /Cooper/ },
+      { marque: 'J', chassis: 'YJA2V1-10003', match: /Commercial|Van|Utility/ },
+    ];
+
+    for (const { marque, chassis, match } of cases) {
+      it(`decodes marque letter "${marque}" correctly`, async () => {
+        vi.mocked(readBody).mockResolvedValue({
+          yearRange: '1961-1978 (Australia)',
+          chassisNumber: chassis,
+        });
+        const result = await handler({});
+        const pos2 = result.decodedPositions.find((p: any) => p.position === 2);
+        expect(pos2?.value).toBe(marque);
+        expect(pos2?.matched).toBe(true);
+        expect(pos2?.name).toMatch(match);
+      });
+    }
+  });
+
+  describe('1961-1978 (Australia) — every engine code (position 3)', () => {
+    it('decodes "A" engine (800-999cc)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1-10001',
+      });
+      const result = await handler({});
+      const pos3 = result.decodedPositions.find((p: any) => p.position === 3);
+      expect(pos3?.value).toBe('A');
+      expect(pos3?.matched).toBe(true);
+      expect(pos3?.name).toMatch(/800|848|998/);
+    });
+
+    it('decodes "G" engine (1275cc Cooper S)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YKG2S2-10002',
+      });
+      const result = await handler({});
+      const pos3 = result.decodedPositions.find((p: any) => p.position === 3);
+      expect(pos3?.value).toBe('G');
+      expect(pos3?.matched).toBe(true);
+      expect(pos3?.name).toMatch(/1275/);
+    });
+
+    it('flags unknown engine letter "X" as unmatched at position 3', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMX2S1-10004',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(false);
+      const pos3 = result.decodedPositions.find((p: any) => p.position === 3);
+      expect(pos3?.matched).toBe(false);
+    });
+  });
+
+  describe('1961-1978 (Australia) — every body letter (position 5)', () => {
+    it('decodes "S" as Saloon', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1-20001',
+      });
+      const result = await handler({});
+      const pos5 = result.decodedPositions.find((p: any) => p.position === 5);
+      expect(pos5?.value).toBe('S');
+      expect(pos5?.name).toMatch(/Saloon|Sedan/);
+    });
+
+    it('decodes "V" as Van / Commercial', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YJA2V1-20002',
+      });
+      const result = await handler({});
+      const pos5 = result.decodedPositions.find((p: any) => p.position === 5);
+      expect(pos5?.value).toBe('V');
+      expect(pos5?.name).toMatch(/Van|Commercial/);
+    });
+
+    it('flags unknown body letter "X" as unmatched at position 5', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2X1-20003',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(false);
+      const pos5 = result.decodedPositions.find((p: any) => p.position === 5);
+      expect(pos5?.matched).toBe(false);
+    });
+  });
+
+  describe('1961-1978 (Australia) — every model digit (position 6)', () => {
+    const cases: Array<{ digit: string; chassis: string; match: RegExp }> = [
+      { digit: '1', chassis: 'YMA2S1-30001', match: /Mk1/i },
+      { digit: '2', chassis: 'YMA2S2-30002', match: /Mk2|Deluxe/i },
+      { digit: '3', chassis: 'YMA2S3-30003', match: /Mini Minor|Mini 1100|1969/ },
+      { digit: '4', chassis: 'YMA2S4-30004', match: /Mini-Matic|Cooper S/i },
+      { digit: '5', chassis: 'YMA2S5-30005', match: /Mini-Matic Mk2/i },
+      { digit: '8', chassis: 'YMA2S8-30008', match: /Clubman GT/ },
+    ];
+
+    for (const { digit, chassis, match } of cases) {
+      it(`decodes model digit "${digit}"`, async () => {
+        vi.mocked(readBody).mockResolvedValue({
+          yearRange: '1961-1978 (Australia)',
+          chassisNumber: chassis,
+        });
+        const result = await handler({});
+        const pos6 = result.decodedPositions.find((p: any) => p.position === 6);
+        expect(pos6?.value).toBe(digit);
+        expect(pos6?.matched).toBe(true);
+        expect(pos6?.name).toMatch(match);
+      });
+    }
+
+    it('flags unknown model digit "9" as unmatched at position 6', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S9-30009',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(false);
+      const pos6 = result.decodedPositions.find((p: any) => p.position === 6);
+      expect(pos6?.matched).toBe(false);
+    });
+  });
+
+  describe('1961-1978 (Australia) — production number and pattern', () => {
+    it('extracts the production sequence into position 12', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1-99999',
+      });
+      const result = await handler({});
+      const numberPos = result.decodedPositions.find((p: any) => p.position === 12);
+      expect(numberPos?.value).toBe('99999');
+      expect(numberPos?.matched).toBe(true);
+    });
+
+    it('accepts short production numbers (e.g. 101)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1-101',
+      });
+      const result = await handler({});
+      const numberPos = result.decodedPositions.find((p: any) => p.position === 12);
+      expect(numberPos?.value).toBe('101');
+    });
+
+    it('returns pattern "YMA2S1####" for Australian range', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1-12345',
+      });
+      const result = await handler({});
+      expect(result.pattern).toBe('YMA2S1####');
+    });
+
+    it('accepts chassis numbers without hyphen separator', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1 12345',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('1961-1978 (Australia) — combined spot checks', () => {
+    it('decodes a full Morris Cooper S Mk1 (YKG2S2)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YKG2S2-12345',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      expect(result.decodedPositions.find((p: any) => p.position === 2)?.value).toBe('K');
+      expect(result.decodedPositions.find((p: any) => p.position === 3)?.value).toBe('G');
+      expect(result.decodedPositions.find((p: any) => p.position === 6)?.value).toBe('2');
+    });
+
+    it('case-insensitive: lowercase input is uppercased and decodes', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'yma2s1-12345',
+      });
+      const result = await handler({});
+      expect(result.chassisNumber).toBe('YMA2S1-12345');
+      expect(result.isValid).toBe(true);
+    });
+
+    it('reports errors when origin letter is wrong (e.g. "XMA2S1")', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'XMA2S1-12345',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(false);
+      const pos1 = result.decodedPositions.find((p: any) => p.position === 1);
+      expect(pos1?.matched).toBe(false);
+    });
+
+    it('accepts the 30-char year range string (boundary check)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)', // 22 chars — previously over old 20-char limit
+        chassisNumber: 'YMA2S1-12345',
+      });
+      const result = await handler({});
+      expect(result).toBeTruthy();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ============================================================
+  // UK additions — expanded coverage
+  // ============================================================
+
+  describe('1974-1980 — "N" trim (Special Deluxe) exhaustive checks', () => {
+    it('N trim is accepted alongside canonical engine code K (Austin saloon)', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1974-1980',
+        chassisNumber: 'X-K2S1N-200001A',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      const pos5 = result.decodedPositions.find((p: any) => p.position === 5);
+      expect(pos5?.value).toBe('N');
+    });
+
+    it('N trim is accepted with alternative Morris (L) engine code prefix', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1974-1980',
+        chassisNumber: 'X-L2S1N-200002A',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      const pos5 = result.decodedPositions.find((p: any) => p.position === 5);
+      expect(pos5?.value).toBe('N');
+      expect(pos5?.name).toMatch(/Special Deluxe|non-North America/i);
+    });
+  });
+
+  describe('1974-1980 — "2D" 1275GT body code exhaustive checks', () => {
+    it('accepts E-engine + 2D body for a 1275GT', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1974-1980',
+        chassisNumber: 'X-E2D2N-200010A',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      const pos3 = result.decodedPositions.find((p: any) => p.position === 3);
+      expect(pos3?.value).toBe('2D');
+      expect(pos3?.name).toMatch(/1275GT/);
+      expect(pos3?.name).not.toMatch(/unclear/i);
+    });
+  });
+
+  describe('1985-1990 — catalyst "3" exhaustive checks', () => {
+    it('accepts "3" at position 8 alongside Mini Mayfair L2S pattern', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1985-1990',
+        chassisNumber: 'SAX-X-L2S3N20-300010A',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      const pos8 = result.decodedPositions.find((p: any) => p.position === 8);
+      expect(pos8?.value).toBe('3');
+      expect(pos8?.name).toMatch(/catalyst/i);
+    });
+
+    it('existing "1" (non-catalyst) option still decodes alongside "3"', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1985-1990',
+        chassisNumber: 'SAX-X-L2S1N20-300011A',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      const pos8 = result.decodedPositions.find((p: any) => p.position === 8);
+      expect(pos8?.value).toBe('1');
+      // "1" explicitly identifies the non-catalyst variant (the name contains
+      // "non-catalyst"), which is distinct from "3" (catalyst-equipped).
+      expect(pos8?.name).toMatch(/non-catalyst/i);
+      expect(pos8?.name).not.toMatch(/catalyst-equipped/i);
+    });
+  });
+
+  describe('1990-on — Cooper "C" exhaustive checks', () => {
+    it('accepts XN-C-A pattern for Cooper 1.3i', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1990-on',
+        chassisNumber: 'SAXXN-C-A-Y-B-B-D-400010',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      const pos6 = result.decodedPositions.find((p: any) => p.position === 6);
+      expect(pos6?.value).toBe('C');
+      expect(pos6?.name).toMatch(/Cooper/);
+    });
+
+    it('existing "N" (non-Cooper) option still decodes alongside "C"', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1990-on',
+        chassisNumber: 'SAXXN-N-A-Y-B-B-D-400011',
+      });
+      const result = await handler({});
+      expect(result.isValid).toBe(true);
+      const pos6 = result.decodedPositions.find((p: any) => p.position === 6);
+      expect(pos6?.value).toBe('N');
+      expect(pos6?.name).not.toMatch(/Cooper/);
+    });
+  });
+
+  // ============================================================
+  // yearRange length boundary (20→30 char bump)
+  // ============================================================
+
+  describe('yearRange length boundary after 30-char bump', () => {
+    it('accepts a yearRange string up to 30 chars when valid', async () => {
+      // Inject a synthetic 30-char range is not testable (no such range exists),
+      // but we can verify the new AU title (22 chars) is accepted — regression
+      // guard for the previous 20-char cap.
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (Australia)',
+        chassisNumber: 'YMA2S1-55555',
+      });
+      const result = await handler({});
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects yearRange strings over 30 chars with 400', async () => {
+      vi.mocked(readBody).mockResolvedValue({
+        yearRange: '1961-1978 (AustraliaXXXXXXXXXXX)', // 31 chars
+        chassisNumber: 'YMA2S1-55555',
+      });
+      await expect(handler({})).rejects.toThrow();
+      try {
+        await handler({});
+      } catch (e: any) {
+        expect(e.statusCode).toBe(400);
+        expect(e.message).toContain('too long');
+      }
     });
   });
 });

--- a/tests/unit/server/mcp/chassis-decoder.test.ts
+++ b/tests/unit/server/mcp/chassis-decoder.test.ts
@@ -1,0 +1,341 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock Nitro/MCP globals before importing the tool
+// ---------------------------------------------------------------------------
+const { mockJsonResult, mockErrorResult, mockUseRuntimeConfig } = vi.hoisted(() => {
+  const mockJsonResult = vi.fn((data: any) => data);
+  const mockErrorResult = vi.fn((message: string) => ({ error: true, message }));
+  const mockUseRuntimeConfig = vi.fn(() => ({
+    public: { siteUrl: 'http://localhost:3000' },
+  }));
+  (globalThis as any).defineMcpTool = (config: any) => config;
+  (globalThis as any).jsonResult = mockJsonResult;
+  (globalThis as any).errorResult = mockErrorResult;
+  (globalThis as any).useRuntimeConfig = mockUseRuntimeConfig;
+  return { mockJsonResult, mockErrorResult, mockUseRuntimeConfig };
+});
+
+import { chassisRanges } from '~/data/models/decoders';
+
+// ---------------------------------------------------------------------------
+// Helper: fetch mock factory. Accepts a response body and returns a mock
+// that resolves to a Response-like object.
+// ---------------------------------------------------------------------------
+function mockFetchOk(body: any) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+function mockFetchErr(status: number, statusText: string, body = 'Bad Request') {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText,
+    json: async () => ({}),
+    text: async () => body,
+  });
+}
+
+const sampleDecoderResponse = {
+  chassisNumber: 'YMA2S1-12345',
+  yearRange: '1961-1978 (Australia)',
+  pattern: 'YMA2S1####',
+  isValid: true,
+  errors: [],
+  decodedPositions: [
+    {
+      position: 1,
+      value: 'Y',
+      name: 'Origin of manufacture: Australia (BMC / Leyland Australia, Zetland NSW)',
+      matched: true,
+    },
+    {
+      position: 2,
+      value: 'M',
+      name: 'Morris (Morris 850, Mini Deluxe, Mini Minor, Mini-Matic Mk1)',
+      matched: true,
+    },
+    { position: 3, value: 'A', name: 'A-series engine, 800–999cc', matched: true },
+    { position: 4, value: '2', name: '2-door body', matched: true },
+    { position: 5, value: 'S', name: 'Saloon (Sedan)', matched: true },
+    {
+      position: 6,
+      value: '1',
+      name: 'Mk1: Morris 850 (YMA2S1) or Morris Cooper (YKA2S1), 1961–1966',
+      matched: true,
+    },
+    { position: 12, value: '12345', name: 'Production sequence number', matched: true },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Import the tool config once mocks are in place
+// ---------------------------------------------------------------------------
+let toolConfig: any;
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockJsonResult.mockClear();
+  mockErrorResult.mockClear();
+  mockUseRuntimeConfig.mockClear();
+  mockJsonResult.mockImplementation((data: any) => data);
+  mockErrorResult.mockImplementation((message: string) => ({ error: true, message }));
+  mockUseRuntimeConfig.mockImplementation(() => ({ public: { siteUrl: 'http://localhost:3000' } }));
+  const mod = await import('~/server/mcp/tools/chassis-decoder');
+  toolConfig = mod.default;
+});
+
+// ---------------------------------------------------------------------------
+// Tool configuration / metadata
+// ---------------------------------------------------------------------------
+describe('Chassis Decoder MCP Tool — configuration', () => {
+  it('has a description string that mentions Australian Minis', () => {
+    expect(typeof toolConfig.description).toBe('string');
+    expect(toolConfig.description.length).toBeGreaterThan(0);
+    expect(toolConfig.description).toMatch(/Australian/);
+  });
+
+  it('has yearRange and chassisNumber in the input schema', () => {
+    const keys = Object.keys(toolConfig.inputSchema);
+    expect(keys).toContain('yearRange');
+    expect(keys).toContain('chassisNumber');
+  });
+
+  it('has a handler function', () => {
+    expect(typeof toolConfig.handler).toBe('function');
+  });
+
+  it('has a cache setting of 24h', () => {
+    expect(toolConfig.cache).toBe('24h');
+  });
+
+  it('yearRange zod enum contains every range defined in chassisRanges', () => {
+    // The zod enum values are stored on the schema's ._def.values (Zod v3)
+    // or via .options in newer versions. Inspect both safely.
+    const schema = toolConfig.inputSchema.yearRange;
+    const values =
+      (schema?._def?.values as readonly string[] | undefined) ??
+      (schema?.options as readonly string[] | undefined) ??
+      [];
+    const enumValues = [...values];
+    for (const range of chassisRanges) {
+      expect(enumValues).toContain(range.title);
+    }
+  });
+
+  it('yearRange zod enum explicitly includes the new Australian range', () => {
+    const schema = toolConfig.inputSchema.yearRange;
+    const values =
+      (schema?._def?.values as readonly string[] | undefined) ??
+      (schema?.options as readonly string[] | undefined) ??
+      [];
+    expect([...values]).toContain('1961-1978 (Australia)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — input validation (before fetch)
+// ---------------------------------------------------------------------------
+describe('Chassis Decoder MCP Tool — input validation', () => {
+  it('rejects chassis numbers with disallowed characters', async () => {
+    const result = await toolConfig.handler({
+      yearRange: '1959-1969',
+      chassisNumber: 'BAD@CHARS!',
+    });
+    expect(mockErrorResult).toHaveBeenCalledOnce();
+    expect(result.error).toBe(true);
+    expect(result.message).toMatch(/invalid characters/i);
+  });
+
+  it('rejects unknown year range titles', async () => {
+    const result = await toolConfig.handler({
+      yearRange: 'not-a-real-range' as any,
+      chassisNumber: 'ABC123',
+    });
+    expect(mockErrorResult).toHaveBeenCalledOnce();
+    expect(result.message).toMatch(/Invalid year range/);
+  });
+
+  it('accepts hyphens, spaces, and forward slashes in chassis numbers', async () => {
+    globalThis.fetch = mockFetchOk(sampleDecoderResponse) as any;
+    const result = await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1 / 12345 - A',
+    });
+    // Should not have been rejected by the character validator
+    expect(mockErrorResult).not.toHaveBeenCalled();
+    expect(result).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — fetch wiring
+// ---------------------------------------------------------------------------
+describe('Chassis Decoder MCP Tool — API call', () => {
+  it('calls the chassis decoder API via PUT with JSON body', async () => {
+    const fetchMock = mockFetchOk(sampleDecoderResponse);
+    globalThis.fetch = fetchMock as any;
+
+    await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1-12345',
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/api/decoders/chassis');
+    expect(init.method).toBe('PUT');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1-12345',
+    });
+  });
+
+  it('uses siteUrl from runtime config when provided', async () => {
+    mockUseRuntimeConfig.mockImplementation(() => ({
+      public: { siteUrl: 'https://classicminidiy.com' },
+    }));
+    const fetchMock = mockFetchOk(sampleDecoderResponse);
+    globalThis.fetch = fetchMock as any;
+
+    await toolConfig.handler({
+      yearRange: '1959-1969',
+      chassisNumber: 'A-A2S7L-807922A',
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://classicminidiy.com/api/decoders/chassis');
+  });
+
+  it('falls back to localhost when siteUrl is missing', async () => {
+    mockUseRuntimeConfig.mockImplementation(() => ({ public: {} }));
+    const fetchMock = mockFetchOk(sampleDecoderResponse);
+    globalThis.fetch = fetchMock as any;
+
+    await toolConfig.handler({
+      yearRange: '1959-1969',
+      chassisNumber: 'A-A2S7L-807922A',
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/api/decoders/chassis');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — response shaping
+// ---------------------------------------------------------------------------
+describe('Chassis Decoder MCP Tool — response shaping', () => {
+  it('returns a structured result with inputs, results, context, and humanReadable sections', async () => {
+    globalThis.fetch = mockFetchOk(sampleDecoderResponse) as any;
+    const result = await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1-12345',
+    });
+
+    expect(result).toHaveProperty('inputs');
+    expect(result).toHaveProperty('results');
+    expect(result).toHaveProperty('context');
+    expect(result).toHaveProperty('humanReadable');
+    expect(result).toHaveProperty('formattedText');
+  });
+
+  it('echoes yearRange and chassisNumber into the inputs block', async () => {
+    globalThis.fetch = mockFetchOk(sampleDecoderResponse) as any;
+    const result = await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1-12345',
+    });
+    expect(result.inputs.yearRange).toBe('1961-1978 (Australia)');
+    expect(result.inputs.chassisNumber).toBe('YMA2S1-12345');
+  });
+
+  it('surfaces the decoded positions in results.decodedPositions', async () => {
+    globalThis.fetch = mockFetchOk(sampleDecoderResponse) as any;
+    const result = await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1-12345',
+    });
+    expect(Array.isArray(result.results.decodedPositions)).toBe(true);
+    expect(result.results.decodedPositions.length).toBe(sampleDecoderResponse.decodedPositions.length);
+  });
+
+  it('formatted text contains VALID marker and pattern when isValid=true', async () => {
+    globalThis.fetch = mockFetchOk(sampleDecoderResponse) as any;
+    const result = await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1-12345',
+    });
+    expect(result.formattedText).toContain('VALID');
+    expect(result.formattedText).toContain('YMA2S1####');
+    expect(result.formattedText).toContain('YMA2S1-12345');
+  });
+
+  it('formatted text breaks down each decoded position', async () => {
+    globalThis.fetch = mockFetchOk(sampleDecoderResponse) as any;
+    const result = await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YMA2S1-12345',
+    });
+    // One line per decoded position, with position number and matched/unmatched marker
+    for (const pos of sampleDecoderResponse.decodedPositions) {
+      expect(result.humanReadable.breakdown).toContain(`Position ${pos.position}:`);
+    }
+  });
+
+  it('surfaces errors from the API response when isValid=false', async () => {
+    globalThis.fetch = mockFetchOk({
+      ...sampleDecoderResponse,
+      isValid: false,
+      errors: ['Unknown Make letter at position 2'],
+    }) as any;
+
+    const result = await toolConfig.handler({
+      yearRange: '1961-1978 (Australia)',
+      chassisNumber: 'YZA2S1-12345',
+    });
+
+    expect(result.formattedText).toContain('INVALID');
+    expect(result.formattedText).toContain('Unknown Make letter at position 2');
+    expect(result.context.validationStatus).toMatch(/Invalid/i);
+    expect(result.context.errors).toEqual(['Unknown Make letter at position 2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — error propagation
+// ---------------------------------------------------------------------------
+describe('Chassis Decoder MCP Tool — error handling', () => {
+  it('returns errorResult when the API responds with a non-OK status', async () => {
+    globalThis.fetch = mockFetchErr(400, 'Bad Request', 'Chassis number too short') as any;
+    const result = await toolConfig.handler({
+      yearRange: '1959-1969',
+      chassisNumber: 'A-A',
+    });
+    expect(mockErrorResult).toHaveBeenCalledOnce();
+    expect(result.error).toBe(true);
+    expect(result.message).toMatch(/Chassis decoder API error: 400/);
+    expect(result.message).toContain('Chassis number too short');
+  });
+
+  it('returns errorResult when fetch itself throws (network failure)', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network unreachable')) as any;
+    const result = await toolConfig.handler({
+      yearRange: '1959-1969',
+      chassisNumber: 'A-A2S7L-807922A',
+    });
+    expect(mockErrorResult).toHaveBeenCalledOnce();
+    expect(result.error).toBe(true);
+    expect(result.message).toMatch(/Internal server error/);
+    expect(result.message).toContain('Network unreachable');
+  });
+});


### PR DESCRIPTION
## Summary
- Cross-references [Somerford Mini](https://www.somerfordmini.co.uk/mini-production-history) and [JoltFreak](https://joltfreak.tripod.com/id13.html) to close data gaps in the existing UK chassis ranges
- Adds a new `1961-1978 (Australia)` range for YMA2S1-style body/type codes sourced from [mini.org.au](https://www.mini.org.au/identify-a-classic-mini) and [eight-fifty.com](https://eight-fifty.com/identification/australian-minis/)
- Backfills comprehensive tests (+71 new, bringing decoder coverage from 66 to 137 dedicated tests)

## UK data improvements
| Range | Change |
|---|---|
| 1969-1974 | Consolidated duplicate `A` entries at position 2 |
| 1974-1980 | Added `N` Special Deluxe trim at position 5; corrected `2D` description to identify 1275GT (was "unclear if this was used") |
| 1985-1990 | Added `3` catalyst code at position 8 |
| 1990-on | Added `C` Cooper code at position 6 (XN-CA prefix) |

## New Australian range (`YMA2S1-####`)
Six-character body/type code with position breakdown:
- **Pos 1** `Y` — Australian origin (BMC / Leyland Australia, Zetland NSW)
- **Pos 2** `M` Morris / `K` Cooper / `J` Commercial
- **Pos 3** `A` 800-999cc / `G` 1275cc (Cooper S Mk1)
- **Pos 4** `2` two-door body
- **Pos 5** `S` Saloon / `V` Van
- **Pos 6** `1-5`, `8` — Mk1 through Clubman GT variants

Known limitation: Leyland-era 5-char format (`YG2S1`) and 7-char van format (`YJBAV1R`) are documented but not yet handled.

## Infrastructure
- Bumped API yearRange max length 20→30 to accommodate the longer Australian title
- Updated MCP tool zod enum and Vue page dropdown to expose the new range
- AI chat (via MCP) gains Australian decoding automatically on next cache refresh (24h TTL)

## Backwards compatibility
All changes are additive:
- Existing UK year ranges decode identically for existing inputs
- Added position options only improve match rate (previously `matched: false` codes now match correctly)
- Response schema unchanged
- yearRange length loosening is backwards-compatible
- External mobile consumers will continue to work; they'll gain the AU range when they update their hardcoded dropdowns

## Test plan
- [x] `bun run vitest run tests/unit/data/decoders-model.test.ts` — 42 pass
- [x] `bun run vitest run tests/unit/server/api/decoders/chassis.test.ts` — 75 pass
- [x] `bun run vitest run tests/unit/server/mcp/chassis-decoder.test.ts` — 20 pass
- [x] Full suite: 1,363 tests across 50 files pass
- [x] Verified in-browser: `YMA2S1-12345` decodes to Morris 850 Mk1 with all 7 positions matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)