### PR TITLE
test: add coverage for useColorMode and useToast composables

### DIFF
--- a/tests/unit/composables/useColorMode.test.ts
+++ b/tests/unit/composables/useColorMode.test.ts
@@ -18,7 +18,7 @@ function stubMatchMedia(initialMatches: boolean) {
     dispatchEvent: vi.fn(),
   };
   const impl = vi.fn().mockReturnValue(mqList);
-  Object.defineProperty(window, 'matchMedia', { writable: true, configurable: true, value: impl });
+  vi.stubGlobal('matchMedia', impl);
 
   return {
     impl,
@@ -46,7 +46,7 @@ function stubLocalStorage(initial: Record<string, string> = {}) {
     length: 0,
     key: vi.fn(),
   };
-  Object.defineProperty(window, 'localStorage', { writable: true, configurable: true, value: mock });
+  vi.stubGlobal('localStorage', mock);
   return { mock, store };
 }
 
@@ -58,6 +58,7 @@ describe('useColorMode', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('initial state', () => {

--- a/tests/unit/composables/useColorMode.test.ts
+++ b/tests/unit/composables/useColorMode.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useColorMode } from '~/app/composables/useColorMode';
+
+type MediaQueryChangeHandler = (e: Partial<MediaQueryListEvent>) => void;
+
+function stubMatchMedia(initialMatches: boolean) {
+  const listeners: MediaQueryChangeHandler[] = [];
+  const mqList = {
+    matches: initialMatches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: vi.fn((_event: string, cb: MediaQueryChangeHandler) => {
+      listeners.push(cb);
+    }),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+  const impl = vi.fn().mockReturnValue(mqList);
+  Object.defineProperty(window, 'matchMedia', { writable: true, configurable: true, value: impl });
+
+  return {
+    impl,
+    mqList,
+    trigger(next: boolean) {
+      mqList.matches = next;
+      listeners.forEach((cb) => cb({ matches: next }));
+    },
+  };
+}
+
+function stubLocalStorage(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  const mock = {
+    getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      for (const key of Object.keys(store)) delete store[key];
+    }),
+    length: 0,
+    key: vi.fn(),
+  };
+  Object.defineProperty(window, 'localStorage', { writable: true, configurable: true, value: mock });
+  return { mock, store };
+}
+
+describe('useColorMode', () => {
+  beforeEach(() => {
+    (global as any).__resetNuxtState();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('defaults preference to "system" when no value is stored', () => {
+      stubLocalStorage();
+      stubMatchMedia(false);
+
+      const { preference } = useColorMode();
+      expect(preference.value).toBe('system');
+    });
+
+    it('reads "dark" preference from localStorage and applies the dark theme', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'cmdiy-dark' });
+      stubMatchMedia(false);
+
+      const { preference, isDark, resolved } = useColorMode();
+
+      expect(preference.value).toBe('dark');
+      expect(isDark.value).toBe(true);
+      expect(resolved.value).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy-dark');
+    });
+
+    it('reads "light" preference from localStorage and applies the light theme', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'cmdiy' });
+      stubMatchMedia(true);
+
+      const { preference, isDark, resolved } = useColorMode();
+
+      expect(preference.value).toBe('light');
+      expect(isDark.value).toBe(false);
+      expect(resolved.value).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy');
+    });
+
+    it('falls back to system preference (light) when nothing is stored', () => {
+      stubLocalStorage();
+      stubMatchMedia(false);
+
+      const { preference, resolved } = useColorMode();
+
+      expect(preference.value).toBe('system');
+      expect(resolved.value).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy');
+    });
+
+    it('falls back to system preference (dark) when nothing is stored', () => {
+      stubLocalStorage();
+      stubMatchMedia(true);
+
+      const { preference, resolved, isDark } = useColorMode();
+
+      expect(preference.value).toBe('system');
+      expect(resolved.value).toBe('dark');
+      expect(isDark.value).toBe(true);
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy-dark');
+    });
+
+    it('treats unrecognized stored values as "system"', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'garbage-value' });
+      stubMatchMedia(false);
+
+      const { preference } = useColorMode();
+      expect(preference.value).toBe('system');
+    });
+  });
+
+  describe('setting preference', () => {
+    it('persists and applies "dark" when set', () => {
+      const { mock: localStorageMock } = stubLocalStorage();
+      stubMatchMedia(false);
+
+      const { preference, resolved } = useColorMode();
+      preference.value = 'dark';
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('cmdiy-theme', 'cmdiy-dark');
+      expect(resolved.value).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy-dark');
+    });
+
+    it('persists and applies "light" when set', () => {
+      const { mock: localStorageMock } = stubLocalStorage({ 'cmdiy-theme': 'cmdiy-dark' });
+      stubMatchMedia(true);
+
+      const { preference, resolved } = useColorMode();
+      preference.value = 'light';
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('cmdiy-theme', 'cmdiy');
+      expect(resolved.value).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy');
+    });
+
+    it('removes the stored key and falls back to system preference when set to "system"', () => {
+      const { mock: localStorageMock } = stubLocalStorage({ 'cmdiy-theme': 'cmdiy-dark' });
+      stubMatchMedia(true);
+
+      const { preference, resolved } = useColorMode();
+      preference.value = 'system';
+
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('cmdiy-theme');
+      expect(resolved.value).toBe('dark');
+    });
+
+    it('applies "cmdiy" when system preference is light after switching to "system"', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'cmdiy-dark' });
+      stubMatchMedia(false);
+
+      const { preference, resolved } = useColorMode();
+      preference.value = 'system';
+
+      expect(resolved.value).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy');
+    });
+
+    it('keeps value and preference in sync', () => {
+      stubLocalStorage();
+      stubMatchMedia(false);
+
+      const { preference, value } = useColorMode();
+      value.value = 'dark';
+
+      expect(preference.value).toBe('dark');
+      expect(value.value).toBe('dark');
+    });
+  });
+
+  describe('toggle', () => {
+    it('switches from dark to light', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'cmdiy-dark' });
+      stubMatchMedia(false);
+
+      const { toggle, preference, resolved } = useColorMode();
+      toggle();
+
+      expect(preference.value).toBe('light');
+      expect(resolved.value).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy');
+    });
+
+    it('switches from light to dark', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'cmdiy' });
+      stubMatchMedia(false);
+
+      const { toggle, preference, resolved } = useColorMode();
+      toggle();
+
+      expect(preference.value).toBe('dark');
+      expect(resolved.value).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy-dark');
+    });
+
+    it('flips from system-resolved-light into an explicit "dark" preference', () => {
+      stubLocalStorage();
+      stubMatchMedia(false);
+
+      const { toggle, preference, resolved } = useColorMode();
+      expect(resolved.value).toBe('light');
+
+      toggle();
+      expect(preference.value).toBe('dark');
+      expect(resolved.value).toBe('dark');
+    });
+
+    it('flips from system-resolved-dark into an explicit "light" preference', () => {
+      stubLocalStorage();
+      stubMatchMedia(true);
+
+      const { toggle, preference, resolved } = useColorMode();
+      expect(resolved.value).toBe('dark');
+
+      toggle();
+      expect(preference.value).toBe('light');
+      expect(resolved.value).toBe('light');
+    });
+
+    it('double-toggle returns to the original resolved mode', () => {
+      stubLocalStorage();
+      stubMatchMedia(false);
+
+      const { toggle, resolved } = useColorMode();
+      const initial = resolved.value;
+      toggle();
+      toggle();
+
+      expect(resolved.value).toBe(initial);
+    });
+  });
+
+  describe('system preference changes', () => {
+    it('updates resolved theme when system changes and preference is "system"', () => {
+      stubLocalStorage();
+      const media = stubMatchMedia(false);
+
+      const { resolved } = useColorMode();
+      expect(resolved.value).toBe('light');
+
+      media.trigger(true);
+
+      expect(resolved.value).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy-dark');
+    });
+
+    it('ignores system changes when preference is an explicit "light"', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'cmdiy' });
+      const media = stubMatchMedia(false);
+
+      const { resolved } = useColorMode();
+      media.trigger(true);
+
+      expect(resolved.value).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy');
+    });
+
+    it('ignores system changes when preference is an explicit "dark"', () => {
+      stubLocalStorage({ 'cmdiy-theme': 'cmdiy-dark' });
+      const media = stubMatchMedia(true);
+
+      const { resolved } = useColorMode();
+      media.trigger(false);
+
+      expect(resolved.value).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cmdiy-dark');
+    });
+  });
+
+  describe('preferred computed', () => {
+    it('reports "light" when the system prefers light', () => {
+      stubLocalStorage();
+      stubMatchMedia(false);
+
+      const { preferred } = useColorMode();
+      expect(preferred.value).toBe('light');
+    });
+
+    it('reports "dark" when the system prefers dark', () => {
+      stubLocalStorage();
+      stubMatchMedia(true);
+
+      const { preferred } = useColorMode();
+      expect(preferred.value).toBe('dark');
+    });
+  });
+
+  describe('shared state', () => {
+    it('two useColorMode() callers share preference state', () => {
+      stubLocalStorage();
+      stubMatchMedia(false);
+
+      const first = useColorMode();
+      const second = useColorMode();
+
+      first.preference.value = 'dark';
+
+      expect(second.preference.value).toBe('dark');
+      expect(second.resolved.value).toBe('dark');
+    });
+  });
+});

