### PR TITLE
fix(auth): explicit PKCE code exchange on /auth/callback

### DIFF
--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -37,13 +37,15 @@
     try {
       // Explicit PKCE code exchange — supabase-js's detectSessionInUrl auto-magic
       // is racy with our custom lock implementation, so do it manually.
+      // If detectSessionInUrl happens to win the race, our manual call will
+      // return "code already used"; in that case initAuth() below will still
+      // pick up the session, so we don't surface the error unless we end up
+      // genuinely unauthenticated.
       const code = new URLSearchParams(window.location.search).get('code');
+      let exchangeError: { message?: string } | null = null;
       if (code) {
-        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(window.location.href);
-        if (exchangeError) {
-          errorMessage.value = exchangeError.message || 'Authentication failed. Please try again.';
-          return;
-        }
+        const result = await supabase.auth.exchangeCodeForSession(window.location.href);
+        exchangeError = result.error;
       }
 
       await initAuth();
@@ -64,7 +66,7 @@
           navigateTo('/', { replace: true });
         }
       } else {
-        errorMessage.value = 'Authentication failed. Please try again.';
+        errorMessage.value = exchangeError?.message || 'Authentication failed. Please try again.';
       }
     } catch (e: any) {
       errorMessage.value = e.message || 'Authentication failed';

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -29,11 +29,23 @@
     meta: [{ name: 'robots', content: 'noindex, nofollow' }],
   });
 
+  const supabase = useSupabase();
   const { initAuth, isAuthenticated, isAdmin, userProfile, waitForAuth } = useAuth();
   const errorMessage = ref('');
 
   onMounted(async () => {
     try {
+      // Explicit PKCE code exchange — supabase-js's detectSessionInUrl auto-magic
+      // is racy with our custom lock implementation, so do it manually.
+      const code = new URLSearchParams(window.location.search).get('code');
+      if (code) {
+        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(window.location.href);
+        if (exchangeError) {
+          errorMessage.value = exchangeError.message || 'Authentication failed. Please try again.';
+          return;
+        }
+      }
+
       await initAuth();
       // Wait briefly for session to be detected from URL
       await new Promise((resolve) => setTimeout(resolve, 500));


### PR DESCRIPTION
## Summary

- Google OAuth (and any PKCE flow) was failing on `/auth/callback` for users — the page relied on supabase-js's `detectSessionInUrl` to silently exchange the `?code=` for a session, but that auto-detect races with our custom `lock` implementation in `useSupabase` and supabase-js v2.100's async-fire-and-forget client init. The PKCE `code_verifier` stayed in localStorage and no session was ever established → \"Authentication failed. Please try again.\"
- Fix: explicitly call `supabase.auth.exchangeCodeForSession(window.location.href)` when a `?code=` query param is present, surfacing the error inline if it fails.

## How we found it

Manually calling `POST https://auth.classicminidiy.com/auth/v1/token?grant_type=pkce` with the same code + verifier from the failing page returned **200 + full session JSON**. So the endpoint, CORS, code, and verifier were all healthy — supabase-js just wasn't making the call. Explicit `exchangeCodeForSession` uses the exact same path and bypasses the race.

## Test plan

- [ ] Click \"Login with Google\" from `/login` → completes successfully and lands on `/admin` (or `/welcome` for new users)
- [ ] Magic-link email sign-in still works (uses the same callback page)
- [ ] On a deliberately invalid/expired link, the page now shows the actual error message instead of the generic \"Authentication failed\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)