### PR TITLE
chore(newsletter): point blog/newsletter links to news.classicminidiy.com

### DIFF
--- a/app/components/MainNav.vue
+++ b/app/components/MainNav.vue
@@ -58,7 +58,7 @@
     {
       label: t('navigation.blog'),
       faIcon: 'fa-pencil',
-      to: 'https://classicminidiy.substack.com/',
+      to: 'https://news.classicminidiy.com/',
     },
     {
       label: t('navigation.store'),

--- a/app/pages/links.vue
+++ b/app/pages/links.vue
@@ -24,7 +24,7 @@
       id: 'newsletter',
       label: t('links.newsletter.label'),
       sub: t('links.newsletter.sub'),
-      href: 'https://classicminidiy.substack.com/',
+      href: 'https://news.classicminidiy.com/',
       icon: 'fad fa-envelope-open-text',
       btnClass: 'btn-primary',
     },


### PR DESCRIPTION
## Summary
The newsletter migrated from Substack to a self-hosted Ghost blog at \`news.classicminidiy.com\`. This updates the two remaining hardcoded \`classicminidiy.substack.com\` URLs in the codebase so visitors land on the new platform.

- [app/components/MainNav.vue](app/components/MainNav.vue) — main nav "Blog" entry
- [app/pages/links.vue](app/pages/links.vue) — link-in-bio newsletter CTA

Labels are already generic (\`navigation.blog\` / \`links.newsletter.label\`), so no copy changes needed — the migration is URL-only.

> Note: PR #590 also touches \`app/pages/links.vue\`. If that merges first, this PR will need a trivial conflict resolution on the same line (or vice versa).

## Test plan
- [ ] \`bun run dev\` and click "Blog" in the main nav → lands on news.classicminidiy.com
- [ ] Visit \`/links\` and click "Subscribe to the Newsletter" → lands on news.classicminidiy.com
- [ ] \`grep -r substack\` returns no matches in tracked source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)