### PR TITLE
fix: stop intermittent FA icon failures + pre-bundle fuse.js

### DIFF
--- a/app/plugins/fontawesome.client.ts
+++ b/app/plugins/fontawesome.client.ts
@@ -1,30 +1,92 @@
-// Trigger Font Awesome <i>→<svg> replacement AFTER Vue hydration is complete.
-// Initial replacement is disabled via window.FontAwesomeConfig in nuxt.config.ts
-// to prevent hydration mismatches.
+// Coordinate the Font Awesome Kit lifecycle so icons reliably render without
+// causing hydration churn.
+//
+// nuxt.config.ts sets `window.FontAwesomeConfig = { autoReplaceSvg: false,
+// observeMutations: false }` BEFORE the kit script loads, which prevents the
+// kit from sweeping <i> tags during/around Vue hydration (that swap caused
+// page-flashing as Vue tore down and re-patched the affected subtrees).
+//
+// This plugin's job is to re-enable Font Awesome's normal behaviour AFTER
+// hydration is complete so:
+//   1. Existing <i> tags get converted to <svg> once the kit has loaded.
+//   2. Any <i> tags rendered later (route changes, modals, lazy components,
+//      reactive list updates) get converted automatically — no manual
+//      i2svg() call from the rendering component required.
+//
+// The previous version polled for `window.FontAwesome` for 5 seconds and
+// gave up, which intermittently failed on slow networks where the deferred
+// kit script took longer to load. We now (a) listen for the script's load
+// event so we react deterministically the moment FA arrives, (b) keep a
+// no-op-cheap polling fallback running for up to 30 seconds for the rare
+// case where the load event has already fired before we attached, and
+// (c) turn on FA's MutationObserver once so subsequent renders are
+// handled automatically.
 export default defineNuxtPlugin((nuxtApp) => {
-  const replaceIcons = () => {
+  let enabled = false;
+
+  const enableFa = (): boolean => {
+    if (enabled) return true;
     const FA = (window as any).FontAwesome;
-    if (FA?.dom?.i2svg) {
-      FA.dom.i2svg();
+    if (!FA) return false;
+
+    // Re-enable mutation observation now that hydration is done so any new
+    // <i class="fas fa-*"> tags rendered after this point are automatically
+    // converted by FA itself — no need to manually call i2svg() in
+    // components that render icons reactively.
+    if (FA.config) {
+      FA.config.autoReplaceSvg = 'nest';
+      FA.config.observeMutations = true;
     }
+
+    // One-time sweep of any existing static markup.
+    if (FA.dom?.i2svg) FA.dom.i2svg();
+    // Start the MutationObserver explicitly — some versions of the kit
+    // need an explicit kick once `observeMutations` flips from false → true
+    // post-init.
+    if (FA.dom?.watch) FA.dom.watch();
+
+    enabled = true;
+    return true;
   };
 
-  nuxtApp.hook('app:suspense:resolve', () => {
-    // Wait for the FA kit script to finish loading, then replace on each nav.
-    if ((window as any).FontAwesome) {
-      replaceIcons();
-    } else {
-      const interval = setInterval(() => {
-        if ((window as any).FontAwesome) {
-          clearInterval(interval);
-          replaceIcons();
-        }
-      }, 50);
-      setTimeout(() => clearInterval(interval), 5000);
-    }
-  });
+  const armEnable = () => {
+    if (enableFa()) return;
 
+    // Deterministic path: react when the kit script finishes loading.
+    const script = document.querySelector(
+      'script[src*="kit.fontawesome.com"], script[src*="ka-f.fontawesome.com"]'
+    ) as HTMLScriptElement | null;
+    if (script) {
+      script.addEventListener('load', () => enableFa(), { once: true });
+    }
+
+    // Defensive fallback: if the load event already fired (script may have
+    // resolved between hook firing and our listener attaching) or if the
+    // kit takes longer than expected (slow/congested CDN), poll for up to
+    // 30 seconds. Cheap — a single property read on window every 100ms.
+    let attempts = 0;
+    const MAX_ATTEMPTS = 300; // 300 × 100ms = 30s
+    const interval = window.setInterval(() => {
+      attempts += 1;
+      if (enableFa() || attempts >= MAX_ATTEMPTS) {
+        window.clearInterval(interval);
+      }
+    }, 100);
+  };
+
+  nuxtApp.hook('app:suspense:resolve', armEnable);
+
+  // Belt-and-suspenders re-sweep on page navigation. With observeMutations
+  // turned on this is mostly redundant, but it cheaply catches any edge
+  // case where the observer hasn't been wired up yet (e.g. very first
+  // navigation while FA is still loading) without causing rework when it
+  // has — i2svg() is idempotent on already-converted markup.
   nuxtApp.hook('page:finish', () => {
-    replaceIcons();
+    if (!enabled) {
+      armEnable();
+      return;
+    }
+    const FA = (window as any).FontAwesome;
+    if (FA?.dom?.i2svg) FA.dom.i2svg();
   });
 });

--- a/app/plugins/fontawesome.client.ts
+++ b/app/plugins/fontawesome.client.ts
@@ -23,6 +23,13 @@
 // handled automatically.
 export default defineNuxtPlugin((nuxtApp) => {
   let enabled = false;
+  // `arming` tracks whether we're already in the "waiting for the kit to
+  // load" phase. Without it, a `page:finish` hook firing during rapid
+  // navigation (while the kit is still loading on a slow connection)
+  // would attach a second `script` load listener and start a parallel
+  // polling interval — wasteful, and a small leak until the kit finally
+  // resolves and both copies fire enableFa().
+  let arming = false;
 
   const enableFa = (): boolean => {
     if (enabled) return true;
@@ -50,14 +57,28 @@ export default defineNuxtPlugin((nuxtApp) => {
   };
 
   const armEnable = () => {
+    if (enabled || arming) return;
     if (enableFa()) return;
+
+    arming = true;
+
+    const finish = () => {
+      arming = false;
+    };
 
     // Deterministic path: react when the kit script finishes loading.
     const script = document.querySelector(
       'script[src*="kit.fontawesome.com"], script[src*="ka-f.fontawesome.com"]'
     ) as HTMLScriptElement | null;
     if (script) {
-      script.addEventListener('load', () => enableFa(), { once: true });
+      script.addEventListener(
+        'load',
+        () => {
+          enableFa();
+          finish();
+        },
+        { once: true }
+      );
     }
 
     // Defensive fallback: if the load event already fired (script may have
@@ -70,6 +91,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       attempts += 1;
       if (enableFa() || attempts >= MAX_ATTEMPTS) {
         window.clearInterval(interval);
+        finish();
       }
     }, 100);
   };

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -479,6 +479,7 @@ export default defineNuxtConfig({
         'highlight.js',
         '@vue/devtools-core',
         '@vue/devtools-kit',
+        'fuse.js',
       ],
       exclude: [],
     },


### PR DESCRIPTION
## Summary

Two unrelated dev/runtime reliability issues bundled into one small PR. Both are surface-area fixes — no UX or feature changes.

### 1. Font Awesome — intermittent icon failures

Multiple users reported icons sometimes not rendering at all. Three failure modes in the previous setup, all triggered by network conditions or late component renders:

- The kit script loads with `defer: true` (kept for LCP). The plugin polled `window.FontAwesome` every 50 ms but **gave up after 5 seconds**. On slow or congested connections the FA Kit JIT-compiled response can take longer than that, the polling stops, and icons stay as raw `<i>` tags forever — no retry path.
- The plugin never listened to the script's actual `load` event, so even when polling was alive there was a 0–50 ms latency window on every check.
- `observeMutations: false` was set in `nuxt.config.ts` to prevent hydration churn during initial page render — but it was never re-enabled after hydration. Anything reactively rendered later (route changes, modals, lazy components) had to be manually swept by scattered `i2svg()` calls, and components that didn't sweep showed empty icon slots until the user navigated.

**Fix in `app/plugins/fontawesome.client.ts`:**
- Attach a `script.addEventListener('load')` on the kit script — deterministic activation the moment FA arrives.
- Polling fallback bumped from 5 s → 30 s and made cheaper (single property read every 100 ms).
- Once FA is available, **flip `observeMutations: true`** and `autoReplaceSvg: 'nest'` back on, then call `FA.dom.watch()` to start the MutationObserver. Subsequent renders are converted by FA itself; no more empty slots on dynamic content, no more component-level `i2svg()` calls required.
- Idempotency guard so the `page:finish` hook doesn't duplicate setup.

**Verified live**: `FontAwesome.config.observeMutations === true` after hydration on `/technical/needles` and `/archive/wheels`. 0 unconverted `<i class="fas">` tags remaining post-load. Icons survive client-side route changes without any manual sweep.

### 2. Pre-bundle `fuse.js` in Vite

Vite was discovering `fuse.js` at runtime when search/autocomplete components first lazy-load, forcing a full dev-server page reload mid-session (Nuxt printed `"Vite discovered new dependencies at runtime"` with the suggested optimizeDeps list). Adding it to `vite.optimizeDeps.include` eliminates the reload — no production bundle impact.

## Test plan
- [x] `bun run dev` — no `"Vite discovered new dependencies at runtime"` warning when navigating to a search/autocomplete page
- [x] On any icon-heavy page (Wheels, Needles), confirm `window.FontAwesome.config.observeMutations === true` after the page finishes loading
- [x] Confirm no raw `<i class="fas …">` tags remain in the DOM after navigation
- [x] Confirm icons still render in modals, lazy-loaded components, and reactively-added list rows without manual `i2svg()` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)