### PR TITLE
fix(auth): pass code string to exchangeCodeForSession, not full URL

### DIFF
--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -44,7 +44,9 @@
       const code = new URLSearchParams(window.location.search).get('code');
       let exchangeError: { message?: string } | null = null;
       if (code) {
-        const result = await supabase.auth.exchangeCodeForSession(window.location.href);
+        // Pass the code string only, NOT window.location.href — supabase-js
+        // puts this value directly into the /token POST body's auth_code field.
+        const result = await supabase.auth.exchangeCodeForSession(code);
         exchangeError = result.error;
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #585 — that PR merged before this final fix was pushed. Without this, the new explicit PKCE code-exchange path is still broken: supabase-js puts the value passed to `exchangeCodeForSession` directly into the `/token` POST body's `auth_code` field (no URL parsing). I was passing `window.location.href`, which sent the entire callback URL as the auth code, and the server rejected it.

This is the actual fix that makes Google login work — verified end-to-end on localhost with this branch checked out (clean signin → success → admin redirect).

## Verification

- [x] Confirmed `_exchangeCodeForSession` source in `node_modules/@supabase/auth-js/dist/main/GoTrueClient.js:946-960` puts `authCode` directly into `body.auth_code`
- [x] Matches the manual `fetch` test that returned 200 + full session during debugging
- [x] Tested locally on `fix/auth-callback-pkce-exchange` branch (which had this commit): clean Google signin → callback page → redirect to `/` works

## Test plan

- [ ] Click \"Login with Google\" from `/login` in production after merge
- [ ] Lands you on `/` or `/admin`, NOT on `/auth/callback` showing an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)