### PR TITLE
fix(security): require auth + ownership on submission upload endpoints

### DIFF
--- a/app/components/WheelSubmit.vue
+++ b/app/components/WheelSubmit.vue
@@ -195,7 +195,7 @@
       formData.append(`file${i}`, file);
     });
 
-    return await useFetch('/api/wheels/save/images', {
+    return await useAuthFetch('/api/wheels/save/images', {
       method: 'POST',
       body: formData,
       query: { uuid },

--- a/app/composables/useAuthFetch.ts
+++ b/app/composables/useAuthFetch.ts
@@ -1,0 +1,42 @@
+/**
+ * Wrapper around useFetch for authenticated user API endpoints.
+ *
+ * Injects the Supabase access token as an Authorization header so server-side
+ * `requireUserAuth` can validate the caller. Use this for any /api/* endpoint
+ * that requires the user to be logged in (non-admin).
+ */
+export const useAuthFetch = <T>(url: string, opts: Record<string, any> = {}) => {
+  const supabase = useSupabase();
+
+  return useFetch<T>(url, {
+    ...opts,
+    server: false,
+    async onRequest({ options }) {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (session?.access_token) {
+        options.headers = new Headers(options.headers);
+        options.headers.set('Authorization', `Bearer ${session.access_token}`);
+      }
+    },
+  });
+};
+
+/**
+ * Wrapper around $fetch for authenticated user mutations.
+ */
+export const $authFetch = async <T>(url: string, opts: Record<string, any> = {}): Promise<T> => {
+  const supabase = useSupabase();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  return $fetch<T>(url, {
+    ...opts,
+    headers: {
+      ...opts.headers,
+      ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+    },
+  });
+};

--- a/app/composables/useAuthFetch.ts
+++ b/app/composables/useAuthFetch.ts
@@ -32,11 +32,13 @@ export const $authFetch = async <T>(url: string, opts: Record<string, any> = {})
     data: { session },
   } = await supabase.auth.getSession();
 
+  const headers = new Headers(opts.headers);
+  if (session?.access_token) {
+    headers.set('Authorization', `Bearer ${session.access_token}`);
+  }
+
   return $fetch<T>(url, {
     ...opts,
-    headers: {
-      ...opts.headers,
-      ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
-    },
+    headers,
   });
 };

--- a/app/pages/contribute/color.vue
+++ b/app/pages/contribute/color.vue
@@ -121,7 +121,7 @@
         const uploadData = new FormData();
         swatchFiles.value.forEach((file, i) => uploadData.append(`file${i}`, file));
 
-        const { error: uploadError } = await useFetch('/api/archive/upload', {
+        const { error: uploadError } = await useAuthFetch('/api/archive/upload', {
           method: 'POST',
           body: uploadData,
           query: { bucket: 'archive-colors', submissionId: submission.id, category: 'swatch' },
@@ -137,7 +137,7 @@
         const uploadData = new FormData();
         carPhotoFiles.value.forEach((file, i) => uploadData.append(`file${i}`, file));
 
-        const { error: uploadError } = await useFetch('/api/archive/upload', {
+        const { error: uploadError } = await useAuthFetch('/api/archive/upload', {
           method: 'POST',
           body: uploadData,
           query: { bucket: 'archive-colors', submissionId: submission.id, category: 'car-photos' },

--- a/app/pages/contribute/document.vue
+++ b/app/pages/contribute/document.vue
@@ -136,7 +136,7 @@
       // Upload document files
       const docFormData = new FormData();
       documentFiles.value.forEach((file, i) => docFormData.append(`file${i}`, file));
-      const { error: docUploadError } = await useFetch('/api/archive/upload', {
+      const { error: docUploadError } = await useAuthFetch('/api/archive/upload', {
         method: 'POST',
         body: docFormData,
         query: { bucket: 'archive-documents', submissionId: response.id },
@@ -150,7 +150,7 @@
       if (thumbnailFiles.value.length > 0) {
         const thumbFormData = new FormData();
         thumbnailFiles.value.forEach((file, i) => thumbFormData.append(`file${i}`, file));
-        const { error: thumbUploadError } = await useFetch('/api/archive/upload', {
+        const { error: thumbUploadError } = await useAuthFetch('/api/archive/upload', {
           method: 'POST',
           body: thumbFormData,
           query: { bucket: 'archive-thumbnails', submissionId: response.id },

--- a/app/pages/contribute/wheel.vue
+++ b/app/pages/contribute/wheel.vue
@@ -115,7 +115,7 @@
       // 2. Upload photos
       const formData = new FormData();
       photoFiles.value.forEach((file, i) => formData.append(`file${i}`, file));
-      await useFetch('/api/archive/upload', {
+      await useAuthFetch('/api/archive/upload', {
         method: 'POST',
         body: formData,
         query: { bucket: 'archive-wheels', submissionId: submission.id },

--- a/server/api/archive/upload.ts
+++ b/server/api/archive/upload.ts
@@ -1,33 +1,37 @@
 import { getServiceClient } from '../../utils/supabase';
+import { requireUserAuth } from '../../utils/userAuth';
+import { detectMimeFromMagic, generateSafeFilename, type DetectedMime } from '../../utils/uploadValidation';
 
 const ALLOWED_BUCKETS = ['archive-documents', 'archive-thumbnails', 'archive-colors', 'archive-wheels'] as const;
 type AllowedBucket = (typeof ALLOWED_BUCKETS)[number];
 
 interface BucketConfig {
-  allowedTypes: string[];
+  allowedTypes: DetectedMime[];
   maxSizeBytes: number;
 }
 
 const BUCKET_CONFIGS: Record<AllowedBucket, BucketConfig> = {
   'archive-documents': {
     allowedTypes: ['application/pdf', 'image/jpeg', 'image/png'],
-    maxSizeBytes: 10 * 1024 * 1024, // 10MB
+    maxSizeBytes: 10 * 1024 * 1024,
   },
   'archive-thumbnails': {
     allowedTypes: ['image/jpeg', 'image/png'],
-    maxSizeBytes: 5 * 1024 * 1024, // 5MB
+    maxSizeBytes: 5 * 1024 * 1024,
   },
   'archive-colors': {
     allowedTypes: ['image/jpeg', 'image/png'],
-    maxSizeBytes: 5 * 1024 * 1024, // 5MB
+    maxSizeBytes: 5 * 1024 * 1024,
   },
   'archive-wheels': {
     allowedTypes: ['image/jpeg', 'image/png'],
-    maxSizeBytes: 3 * 1024 * 1024, // 3MB
+    maxSizeBytes: 3 * 1024 * 1024,
   },
 };
 
 export default defineEventHandler(async (event) => {
+  const { user } = await requireUserAuth(event);
+
   const params = getQuery(event);
   const bucket = params.bucket?.toString();
   const submissionId = params.submissionId?.toString();
@@ -51,6 +55,24 @@ export default defineEventHandler(async (event) => {
   const config = BUCKET_CONFIGS[bucket as AllowedBucket];
   const supabase = getServiceClient();
 
+  const { data: submission, error: submissionError } = await supabase
+    .from('submission_queue')
+    .select('id, submitted_by, status')
+    .eq('id', submissionId)
+    .single();
+
+  if (submissionError || !submission) {
+    throw createError({ statusCode: 404, statusMessage: 'Submission not found' });
+  }
+
+  if (submission.submitted_by !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Not authorized to upload to this submission' });
+  }
+
+  if (submission.status !== 'pending') {
+    throw createError({ statusCode: 409, statusMessage: 'Submission is no longer accepting uploads' });
+  }
+
   try {
     const formData = await readMultipartFormData(event);
 
@@ -63,33 +85,32 @@ export default defineEventHandler(async (event) => {
     for (const file of formData) {
       if (!file.data || !file.filename) continue;
 
-      // Validate file type
-      const fileType = file.type || 'application/octet-stream';
-      if (!config.allowedTypes.includes(fileType)) {
-        throw createError({
-          statusCode: 400,
-          statusMessage: `File type "${fileType}" is not allowed for bucket "${bucket}". Allowed types: ${config.allowedTypes.join(', ')}`,
-        });
-      }
-
-      // Validate file size
       if (file.data.length > config.maxSizeBytes) {
         const maxMB = config.maxSizeBytes / (1024 * 1024);
         throw createError({
           statusCode: 400,
-          statusMessage: `File "${file.filename}" exceeds the maximum size of ${maxMB}MB for bucket "${bucket}"`,
+          statusMessage: `File exceeds the maximum size of ${maxMB}MB for bucket "${bucket}"`,
         });
       }
 
-      const storagePath = `uploads/${submissionId}/${file.filename}`;
+      const detectedMime = detectMimeFromMagic(file.data);
+      if (!detectedMime || !config.allowedTypes.includes(detectedMime)) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: `File content is not an allowed type for bucket "${bucket}". Allowed types: ${config.allowedTypes.join(', ')}`,
+        });
+      }
+
+      const safeName = generateSafeFilename(detectedMime);
+      const storagePath = `uploads/${submissionId}/${safeName}`;
 
       const { error } = await supabase.storage.from(bucket).upload(storagePath, file.data, {
-        contentType: fileType,
-        upsert: true,
+        contentType: detectedMime,
+        upsert: false,
       });
 
       if (error) {
-        console.error(`Error uploading file ${file.filename}:`, error);
+        console.error(`Error uploading file:`, error);
         throw createError({ statusCode: 500, statusMessage: `Upload failed: ${error.message}` });
       }
 
@@ -98,9 +119,16 @@ export default defineEventHandler(async (event) => {
       uploadedPaths.push(urlData.publicUrl);
     }
 
-    // Update the submission queue entry with new file paths
     if (uploadedPaths.length > 0) {
-      const { data: existing } = await supabase.from('submission_queue').select('data').eq('id', submissionId).single();
+      const { data: existing } = await supabase
+        .from('submission_queue')
+        .select('data, submitted_by, status')
+        .eq('id', submissionId)
+        .single();
+
+      if (!existing || existing.submitted_by !== user.id || existing.status !== 'pending') {
+        throw createError({ statusCode: 409, statusMessage: 'Submission state changed during upload' });
+      }
 
       const currentData = (existing?.data as Record<string, unknown>) || {};
       const currentFiles = (currentData.uploadedFiles as any[]) || [];
@@ -114,7 +142,9 @@ export default defineEventHandler(async (event) => {
             uploadedFiles: [...currentFiles, ...newFiles],
           },
         })
-        .eq('id', submissionId);
+        .eq('id', submissionId)
+        .eq('submitted_by', user.id)
+        .eq('status', 'pending');
     }
 
     return { ok: true, paths: uploadedPaths };

--- a/server/api/archive/upload.ts
+++ b/server/api/archive/upload.ts
@@ -12,19 +12,19 @@ interface BucketConfig {
 
 const BUCKET_CONFIGS: Record<AllowedBucket, BucketConfig> = {
   'archive-documents': {
-    allowedTypes: ['application/pdf', 'image/jpeg', 'image/png'],
+    allowedTypes: ['application/pdf', 'image/jpeg', 'image/png', 'image/webp'],
     maxSizeBytes: 10 * 1024 * 1024,
   },
   'archive-thumbnails': {
-    allowedTypes: ['image/jpeg', 'image/png'],
+    allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
     maxSizeBytes: 5 * 1024 * 1024,
   },
   'archive-colors': {
-    allowedTypes: ['image/jpeg', 'image/png'],
+    allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
     maxSizeBytes: 5 * 1024 * 1024,
   },
   'archive-wheels': {
-    allowedTypes: ['image/jpeg', 'image/png'],
+    allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
     maxSizeBytes: 3 * 1024 * 1024,
   },
 };

--- a/server/api/wheels/save/images.ts
+++ b/server/api/wheels/save/images.ts
@@ -1,6 +1,13 @@
 import { getServiceClient } from '../../../utils/supabase';
+import { requireUserAuth } from '../../../utils/userAuth';
+import { detectMimeFromMagic, generateSafeFilename, type DetectedMime } from '../../../utils/uploadValidation';
+
+const ALLOWED_TYPES: DetectedMime[] = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_SIZE_BYTES = 3 * 1024 * 1024;
 
 export default defineEventHandler(async (event) => {
+  const { user } = await requireUserAuth(event);
+
   const params = getQuery(event);
   const uuid = params.uuid?.toString();
 
@@ -10,8 +17,25 @@ export default defineEventHandler(async (event) => {
 
   const supabase = getServiceClient();
 
+  const { data: submission, error: submissionError } = await supabase
+    .from('submission_queue')
+    .select('id, submitted_by, status')
+    .eq('id', uuid)
+    .single();
+
+  if (submissionError || !submission) {
+    throw createError({ statusCode: 404, statusMessage: 'Submission not found' });
+  }
+
+  if (submission.submitted_by !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Not authorized to upload to this submission' });
+  }
+
+  if (submission.status !== 'pending') {
+    throw createError({ statusCode: 409, statusMessage: 'Submission is no longer accepting uploads' });
+  }
+
   try {
-    // Use h3's built-in multipart form data parser
     const formData = await readMultipartFormData(event);
 
     if (!formData || formData.length === 0) {
@@ -23,30 +47,52 @@ export default defineEventHandler(async (event) => {
     for (const file of formData) {
       if (!file.data || !file.filename) continue;
 
-      const storagePath = `uploads/${uuid}/${file.filename}`;
+      if (file.data.length > MAX_SIZE_BYTES) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: `File exceeds the maximum size of ${MAX_SIZE_BYTES / (1024 * 1024)}MB`,
+        });
+      }
+
+      const detectedMime = detectMimeFromMagic(file.data);
+      if (!detectedMime || !ALLOWED_TYPES.includes(detectedMime)) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: `File content is not an allowed image type. Allowed: ${ALLOWED_TYPES.join(', ')}`,
+        });
+      }
+
+      const safeName = generateSafeFilename(detectedMime);
+      const storagePath = `uploads/${uuid}/${safeName}`;
 
       const { error } = await supabase.storage.from('archive-wheels').upload(storagePath, file.data, {
-        contentType: file.type || 'application/octet-stream',
-        upsert: true,
+        contentType: detectedMime,
+        upsert: false,
       });
 
       if (error) {
-        console.error(`Error uploading file ${file.filename}:`, error);
+        console.error(`Error uploading file:`, error);
         throw createError({ statusCode: 500, statusMessage: `Upload failed: ${error.message}` });
       }
 
-      // Get the public URL for the uploaded file
       const { data: urlData } = supabase.storage.from('archive-wheels').getPublicUrl(storagePath);
 
       uploadedPaths.push(urlData.publicUrl);
     }
 
-    // Update the submission queue entry with new photo paths
     if (uploadedPaths.length > 0) {
-      const { data: existing } = await supabase.from('submission_queue').select('data').eq('id', uuid).single();
+      const { data: existing } = await supabase
+        .from('submission_queue')
+        .select('data, submitted_by, status')
+        .eq('id', uuid)
+        .single();
 
-      const currentData = existing?.data || {};
-      const currentPhotos = currentData.images || currentData.photos || [];
+      if (!existing || existing.submitted_by !== user.id || existing.status !== 'pending') {
+        throw createError({ statusCode: 409, statusMessage: 'Submission state changed during upload' });
+      }
+
+      const currentData = (existing?.data as Record<string, any>) || {};
+      const currentPhotos = (currentData.images as any[]) || (currentData.photos as any[]) || [];
 
       await supabase
         .from('submission_queue')
@@ -56,7 +102,9 @@ export default defineEventHandler(async (event) => {
             images: [...currentPhotos, ...uploadedPaths],
           },
         })
-        .eq('id', uuid);
+        .eq('id', uuid)
+        .eq('submitted_by', user.id)
+        .eq('status', 'pending');
     }
 
     return { ok: true };

--- a/server/utils/uploadValidation.ts
+++ b/server/utils/uploadValidation.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from 'node:crypto';
+
+export type DetectedMime = 'image/jpeg' | 'image/png' | 'image/webp' | 'application/pdf';
+
+export function detectMimeFromMagic(data: Buffer | Uint8Array): DetectedMime | null {
+  if (!data || data.length < 12) return null;
+  const b = data;
+
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'image/jpeg';
+
+  if (
+    b[0] === 0x89 &&
+    b[1] === 0x50 &&
+    b[2] === 0x4e &&
+    b[3] === 0x47 &&
+    b[4] === 0x0d &&
+    b[5] === 0x0a &&
+    b[6] === 0x1a &&
+    b[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+
+  if (
+    b[0] === 0x52 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x46 &&
+    b[8] === 0x57 &&
+    b[9] === 0x45 &&
+    b[10] === 0x42 &&
+    b[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+
+  if (b[0] === 0x25 && b[1] === 0x50 && b[2] === 0x44 && b[3] === 0x46 && b[4] === 0x2d) return 'application/pdf';
+
+  return null;
+}
+
+const EXT_FOR_MIME: Record<DetectedMime, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'application/pdf': 'pdf',
+};
+
+export function generateSafeFilename(detectedMime: DetectedMime): string {
+  return `${randomUUID()}.${EXT_FOR_MIME[detectedMime]}`;
+}


### PR DESCRIPTION
## Summary

Fixes two high-severity unauthenticated upload vulnerabilities surfaced by the security review:

- **`server/api/archive/upload.ts`** — anonymous attackers could POST to any pending `submission_queue` UUID, overwrite legitimate submitter files in the four public Supabase buckets (`upsert: true` + client-controlled filename), and inject attacker URLs into the queue row. On admin approval those URLs became the persisted `swatch_path` / `contributor_images` / `photos` / `file_path` of the published archive entry.
- **`server/api/wheels/save/images.ts`** — same pattern: no auth, attacker-supplied `uuid`, `upsert: true`, no MIME validation, attacker-controlled `Content-Type` propagated to the stored object.

## Changes

Both endpoints now:
- Require `requireUserAuth` and verify caller is the submission's `submitted_by`, with `status` still `pending`.
- Validate file content via **magic-byte sniffing** (new `server/utils/uploadValidation.ts`) — the client `Content-Type` is no longer trusted.
- Generate a server-side random storage filename (`<uuid>.<ext>`) instead of echoing the client filename, eliminating path-segment manipulation.
- Upload with `upsert: false` so re-used keys fail closed.
- Re-check ownership/status before patching `submission_queue.data` and scope the `update` with `.eq('submitted_by', user.id).eq('status', 'pending')`.

Frontend callers (`contribute/wheel.vue`, `contribute/color.vue`, `contribute/document.vue`, `WheelSubmit.vue`) now use a new `useAuthFetch` composable that forwards the Supabase access token as a `Bearer` header — mirroring the existing `useAdminFetch` pattern. This is required because the client-side Supabase setup persists sessions in `localStorage`, not cookies.

## Test plan

- [x] `bun run test` — 52/53 test files pass (the 1 failing file, `youtube.test.ts`, fails identically on clean `main` and is unrelated)
- [ ] Manual: submit a new wheel as an authenticated user end-to-end, confirm photos upload and the submission row gets `data.images` populated
- [ ] Manual: submit a color contribution with both swatch and car-photo uploads
- [ ] Manual: submit a document contribution with a thumbnail
- [ ] Manual: confirm an unauthenticated `curl` POST to `/api/archive/upload` and `/api/wheels/save/images` returns 401
- [ ] Manual: confirm an authenticated user posting to another user's pending `submissionId` returns 403
- [ ] Manual: confirm posting a non-image payload with `Content-Type: image/jpeg` is rejected with 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)