### PR TITLE
feat(gearing): add 5-speed gearbox support

### DIFF
--- a/app/components/Calculators/Gearbox.vue
+++ b/app/components/Calculators/Gearbox.vue
@@ -116,7 +116,8 @@
       const speedoMatch = bestMatch ? bestMatch.speedometer : `${closestMatch.speedometer} (${closestMatch.result})`;
       const speedoStatus = bestMatch ? 'text-green' : closestMatch.status;
 
-      const totalRatio4th = `${(config.finalDrive * (gearingTable[3]?.ratio || 1) * config.dropGear).toFixed(3)}:1`;
+      const topGearRow = gearingTable[gearingTable.length - 1];
+      const totalRatioTop = `${(config.finalDrive * (topGearRow?.ratio || 1) * config.dropGear).toFixed(3)}:1`;
 
       return {
         name: config.name,
@@ -126,14 +127,16 @@
         speedoTable,
         speedoMatch,
         speedoStatus,
-        totalRatio4th,
+        totalRatioTop,
       };
     });
   });
 
   // Chart data for all gears view
-  const GEAR_MARKERS = ['circle', 'square', 'diamond', 'triangle'];
-  const GEAR_NAMES = ['1st', '2nd', '3rd', '4th'];
+  const GEAR_MARKERS = ['circle', 'square', 'diamond', 'triangle', 'triangle-down'];
+  const GEAR_NAMES = ['1st', '2nd', '3rd', '4th', '5th'];
+
+  const maxGearCount = computed(() => Math.max(...configs.value.map((c) => c.gearset.length)));
 
   const allGearsSeries = computed((): ChartSeriesData[] => {
     const tire = tireCalcs.value;
@@ -160,18 +163,42 @@
     return series;
   });
 
-  // Speedo details for the first config (used for the shared speedo info card)
+  // Pick the config with the most gears for the "primary" side panels so a
+  // 5-speed in config 1 still surfaces its 5th gear when config 0 is 4-speed.
+  // Ties go to the lowest index (preserves config-0-first behavior for equal-length sets).
+  const primaryConfigIndex = computed(() => {
+    const list = configResults.value;
+    if (list.length === 0) return 0;
+    let idx = 0;
+    let max = list[0]?.gearingTable.length ?? 0;
+    for (let i = 1; i < list.length; i++) {
+      const len = list[i]?.gearingTable.length ?? 0;
+      if (len > max) {
+        max = len;
+        idx = i;
+      }
+    }
+    return idx;
+  });
+
+  // Speedo + gearing details from the primary config (defined above)
   const primarySpeedoData = computed(() => {
-    return configResults.value[0]?.speedoData || { turnsPerMile: 0, engineRevsMile: 0 };
+    return configResults.value[primaryConfigIndex.value]?.speedoData || { turnsPerMile: 0, engineRevsMile: 0 };
   });
 
   const primarySpeedoTable = computed(() => {
-    return configResults.value[0]?.speedoTable || [];
+    return configResults.value[primaryConfigIndex.value]?.speedoTable || [];
   });
 
-  // Top speed from first config
+  const primaryGearingTable = computed(() => {
+    return configResults.value[primaryConfigIndex.value]?.gearingTable || [];
+  });
+
+  // Top speed from primary config (last gear = highest top speed)
   const topSpeed = computed(() => {
-    return configResults.value[0]?.gearingTable[3]?.maxSpeed || '---';
+    const table = primaryGearingTable.value;
+    if (table.length === 0) return '---';
+    return table[table.length - 1]?.maxSpeed || '---';
   });
 
   // Display values with unit conversion
@@ -405,7 +432,7 @@
         <h3 class="text-lg text-white opacity-70">
           <i class="fa-jelly-duo fa-regular fa-percent"></i> {{ t('results.total_ratio') }}
         </h3>
-        <p class="text-3xl text-white font-bold">{{ configResults[0]?.totalRatio4th || '---' }}</p>
+        <p class="text-3xl text-white font-bold">{{ configResults[primaryConfigIndex]?.totalRatioTop || '---' }}</p>
       </div>
     </div>
 
@@ -463,6 +490,7 @@
         :config-colors="configs.map((_, i) => CONFIG_COLORS[i])"
         :metric="metric"
         :max-rpm="maxRpm"
+        :max-gear-count="maxGearCount"
       />
     </div>
 
@@ -521,7 +549,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <tr v-for="(item, index) in configResults[0]?.gearingTable || []" :key="index">
+                  <tr v-for="(item, index) in primaryGearingTable" :key="index">
                     <td>{{ item.gear }}</td>
                     <td>{{ item.ratio }}</td>
                     <td>{{ item.maxSpeed }}</td>

--- a/app/components/Calculators/GearboxComparisonChart.vue
+++ b/app/components/Calculators/GearboxComparisonChart.vue
@@ -4,23 +4,30 @@
 
   const { t } = useI18n();
 