--- a/tests/unit/composables/useToast.test.ts
+++ b/tests/unit/composables/useToast.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useToast } from '~/app/composables/useToast';
+
+describe('useToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (global as any).__resetNuxtState();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('add', () => {
+    it('returns a ToastRecord with defaults applied', () => {
+      const { add } = useToast();
+      const record = add({ title: 'Hello' });
+
+      expect(record.title).toBe('Hello');
+      expect(record.description).toBe('');
+      expect(record.color).toBe('info');
+      expect(record.icon).toBe('');
+      expect(record.timeout).toBe(5000);
+      expect(typeof record.id).toBe('string');
+      expect(record.id.length).toBeGreaterThan(0);
+    });
+
+    it('uses a caller-provided id when present', () => {
+      const { add } = useToast();
+      const record = add({ id: 'custom-id', title: 'Hi' });
+      expect(record.id).toBe('custom-id');
+    });
+
+    it('generates a unique id when none is provided', () => {
+      const { add } = useToast();
+      const a = add({ title: 'A' });
+      const b = add({ title: 'B' });
+      expect(a.id).not.toBe(b.id);
+    });
+
+    it('appends the toast to the shared toasts state', () => {
+      const { add, toasts } = useToast();
+      add({ title: 'One' });
+      add({ title: 'Two' });
+
+      expect(toasts.value).toHaveLength(2);
+      expect(toasts.value[0]?.title).toBe('One');
+      expect(toasts.value[1]?.title).toBe('Two');
+    });
+
+    it('respects custom color, description, and timeout values', () => {
+      const { add } = useToast();
+      const record = add({
+        title: 'Saved',
+        description: 'Your profile was updated',
+        color: 'success',
+        timeout: 2000,
+      });
+      expect(record.description).toBe('Your profile was updated');
+      expect(record.color).toBe('success');
+      expect(record.timeout).toBe(2000);
+    });
+
+    it('auto-removes the toast after the timeout elapses', () => {
+      const { add, toasts } = useToast();
+      add({ title: 'Vanish', timeout: 1000 });
+
+      expect(toasts.value).toHaveLength(1);
+      vi.advanceTimersByTime(999);
+      expect(toasts.value).toHaveLength(1);
+
+      vi.advanceTimersByTime(1);
+      expect(toasts.value).toHaveLength(0);
+    });
+
+    it('does NOT schedule removal when timeout is 0', () => {
+      const { add, toasts } = useToast();
+      add({ title: 'Sticky', timeout: 0 });
+
+      vi.advanceTimersByTime(60_000);
+      expect(toasts.value).toHaveLength(1);
+    });
+
+    it('does NOT schedule removal when timeout is negative', () => {
+      const { add, toasts } = useToast();
+      add({ title: 'Persistent', timeout: -1 });
+
+      vi.advanceTimersByTime(60_000);
+      expect(toasts.value).toHaveLength(1);
+    });
+
+    it('leaves other toasts in place when one auto-removes', () => {
+      const { add, toasts } = useToast();
+      add({ id: 'short', title: 'Short', timeout: 500 });
+      add({ id: 'long', title: 'Long', timeout: 5000 });
+
+      vi.advanceTimersByTime(500);
+      expect(toasts.value).toHaveLength(1);
+      expect(toasts.value[0]?.id).toBe('long');
+    });
+  });
+
+  describe('icon normalization', () => {
+    it('converts i-fa6-solid-* to fas fa-* classes', () => {
+      const { add } = useToast();
+      const record = add({ title: 't', icon: 'i-fa6-solid-circle-check' });
+      expect(record.icon).toBe('fas fa-circle-check');
+    });
+
+    it('converts i-fa6-regular-* to far fa-* classes', () => {
+      const { add } = useToast();
+      const record = add({ title: 't', icon: 'i-fa6-regular-heart' });
+      expect(record.icon).toBe('far fa-heart');
+    });
+
+    it('converts i-fa6-brands-* to fab fa-* classes', () => {
+      const { add } = useToast();
+      const record = add({ title: 't', icon: 'i-fa6-brands-github' });
+      expect(record.icon).toBe('fab fa-github');
+    });
+
+    it('converts i-heroicons-* to fas fa-* as a best-effort fallback', () => {
+      const { add } = useToast();
+      const record = add({ title: 't', icon: 'i-heroicons-bell' });
+      expect(record.icon).toBe('fas fa-bell');
+    });
+
+    it('passes raw fas/far/fab class strings through unchanged', () => {
+      const { add } = useToast();
+      const record = add({ title: 't', icon: 'fas fa-rocket' });
+      expect(record.icon).toBe('fas fa-rocket');
+    });
+
+    it('returns an empty string when no icon is supplied', () => {
+      const { add } = useToast();
+      const record = add({ title: 't' });
+      expect(record.icon).toBe('');
+    });
+  });
+
+  describe('remove', () => {
+    it('removes the toast whose id matches', () => {
+      const { add, remove, toasts } = useToast();
+      add({ id: 'a', title: 'A' });
+      add({ id: 'b', title: 'B' });
+
+      remove('a');
+
+      expect(toasts.value).toHaveLength(1);
+      expect(toasts.value[0]?.id).toBe('b');
+    });
+
+    it('is a no-op for an unknown id', () => {
+      const { add, remove, toasts } = useToast();
+      add({ id: 'a', title: 'A' });
+      remove('does-not-exist');
+
+      expect(toasts.value).toHaveLength(1);
+      expect(toasts.value[0]?.id).toBe('a');
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the toasts array', () => {
+      const { add, clear, toasts } = useToast();
+      add({ title: 'One' });
+      add({ title: 'Two' });
+      add({ title: 'Three' });
+
+      clear();
+      expect(toasts.value).toHaveLength(0);
+    });
+
+    it('is a no-op when there are no toasts', () => {
+      const { clear, toasts } = useToast();
+      expect(() => clear()).not.toThrow();
+      expect(toasts.value).toHaveLength(0);
+    });
+  });
+
+  describe('shared state across invocations', () => {
+    it('two useToast() callers share the same underlying list', () => {
+      const first = useToast();
+      const second = useToast();
+
+      first.add({ id: 'shared', title: 'Shared' });
+      expect(second.toasts.value).toHaveLength(1);
+      expect(second.toasts.value[0]?.id).toBe('shared');
+    });
+
+    it('remove from one instance is visible to the other', () => {
+      const a = useToast();
+      const b = useToast();
+
+      a.add({ id: 'x', title: 'X' });
+      b.remove('x');
+
+      expect(a.toasts.value).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 43 unit tests covering the two composables introduced alongside the daisyUI re-integration (`useColorMode`, `useToast`) that shipped without test coverage.
- Full suite grows from **1363 → 1406 passing** tests across 52 files.

## Coverage details

**`useToast`** (22 tests)
- Default field population and caller-supplied id handling
- Icon normalization across `i-fa6-solid-*`, `i-fa6-regular-*`, `i-fa6-brands-*`, `i-heroicons-*`, raw `fas fa-*` passthrough, and empty-icon paths
- Auto-remove timer behavior, including `timeout: 0` and negative-timeout "sticky" cases
- `remove` (matching id, unknown id no-op), `clear`, and shared-state semantics across instances

**`useColorMode`** (21 tests)
- localStorage hydration for `cmdiy-dark`, `cmdiy`, unrecognized values, and missing keys
- System-preference fallback via `matchMedia` for both light and dark
- Setting explicit `light` / `dark` / `system` (persistence + `data-theme` attribute)
- `toggle()` from explicit and system-resolved starting states (including double-toggle returning to baseline)
- Live `matchMedia` change events: updating when preference is `system`, ignored when preference is explicit
- `preferred` computed and shared preference state across invocations

## Test plan
- [x] `bun run test tests/unit/composables/useColorMode.test.ts tests/unit/composables/useToast.test.ts` — 43/43 pass
- [x] `bun run test` — full suite 1406/1406 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)