### PR TITLE
fix(auth): disable detectSessionInUrl to end PKCE exchange race

### DIFF
--- a/app/composables/useSupabase.ts
+++ b/app/composables/useSupabase.ts
@@ -10,7 +10,15 @@ export const useSupabase = () => {
         auth: {
           persistSession: true,
           autoRefreshToken: true,
-          detectSessionInUrl: true,
+          // Auto-detect is disabled: app/pages/auth/callback.vue calls
+          // supabase.auth.exchangeCodeForSession() manually for both OAuth and
+          // magic-link PKCE callbacks. Leaving auto-detect on creates a race
+          // — both calls compete for the same single-use auth code, the
+          // verifier can be consumed/cleared before either succeeds, and the
+          // flow_state row is left orphaned in the DB. See investigation in
+          // commit message for symptoms (production OAuth failures on
+          // 2026-05-23 with classicminidiy@gmail.com).
+          detectSessionInUrl: false,
           storage: window.localStorage,
           flowType: 'pkce',
           // In-memory mutex to replace Web Locks API, which causes AbortError

--- a/app/composables/useSupabase.ts
+++ b/app/composables/useSupabase.ts
@@ -15,9 +15,7 @@ export const useSupabase = () => {
           // magic-link PKCE callbacks. Leaving auto-detect on creates a race
           // — both calls compete for the same single-use auth code, the
           // verifier can be consumed/cleared before either succeeds, and the
-          // flow_state row is left orphaned in the DB. See investigation in
-          // commit message for symptoms (production OAuth failures on
-          // 2026-05-23 with classicminidiy@gmail.com).
+          // flow_state row is left orphaned in the DB.
           detectSessionInUrl: false,
           storage: window.localStorage,
           flowType: 'pkce',


### PR DESCRIPTION
## Production hotfix — OAuth sign-in failing

**Symptom:** classicminidiy@gmail.com (and likely all users) hitting "Authentication Error / Authentication failed. Please try again." on the Google OAuth flow. Four attempts tonight at 2026-05-23 20:44-20:50 UTC all failed.

## Diagnostic findings (via supabase db query --linked)

For each of Cole's 4 attempts:
- `auth.flow_state` row was created with `auth_code` + `code_challenge` ✓
- `auth.users.raw_user_meta_data` was updated with the Google identity data ✓
- `auth.sessions` got 0 new rows ✗
- `flow_state` row was left in the DB (would normally be deleted after a successful exchange) ✗

That is the signature of a `/auth/v1/token?grant_type=pkce` exchange that never completed.

**Ruled out:** captcha enforcement. The project does have captcha enabled (`/otp`, `/signup`, `/token?grant_type=password` all return `captcha_failed`), but `/token?grant_type=pkce` is exempt — it returned `flow_state_expired` (a normal TTL response), not `captcha_failed`.

## Root cause

`useSupabase` sets both `detectSessionInUrl: true` AND `flowType: 'pkce'`. On `/auth/callback?code=...`, supabase-js auto-fires `exchangeCodeForSession` from `createClient()` — racing with the explicit `exchangeCodeForSession(code)` in `app/pages/auth/callback.vue`. The callback file's own comment flagged this race when it landed:

> supabase-js's detectSessionInUrl auto-magic is racy with our custom lock implementation, so do it manually.

…but only added the manual call alongside auto-detect rather than disabling it. Both calls compete for the same single-use code and the same localStorage code-verifier; the second hits `invalid_grant`, neither writes a session, the `flow_state` is orphaned.

## Fix

`detectSessionInUrl: false` on the client. `auth/callback.vue` already handles both OAuth and magic-link PKCE callbacks via the manual exchange, so there's nothing left to auto-detect. SSR client config already had it off; this brings the client config in line.

## Test plan
- [ ] Once deployed, sign in to www.classicminidiy.com with Google as classicminidiy@gmail.com
- [ ] Verify a new row appears in `auth.sessions` and the `auth.flow_state` row for that attempt is deleted
- [ ] Verify magic-link sign-in still works (also PKCE under the hood, same `?code=...` callback path)
- [ ] Verify token refresh still works on an already-signed-in session (this PR only affects callback handling, not refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)