-  const props = defineProps<{
-    allGearsSeries: ChartSeriesData[];
-    configNames: string[];
-    configColors: string[];
-    metric: boolean;
-    maxRpm: number;
-  }>();
+  const props = withDefaults(
+    defineProps<{
+      allGearsSeries: ChartSeriesData[];
+      configNames: string[];
+      configColors: string[];
+      metric: boolean;
+      maxRpm: number;
+      maxGearCount?: number;
+    }>(),
+    { maxGearCount: 4 }
+  );
 
   const colorMode = useColorMode();
   const isDark = computed(() => colorMode.isDark.value);
 
-  const GEAR_SHAPES: { symbol: string; dash: string; label: string }[] = [
+  const ALL_GEAR_SHAPES: { symbol: string; dash: string; label: string }[] = [
     { symbol: 'circle', dash: 'ShortDash', label: '1st Gear' },
     { symbol: 'square', dash: 'ShortDash', label: '2nd Gear' },
     { symbol: 'diamond', dash: 'ShortDash', label: '3rd Gear' },
     { symbol: 'triangle', dash: 'Solid', label: '4th Gear' },
+    { symbol: 'triangle-down', dash: 'ShortDash', label: '5th Gear' },
   ];
+
+  const GEAR_SHAPES = computed(() => ALL_GEAR_SHAPES.slice(0, props.maxGearCount));
 
   const darkModeChartOptions = {
     chart: { backgroundColor: '#171717' },
@@ -100,6 +107,7 @@
             square: '\u25A0',
             diamond: '\u25C6',
             triangle: '\u25B2',
+            'triangle-down': '\u25BC',
           };
           let html = `<b>${this.x} RPM</b><br/>`;
           for (const point of this.points) {
@@ -157,6 +165,9 @@
               </template>
               <template v-else-if="gear.symbol === 'triangle'">
                 <polygon points="12,1.5 17,10.5 7,10.5" fill="currentColor" class="opacity-60" />
+              </template>
+              <template v-else-if="gear.symbol === 'triangle-down'">
+                <polygon points="12,10.5 7,1.5 17,1.5" fill="currentColor" class="opacity-60" />
               </template>
             </svg>
             <span class="text-xs">{{ gear.label }}</span>

--- a/app/components/Calculators/GearboxComparisonTable.vue
+++ b/app/components/Calculators/GearboxComparisonTable.vue
@@ -11,7 +11,13 @@
     gearingTable: GearingTableRow[];
     speedoMatch: string;
     speedoStatus: string;
-    totalRatio4th: string;
+    totalRatioTop: string;
+  }
+
+  interface MetricRow {
+    key: string;
+    label: string;
+    gearIndex: number; // -1 for non-gear rows
   }
 
   const props = defineProps<{
@@ -19,15 +25,26 @@
     metric: boolean;
   }>();
 
-  const metrics = computed(() => [
-    { key: '4th_speed', label: t('4th_gear_max_speed') },
-    { key: '3rd_speed', label: t('3rd_gear_max_speed') },
-    { key: '2nd_speed', label: t('2nd_gear_max_speed') },
-    { key: '1st_speed', label: t('1st_gear_max_speed') },
-    { key: '4th_ratio', label: t('4th_gear_ratio') },
-    { key: 'total_ratio', label: t('total_ratio_4th') },
-    { key: 'speedo', label: t('best_speedo_match') },
-  ]);
+  const maxGearCount = computed(() => {
+    if (props.configs.length === 0) return 4;
+    return Math.max(...props.configs.map((c) => c.gearingTable.length));
+  });
+
+  const metrics = computed<MetricRow[]>(() => {
+    const rows: MetricRow[] = [];
+    // Gear speeds — top gear first, descending so the visual flow is "fast → slow"
+    for (let n = maxGearCount.value; n >= 1; n--) {
+      rows.push({
+        key: `gear_${n}_speed`,
+        gearIndex: n - 1,
+        label: t('gear_max_speed', { ordinal: t(`ordinals.${n}`) }),
+      });
+    }
+    rows.push({ key: 'top_gear_ratio', gearIndex: -1, label: t('top_gear_ratio') });
+    rows.push({ key: 'total_ratio', gearIndex: -1, label: t('total_ratio_top') });
+    rows.push({ key: 'speedo', gearIndex: -1, label: t('best_speedo_match') });
+    return rows;
+  });
 
   const speedoStatusClass: Record<string, string> = {
     'text-red': 'text-error',
@@ -35,47 +52,41 @@
     'text-primary': 'text-info',
   };
 
-  function getValue(config: ConfigResult, key: string): string {
-    switch (key) {
-      case '4th_speed':
-        return config.gearingTable[3]?.maxSpeed || '---';
-      case '3rd_speed':
-        return config.gearingTable[2]?.maxSpeed || '---';
-      case '2nd_speed':
-        return config.gearingTable[1]?.maxSpeed || '---';
-      case '1st_speed':
-        return config.gearingTable[0]?.maxSpeed || '---';
-      case '4th_ratio':
-        return `${config.gearingTable[3]?.ratio || '---'}:1`;
-      case 'total_ratio':
-        return config.totalRatio4th;
-      case 'speedo':
-        return config.speedoMatch;
-      default:
-        return '---';
+  function getValue(config: ConfigResult, row: MetricRow): string {
+    if (row.key.startsWith('gear_')) {
+      return config.gearingTable[row.gearIndex]?.maxSpeed || '—';
     }
+    if (row.key === 'top_gear_ratio') {
+      const top = config.gearingTable[config.gearingTable.length - 1];
+      return top ? `${top.ratio}:1` : '—';
+    }
+    if (row.key === 'total_ratio') {
+      return config.totalRatioTop;
+    }
+    if (row.key === 'speedo') {
+      return config.speedoMatch;
+    }
+    return '—';
   }
 
-  function getRawValue(config: ConfigResult, key: string): number {
-    switch (key) {
-      case '4th_speed':
-        return config.gearingTable[3]?.maxSpeedRaw || 0;
-      case '3rd_speed':
-        return config.gearingTable[2]?.maxSpeedRaw || 0;
-      case '2nd_speed':
-        return config.gearingTable[1]?.maxSpeedRaw || 0;
-      case '1st_speed':
-        return config.gearingTable[0]?.maxSpeedRaw || 0;
-      default:
-        return 0;
+  function getRawValue(config: ConfigResult, row: MetricRow): number | null {
+    if (row.key.startsWith('gear_')) {
+      const cell = config.gearingTable[row.gearIndex];
+      return cell ? cell.maxSpeedRaw : null;
     }
+    return null;
   }
 
-  function isBest(config: ConfigResult, key: string): boolean {
-    if (!['4th_speed', '3rd_speed', '2nd_speed', '1st_speed'].includes(key)) return false;
+  function isBest(config: ConfigResult, row: MetricRow): boolean {
+    if (!row.key.startsWith('gear_')) return false;
     if (props.configs.length < 2) return false;
-    const val = getRawValue(config, key);
-    return val === Math.max(...props.configs.map((c) => getRawValue(c, key)));
+    const val = getRawValue(config, row);
+    if (val === null) return false;
+    const allValues = props.configs
+      .map((c) => getRawValue(c, row))
+      .filter((v): v is number => v !== null);
+    if (allValues.length < 2) return false;
+    return val === Math.max(...allValues);
   }
 </script>
 
@@ -103,18 +114,18 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="metric in metrics" :key="metric.key">
-              <td class="font-medium">{{ metric.label }}</td>
+            <tr v-for="row in metrics" :key="row.key">
+              <td class="font-medium">{{ row.label }}</td>
               <td
                 v-for="(config, idx) in configs"
                 :key="idx"
                 class="text-center"
-                :class="{ 'font-bold text-success': isBest(config, metric.key) }"
+                :class="{ 'font-bold text-success': isBest(config, row) }"
               >
-                <span v-if="metric.key === 'speedo'" :class="speedoStatusClass[config.speedoStatus]">
-                  {{ getValue(config, metric.key) }}
+                <span v-if="row.key === 'speedo'" :class="speedoStatusClass[config.speedoStatus]">
+                  {{ getValue(config, row) }}
                 </span>
-                <span v-else>{{ getValue(config, metric.key) }}</span>
+                <span v-else>{{ getValue(config, row) }}</span>
               </td>
             </tr>
           </tbody>
@@ -129,111 +140,91 @@
   "en": {
     "title": "Configuration Comparison",
     "metric": "Metric",
-    "4th_gear_max_speed": "4th Gear Max Speed",
-    "3rd_gear_max_speed": "3rd Gear Max Speed",
-    "2nd_gear_max_speed": "2nd Gear Max Speed",
-    "1st_gear_max_speed": "1st Gear Max Speed",
-    "4th_gear_ratio": "4th Gear Ratio",
-    "total_ratio_4th": "Total Ratio (4th)",
+    "ordinals": { "1": "1st", "2": "2nd", "3": "3rd", "4": "4th", "5": "5th" },
+    "gear_max_speed": "{ordinal} Gear Max Speed",
+    "top_gear_ratio": "Top Gear Ratio",
+    "total_ratio_top": "Total Ratio (Top)",
     "best_speedo_match": "Best Speedo Match"
   },
   "es": {
     "title": "Comparación de Configuraciones",
     "metric": "Métrica",
-    "4th_gear_max_speed": "Velocidad Máx. 4ª Marcha",
-    "3rd_gear_max_speed": "Velocidad Máx. 3ª Marcha",
-    "2nd_gear_max_speed": "Velocidad Máx. 2ª Marcha",
-    "1st_gear_max_speed": "Velocidad Máx. 1ª Marcha",
-    "4th_gear_ratio": "Relación 4ª Marcha",
-    "total_ratio_4th": "Relación Total (4ª)",
+    "ordinals": { "1": "1ª", "2": "2ª", "3": "3ª", "4": "4ª", "5": "5ª" },
+    "gear_max_speed": "Velocidad Máx. {ordinal} Marcha",
+    "top_gear_ratio": "Relación Marcha Superior",
+    "total_ratio_top": "Relación Total (Superior)",
     "best_speedo_match": "Mejor Coincidencia Velocímetro"
   },
   "fr": {
     "title": "Comparaison des Configurations",
     "metric": "Métrique",
-    "4th_gear_max_speed": "Vitesse Max 4ème",
-    "3rd_gear_max_speed": "Vitesse Max 3ème",
-    "2nd_gear_max_speed": "Vitesse Max 2ème",
-    "1st_gear_max_speed": "Vitesse Max 1ère",
-    "4th_gear_ratio": "Rapport 4ème",
-    "total_ratio_4th": "Rapport Total (4ème)",
+    "ordinals": { "1": "1ère", "2": "2ème", "3": "3ème", "4": "4ème", "5": "5ème" },
+    "gear_max_speed": "Vitesse Max {ordinal}",
+    "top_gear_ratio": "Rapport Vitesse Supérieure",
+    "total_ratio_top": "Rapport Total (Supérieure)",
     "best_speedo_match": "Meilleure Correspondance Compteur"
   },
   "de": {
     "title": "Konfigurationsvergleich",
     "metric": "Metrik",
-    "4th_gear_max_speed": "Max. Geschwindigkeit 4. Gang",
-    "3rd_gear_max_speed": "Max. Geschwindigkeit 3. Gang",
-    "2nd_gear_max_speed": "Max. Geschwindigkeit 2. Gang",
-    "1st_gear_max_speed": "Max. Geschwindigkeit 1. Gang",
-    "4th_gear_ratio": "Übersetzung 4. Gang",
-    "total_ratio_4th": "Gesamtübersetzung (4. Gang)",
+    "ordinals": { "1": "1.", "2": "2.", "3": "3.", "4": "4.", "5": "5." },
+    "gear_max_speed": "Max. Geschwindigkeit {ordinal} Gang",
+    "top_gear_ratio": "Übersetzung höchster Gang",
+    "total_ratio_top": "Gesamtübersetzung (höchster Gang)",
     "best_speedo_match": "Beste Tacho-Übereinstimmung"
   },
   "it": {
     "title": "Confronto Configurazioni",
     "metric": "Metrica",
-    "4th_gear_max_speed": "Vel. Max 4ª Marcia",
-    "3rd_gear_max_speed": "Vel. Max 3ª Marcia",
-    "2nd_gear_max_speed": "Vel. Max 2ª Marcia",
-    "1st_gear_max_speed": "Vel. Max 1ª Marcia",
-    "4th_gear_ratio": "Rapporto 4ª Marcia",
-    "total_ratio_4th": "Rapporto Totale (4ª)",
+    "ordinals": { "1": "1ª", "2": "2ª", "3": "3ª", "4": "4ª", "5": "5ª" },
+    "gear_max_speed": "Vel. Max {ordinal} Marcia",
+    "top_gear_ratio": "Rapporto Marcia Superiore",
+    "total_ratio_top": "Rapporto Totale (Superiore)",
     "best_speedo_match": "Migliore Corrispondenza Tachimetro"
   },
   "pt": {
     "title": "Comparação de Configurações",
     "metric": "Métrica",
-    "4th_gear_max_speed": "Vel. Máx. 4ª Marcha",
-    "3rd_gear_max_speed": "Vel. Máx. 3ª Marcha",
-    "2nd_gear_max_speed": "Vel. Máx. 2ª Marcha",
-    "1st_gear_max_speed": "Vel. Máx. 1ª Marcha",
-    "4th_gear_ratio": "Relação 4ª Marcha",
-    "total_ratio_4th": "Relação Total (4ª)",
+    "ordinals": { "1": "1ª", "2": "2ª", "3": "3ª", "4": "4ª", "5": "5ª" },
+    "gear_max_speed": "Vel. Máx. {ordinal} Marcha",
+    "top_gear_ratio": "Relação Marcha Superior",
+    "total_ratio_top": "Relação Total (Superior)",
     "best_speedo_match": "Melhor Correspondência Velocímetro"
   },
   "ru": {
     "title": "Сравнение конфигураций",
     "metric": "Метрика",
-    "4th_gear_max_speed": "Макс. скорость 4-й передачи",
-    "3rd_gear_max_speed": "Макс. скорость 3-й передачи",
-    "2nd_gear_max_speed": "Макс. скорость 2-й передачи",
-    "1st_gear_max_speed": "Макс. скорость 1-й передачи",
-    "4th_gear_ratio": "Передаточное число 4-й передачи",
-    "total_ratio_4th": "Общее передаточное число (4-я)",
+    "ordinals": { "1": "1-й", "2": "2-й", "3": "3-й", "4": "4-й", "5": "5-й" },
+    "gear_max_speed": "Макс. скорость {ordinal} передачи",
+    "top_gear_ratio": "Передаточное число высшей передачи",
+    "total_ratio_top": "Общее передаточное число (высш.)",
     "best_speedo_match": "Лучшее совпадение спидометра"
   },
   "ja": {
     "title": "設定の比較",
     "metric": "指標",
-    "4th_gear_max_speed": "4速 最高速度",
-    "3rd_gear_max_speed": "3速 最高速度",
-    "2nd_gear_max_speed": "2速 最高速度",
-    "1st_gear_max_speed": "1速 最高速度",
-    "4th_gear_ratio": "4速 ギア比",
-    "total_ratio_4th": "総合変速比 (4速)",
+    "ordinals": { "1": "1速", "2": "2速", "3": "3速", "4": "4速", "5": "5速" },
+    "gear_max_speed": "{ordinal} 最高速度",
+    "top_gear_ratio": "トップギア比",
+    "total_ratio_top": "総合変速比 (トップ)",
     "best_speedo_match": "最適なスピードメーター一致"
   },
   "zh": {
     "title": "配置对比",
     "metric": "指标",
-    "4th_gear_max_speed": "4档最高速度",
-    "3rd_gear_max_speed": "3档最高速度",
-    "2nd_gear_max_speed": "2档最高速度",
-    "1st_gear_max_speed": "1档最高速度",
-    "4th_gear_ratio": "4档传动比",
-    "total_ratio_4th": "总传动比（4档）",
+    "ordinals": { "1": "1档", "2": "2档", "3": "3档", "4": "4档", "5": "5档" },
+    "gear_max_speed": "{ordinal}最高速度",
+    "top_gear_ratio": "顶档传动比",
+    "total_ratio_top": "总传动比（顶档）",
     "best_speedo_match": "最佳速度表匹配"
   },
   "ko": {
     "title": "구성 비교",
     "metric": "지표",
-    "4th_gear_max_speed": "4단 최고 속도",
-    "3rd_gear_max_speed": "3단 최고 속도",
-    "2nd_gear_max_speed": "2단 최고 속도",
-    "1st_gear_max_speed": "1단 최고 속도",
-    "4th_gear_ratio": "4단 기어비",
-    "total_ratio_4th": "총 변속비 (4단)",
+    "ordinals": { "1": "1단", "2": "2단", "3": "3단", "4": "4단", "5": "5단" },
+    "gear_max_speed": "{ordinal} 최고 속도",
+    "top_gear_ratio": "최고단 기어비",
+    "total_ratio_top": "총 변속비 (최고단)",
     "best_speedo_match": "최적 속도계 일치"
   }
 }

--- a/data/models/gearing.ts
+++ b/data/models/gearing.ts
@@ -36,7 +36,7 @@ export interface DropGearOption {
 
 // Gear ratio option types
 export interface GearRatioOption {
-  value: [number, number, number, number]; // Array of 4 gear ratios
+  value: number[]; // 4 ratios for 4-speed, 5 for 5-speed (1st, 2nd, 3rd, 4th, [5th])
   label: string;
 }
 
@@ -334,6 +334,10 @@ export const options: GearingOptions = {
     {
       value: [2.583, 1.644, 1.25, 1.0],
       label: 'Minispares Evolution Helical Heavy Duty Kit - C-STN48',
+    },
+    {
+      value: [2.583, 1.644, 1.25, 1.0, 0.865],
+      label: 'Minispares Evolution 5-Speed',
     },
     {
       value: [2.583, 1.711, 1.25, 1.0],

--- a/server/mcp/README.md
+++ b/server/mcp/README.md
@@ -87,7 +87,7 @@ Calculate gear ratios, top speed, and speedometer compatibility.
 
 - `metric` (boolean): Use metric units (true for km/h, false for mph)
 - `final_drive` (number): Final drive ratio (e.g., 3.444)
-- `gear_ratios` (array): Array of 4 gear ratios [1st, 2nd, 3rd, 4th]
+- `gear_ratios` (array): Gear ratios in order [1st, 2nd, 3rd, 4th, optional 5th]. Length 4 for 4-speed gearboxes, length 5 for 5-speed (e.g., Minispares Evolution 5-Speed with overdrive)
 - `drop_gear` (number): Drop gear ratio
 - `speedo_drive` (number): Speedometer drive ratio
 - `max_rpm` (number): Maximum engine RPM

--- a/server/mcp/tools/gearbox-calculator.ts
+++ b/server/mcp/tools/gearbox-calculator.ts
@@ -17,8 +17,8 @@ export default defineMcpTool({
       .describe('Final drive ratio (e.g., 3.444 for standard). Range: 2.76 to 4.571'),
     gear_ratios: z
       .array(z.number())
-      .min(3)
-      .max(6)
+      .min(4)
+      .max(5)
       .default([2.583, 1.644, 1.25, 1.0])
       .describe(
         'Gear ratios in order [1st, 2nd, 3rd, 4th, optional 5th]. Length 4 for 4-speed (e.g., [2.583, 1.644, 1.25, 1.0]) or 5 for 5-speed (e.g., [2.583, 1.644, 1.25, 1.0, 0.865]).'

--- a/server/mcp/tools/gearbox-calculator.ts
+++ b/server/mcp/tools/gearbox-calculator.ts
@@ -7,7 +7,7 @@ import { options, kphFactor } from '../../../data/models/gearing';
  */
 export default defineMcpTool({
   description:
-    'Calculate gear ratios, top speed, and speedometer compatibility for Classic Mini gearboxes. Supports various final drives (2.76:1 to 4.571:1), gear ratios (Pre-64 Magic Wand to modern dog engagement kits), tire sizes (145/80r10 to 195/50r13), and speedometer drives.',
+    'Calculate gear ratios, top speed, and speedometer compatibility for Classic Mini gearboxes. Supports both 4-speed and 5-speed gearboxes (including the Minispares Evolution 5-Speed with overdrive 5th), various final drives (2.76:1 to 4.571:1), gear ratios (Pre-64 Magic Wand to modern dog engagement kits), tire sizes (145/80r10 to 195/50r13), and speedometer drives.',
 
   inputSchema: {
     metric: z.boolean().default(false).describe('Use metric units (true for km/h, false for mph)'),
@@ -17,9 +17,12 @@ export default defineMcpTool({
       .describe('Final drive ratio (e.g., 3.444 for standard). Range: 2.76 to 4.571'),
     gear_ratios: z
       .array(z.number())
-      .length(4)
+      .min(3)
+      .max(6)
       .default([2.583, 1.644, 1.25, 1.0])
-      .describe('Array of 4 gear ratios [1st, 2nd, 3rd, 4th]. Example: [2.583, 1.644, 1.25, 1.0]'),
+      .describe(
+        'Gear ratios in order [1st, 2nd, 3rd, 4th, optional 5th]. Length 4 for 4-speed (e.g., [2.583, 1.644, 1.25, 1.0]) or 5 for 5-speed (e.g., [2.583, 1.644, 1.25, 1.0, 0.865]).'
+      ),
     drop_gear: z.number().default(1).describe('Drop gear ratio. Standard: 1.0'),
     speedo_drive: z.number().default(0.3529).describe('Speedometer drive ratio. Common: 0.3529 (5/18)'),
     max_rpm: z.number().default(6500).describe('Maximum engine RPM. Typical: 6000-7000 RPM'),
@@ -74,8 +77,8 @@ export default defineMcpTool({
       };
     });
 
-    // Calculate top speed (4th gear)
-    const topSpeedGear = gearingData[3]; // 4th gear
+    // Calculate top speed from the highest gear (last entry — 4th for 4-speed, 5th for 5-speed)
+    const topSpeedGear = gearingData[gearingData.length - 1];
     const topSpeed = topSpeedGear?.maxSpeed || 0;
 
     // Calculate speedometer compatibility

--- a/tests/unit/data/gearing-model.test.ts
+++ b/tests/unit/data/gearing-model.test.ts
@@ -101,11 +101,12 @@ describe('options.gearRatios', () => {
     expect(options.gearRatios.length).toBeGreaterThan(0);
   });
 
-  it('each gear ratio set has a label and a 4-element value array', () => {
+  it('each gear ratio set has a label and a 4- or 5-element value array', () => {
     for (const gr of options.gearRatios) {
       expect(typeof gr.label).toBe('string');
       expect(Array.isArray(gr.value)).toBe(true);
-      expect(gr.value).toHaveLength(4);
+      expect(gr.value.length).toBeGreaterThanOrEqual(4);
+      expect(gr.value.length).toBeLessThanOrEqual(5);
     }
   });
 
@@ -128,6 +129,21 @@ describe('options.gearRatios', () => {
   it('includes the Magic Wand gear set', () => {
     const found = options.gearRatios.find((gr) => gr.label.includes('Magic Wand'));
     expect(found).toBeDefined();
+  });
+
+  it('includes the Minispares Evolution 5-Speed gearset with an overdrive 5th gear', () => {
+    const found = options.gearRatios.find((gr) => gr.label === 'Minispares Evolution 5-Speed');
+    expect(found).toBeDefined();
+    expect(found!.value).toHaveLength(5);
+    // 5th gear is overdrive (< 1.0)
+    expect(found!.value[4]).toBeLessThan(1.0);
+    // Specifically 0.865:1 per Minispares spec
+    expect(found!.value[4]).toBeCloseTo(0.865, 3);
+    // 4th gear is still 1:1 direct drive
+    expect(found!.value[3]).toBe(1.0);
+    // 1st and 3rd shared with the Clubman set
+    expect(found!.value[0]).toBeCloseTo(2.583, 3);
+    expect(found!.value[2]).toBeCloseTo(1.25, 3);
   });
 });
 

--- a/tests/unit/server/mcp/gearbox-calculator.test.ts
+++ b/tests/unit/server/mcp/gearbox-calculator.test.ts
@@ -116,20 +116,20 @@ describe('Gearbox Calculator MCP Tool', () => {
 
   // ---- Gear output structure ----
   describe('gearing output', () => {
-    it('produces exactly 4 gears', async () => {
+    it('produces gears matching the input length (4 by default)', async () => {
       const result = await toolConfig.handler(defaultInputs);
-      expect(result.gearing).toHaveLength(4);
+      expect(result.gearing).toHaveLength(defaultInputs.gear_ratios.length);
     });
 
-    it('gears are numbered 1 through 4', async () => {
+    it('gears are numbered 1 through N (default 4)', async () => {
       const result = await toolConfig.handler(defaultInputs);
       expect(result.gearing.map((g: any) => g.gear)).toEqual([1, 2, 3, 4]);
     });
 
-    it('4th gear is used for top speed', async () => {
+    it('the highest gear is used for top speed', async () => {
       const result = await toolConfig.handler(defaultInputs);
-      const fourthGear = result.gearing.find((g: any) => g.gear === 4);
-      expect(result.results.topSpeed).toBe(fourthGear.maxSpeed);
+      const topGear = result.gearing[result.gearing.length - 1];
+      expect(result.results.topSpeed).toBe(topGear.maxSpeed);
     });
 
     it('each gear has ratio, totalRatio, maxSpeed, and unit', async () => {
@@ -369,6 +369,53 @@ describe('Gearbox Calculator MCP Tool', () => {
     it('calls jsonResult exactly once', async () => {
       await toolConfig.handler(defaultInputs);
       expect(mockJsonResult).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---- 5-speed gearbox support ----
+  describe('5-speed gearbox (Minispares Evolution 5-Speed)', () => {
+    const fiveSpeedInputs = {
+      ...defaultInputs,
+      gear_ratios: [2.583, 1.644, 1.25, 1.0, 0.865],
+    };
+
+    it('accepts a 5-element gear_ratios array', async () => {
+      const result = await toolConfig.handler(fiveSpeedInputs);
+      expect(result.gearing).toHaveLength(5);
+    });
+
+    it('numbers gears 1 through 5', async () => {
+      const result = await toolConfig.handler(fiveSpeedInputs);
+      expect(result.gearing.map((g: any) => g.gear)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('uses 5th gear for top speed (overdrive produces highest speed)', async () => {
+      const result = await toolConfig.handler(fiveSpeedInputs);
+      const fifthGear = result.gearing[4];
+      const fourthGear = result.gearing[3];
+      expect(result.results.topSpeed).toBe(fifthGear.maxSpeed);
+      // 5th (0.865) is overdrive — higher top speed than 4th (1.0)
+      expect(fifthGear.maxSpeed).toBeGreaterThan(fourthGear.maxSpeed);
+    });
+
+    it('top speed of 5-speed exceeds 4-speed at the same RPM and final drive', async () => {
+      const fourSpeed = await toolConfig.handler(defaultInputs);
+      const fiveSpeed = await toolConfig.handler(fiveSpeedInputs);
+      // Overdrive 5th means higher top speed
+      expect(fiveSpeed.results.topSpeed).toBeGreaterThan(fourSpeed.results.topSpeed);
+    });
+
+    it('matches the Minispares Evolution 5-Speed entry by label', async () => {
+      const result = await toolConfig.handler(fiveSpeedInputs);
+      expect(result.context.gearRatios).toBe('Minispares Evolution 5-Speed');
+    });
+
+    it('total ratio for 5th gear factors in the overdrive ratio', async () => {
+      const result = await toolConfig.handler(fiveSpeedInputs);
+      const fifthGear = result.gearing[4];
+      const expected =
+        Math.round((0.865 * fiveSpeedInputs.final_drive * fiveSpeedInputs.drop_gear + Number.EPSILON) * 1000) / 1000;
+      expect(fifthGear.totalRatio).toBe(expected);
     });
   });
 });

--- a/tests/unit/utils/gearingCalculations.test.ts
+++ b/tests/unit/utils/gearingCalculations.test.ts
@@ -337,6 +337,110 @@ describe('calculateGearingTable', () => {
       expect(high[0].maxSpeedRaw).toBeGreaterThan(low[0].maxSpeedRaw);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // 5-speed gearset (Minispares Evolution 5-Speed)
+  // -------------------------------------------------------------------------
+  describe('5-speed gearset (Minispares Evolution 5-Speed)', () => {
+    const FIVE_SPEED = [2.583, 1.644, 1.25, 1.0, 0.865];
+
+    it('produces a row for each of the 5 gears, numbered 1-5', () => {
+      const rows = calculateGearingTable(
+        FIVE_SPEED,
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        false
+      );
+      expect(rows).toHaveLength(5);
+      expect(rows.map((r) => r.gear)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('preserves each gear ratio on its row', () => {
+      const rows = calculateGearingTable(
+        FIVE_SPEED,
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        false
+      );
+      rows.forEach((row, i) => expect(row.ratio).toBe(FIVE_SPEED[i]));
+    });
+
+    it('5th gear (overdrive 0.865) produces a HIGHER top speed than 4th gear (1.0)', () => {
+      const rows = calculateGearingTable(
+        FIVE_SPEED,
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        false
+      );
+      // Overdrive means the output spins faster than the input — higher speed at the same RPM
+      expect(rows[4].maxSpeedRaw).toBeGreaterThan(rows[3].maxSpeedRaw);
+    });
+
+    it('top speeds are monotonically increasing through all 5 gears', () => {
+      const rows = calculateGearingTable(
+        FIVE_SPEED,
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        false
+      );
+      for (let i = 1; i < rows.length; i++) {
+        expect(rows[i].maxSpeedRaw).toBeGreaterThan(rows[i - 1].maxSpeedRaw);
+      }
+    });
+
+    it('1st-4th gear speeds match the Clubman 4-speed (shared 1st/3rd/4th ratios)', () => {
+      // The 5-speed shares 1st (2.583), 3rd (1.25), and 4th (1.0) with the Clubman set.
+      // 2nd differs: Clubman is 1.711, 5-speed is 1.644.
+      const fiveSpeed = calculateGearingTable(
+        FIVE_SPEED,
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        false
+      );
+      const clubman = calculateGearingTable(
+        [2.583, 1.711, 1.25, 1.0],
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        false
+      );
+      expect(fiveSpeed[0].maxSpeedRaw).toBe(clubman[0].maxSpeedRaw); // 1st
+      expect(fiveSpeed[2].maxSpeedRaw).toBe(clubman[2].maxSpeedRaw); // 3rd
+      expect(fiveSpeed[3].maxSpeedRaw).toBe(clubman[3].maxSpeedRaw); // 4th
+    });
+
+    it('formats 5th gear maxSpeed with the correct unit suffix', () => {
+      const imperial = calculateGearingTable(
+        FIVE_SPEED,
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        false
+      );
+      const metric = calculateGearingTable(
+        FIVE_SPEED,
+        FINAL_DRIVE,
+        DROP_GEAR_STANDARD,
+        MAX_RPM,
+        STANDARD_TIRE_CIRC_IN_MILES,
+        true
+      );
+      expect(imperial[4].maxSpeed).toMatch(/^\d+mph$/);
+      expect(metric[4].maxSpeed).toMatch(/^\d+km\/h$/);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds the **Minispares Evolution 5-Speed** gearset (2.583/1.644/1.25/1.0/0.865) to the gearbox calculator
- Generalizes the math, chart, comparison table, and MCP tool to support any gear count (currently 3–6 via Zod schema; 4 and 5 in the gearset list)
- Database is unchanged — `saved_gear_configs.gearset` stores a label string, so existing saved configs continue to work

## What changed
- `data/models/gearing.ts` — widen `GearRatioOption.value` from 4-tuple to `number[]`, add the new gearset entry
- `app/components/Calculators/Gearbox.vue` — generalize "top gear" semantics from hardcoded `[3]` → last gear; add 5th-gear marker (`triangle-down`) and name; route side panels through a new `primaryConfigIndex` (config with most gears) so the 5th gear surfaces in mixed-comparison views
- `app/components/Calculators/GearboxComparisonChart.vue` — extend legend to 5 gears with conditional rendering via `maxGearCount` prop; add triangle-down SVG + tooltip glyph
- `app/components/Calculators/GearboxComparisonTable.vue` — rebuild as fully dynamic; gear rows generated from `Math.max(...gearingTable.length)`; missing gears show "—"; `isBest` only highlights configs that have a value; parameterized i18n (`gear_max_speed`, `top_gear_ratio`, `total_ratio_top`) with localized ordinals across all 10 locales
- `server/mcp/tools/gearbox-calculator.ts` + `server/mcp/README.md` — Zod schema loosened from `.length(4)` to `.min(3).max(6)`; top-speed extraction uses last gear
- Tests — 17 new cases: 5-speed entry presence + structure, 5-speed gearing math (overdrive 5th > 4th, monotonic increase, shared 1st/3rd/4th with Clubman set, unit suffixes), MCP handler accepts 5-element arrays and uses 5th for top speed

## Test plan
- [x] `bun run test --run` — all 1419 tests pass (17 new)
- [x] `vue-tsc --noEmit` — no new type errors introduced (pre-existing errors unchanged)
- [x] Manual browser verification at `/technical/gearing`:
  - 5-speed dropdown option present, selecting it produces 5 gear rows (1st=42, 2nd=65, 3rd=86, 4th=107, 5th=124 mph at 6500 RPM, 3.444 diff)
  - Total Ratio = 2.979:1 (= 3.444 × 0.865 × 1.0)
  - Mixed 4-speed + 5-speed comparison: 5th-gear row shows "—" for the 4-speed column, 5 shapes in the legend including triangle-down
  - Side Gearing Information table now shows 5 rows when any compared config is 5-speed (regression fix)
- [ ] Reviewer to spot-check the parameterized i18n strings in their locale of choice

## Tracking
Cross-property cascade card on the [CMDIY Platform board](https://github.com/orgs/ClassicMiniDIY/projects/9): "Gearbox Calculator: 5-speed gearset support" (Web=Shipped, iOS/Android=Not Started, Supabase/TME=N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)