### PR TITLE
fix(auth): stop prerendering /auth/callback + read code from route.query

### DIFF
--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -50,18 +50,24 @@
       const code = routeCode || winCode;
 
       // --- DIAGNOSTICS (temporary) ---------------------------------------
-      // Tracking a production sign-in failure where flow_state rows are
-      // created server-side but no auth.sessions row appears. Capture every
-      // URL/storage signal so the next failed attempt is fully diagnosed.
+      // Tracking the production OAuth-callback regression. These logs are
+      // stripped from production by terser's drop_console: true and are only
+      // useful in dev / preview — the user-facing error card below is what
+      // carries the actionable signal in prod. Redact the raw auth code
+      // even from dev logs: it's a single-use credential and extensions or
+      // screen recordings could pick it up.
+      // TODO: remove this whole block once prerender:false has been verified
+      //       to resolve the regression in prod.
+      const REDACT = (u: string) => u.replace(/(code=)[^&#]+/gi, '$1[REDACTED]');
       const sbStorageKeys = Object.keys(window.localStorage).filter((k) => k.startsWith('sb-'));
       console.log('[auth/callback] url state:', {
-        href: window.location.href,
+        href: REDACT(window.location.href),
         pathname: window.location.pathname,
-        search: window.location.search,
+        search: REDACT(window.location.search),
         hash: window.location.hash,
-        referrer: document.referrer,
-        routeQueryCode: routeCode,
-        winLocationCode: winCode,
+        referrer: REDACT(document.referrer),
+        routeQueryHasCode: typeof routeCode === 'string',
+        winLocationHasCode: typeof winCode === 'string',
         codeSourceUsed: routeCode ? 'route.query' : winCode ? 'window.location.search' : 'none',
       });
       console.log('[auth/callback] sb-* localStorage keys before exchange:', sbStorageKeys);
@@ -127,11 +133,12 @@
           parts.push('exchange returned no session and no error');
         }
         if (!code) {
-          // Surface enough URL state to distinguish stripped-by-cache vs
-          // never-arrived-from-Supabase. routeQueryHasCode false + winSearch
-          // empty = something served the page without the ?code= (stale CDN,
-          // PWA fallback). routeQueryHasCode true would mean code IS there
-          // but our extraction missed it — would indicate a code bug.
+          // Temporary technical detail rendered to the UI on purpose: once
+          // prerender:false is live this branch should never fire, and on
+          // the next failure (if any) the screenshot alone tells us whether
+          // the router saw the code at all. To be removed in the cleanup
+          // PR that strips the diagnostics block once auth is verified
+          // stable in prod. (Intentionally not i18n'd — temp.)
           parts.push('no auth code in callback URL');
           parts.push(`routeQueryHasCode=${typeof route.query.code === 'string'}`);
           parts.push(`winSearchLen=${window.location.search.length}`);

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -31,6 +31,7 @@
 
   const supabase = useSupabase();
   const { initAuth, isAuthenticated, isAdmin, userProfile, waitForAuth } = useAuth();
+  const route = useRoute();
   const errorMessage = ref('');
 
   onMounted(async () => {
@@ -38,17 +39,32 @@
       // Manual PKCE code exchange. useSupabase has detectSessionInUrl: false,
       // so supabase-js will not auto-process the ?code= param — this call is
       // the only thing that completes the OAuth / magic-link flow.
-      const code = new URLSearchParams(window.location.search).get('code');
+      //
+      // Prefer Vue Router's parsed route.query over window.location.search:
+      // when the page is served from a stale CDN/static cache or PWA
+      // navigateFallback, window.location.search has been observed empty even
+      // though Supabase redirected with ?code=. route.query reflects the
+      // navigation Nuxt routed to, which preserves the real query.
+      const routeCode = typeof route.query.code === 'string' ? route.query.code : null;
+      const winCode = new URLSearchParams(window.location.search).get('code');
+      const code = routeCode || winCode;
 
       // --- DIAGNOSTICS (temporary) ---------------------------------------
       // Tracking a production sign-in failure where flow_state rows are
-      // created server-side but no auth.sessions row appears. We need to
-      // see the actual error the client surfaces, the storage state at the
-      // time of the exchange, and whether getSession sees a session after.
-      // Remove this block once the regression is identified.
+      // created server-side but no auth.sessions row appears. Capture every
+      // URL/storage signal so the next failed attempt is fully diagnosed.
       const sbStorageKeys = Object.keys(window.localStorage).filter((k) => k.startsWith('sb-'));
+      console.log('[auth/callback] url state:', {
+        href: window.location.href,
+        pathname: window.location.pathname,
+        search: window.location.search,
+        hash: window.location.hash,
+        referrer: document.referrer,
+        routeQueryCode: routeCode,
+        winLocationCode: winCode,
+        codeSourceUsed: routeCode ? 'route.query' : winCode ? 'window.location.search' : 'none',
+      });
       console.log('[auth/callback] sb-* localStorage keys before exchange:', sbStorageKeys);
-      console.log('[auth/callback] code present:', !!code);
       // -------------------------------------------------------------------
 
       let exchangeError: { message?: string; code?: string; status?: number; name?: string } | null = null;
@@ -111,7 +127,14 @@
           parts.push('exchange returned no session and no error');
         }
         if (!code) {
+          // Surface enough URL state to distinguish stripped-by-cache vs
+          // never-arrived-from-Supabase. routeQueryHasCode false + winSearch
+          // empty = something served the page without the ?code= (stale CDN,
+          // PWA fallback). routeQueryHasCode true would mean code IS there
+          // but our extraction missed it — would indicate a code bug.
           parts.push('no auth code in callback URL');
+          parts.push(`routeQueryHasCode=${typeof route.query.code === 'string'}`);
+          parts.push(`winSearchLen=${window.location.search.length}`);
         }
         errorMessage.value = parts.length ? parts.join(' | ') : 'Authentication failed. Please try again.';
       }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -376,6 +376,15 @@ export default defineNuxtConfig({
     '/technical/calculators/needles': { prerender: false },
     '/technical/calculators/gearbox': { prerender: false },
     '/admin/**': { prerender: false },
+    // /auth/callback must never be prerendered or CDN-cached: each request
+    // carries a single-use ?code= that the page reads on mount. If the page
+    // is served from a static file or stale CDN cache, the JS bundle may run
+    // with no code in the URL (Supabase 302 → query loss in static handling
+    // edge cases, or PWA navigateFallback serving '/' shell).
+    '/auth/callback': {
+      prerender: false,
+      headers: { 'cache-control': 'no-store, must-revalidate' },
+    },
     '/archive/manuals': { redirect: { to: '/archive/documents?type=manual', statusCode: 301 } },
     '/archive/adverts': { redirect: { to: '/archive/documents?type=advert', statusCode: 301 } },
     '/archive/catalogues': { redirect: { to: '/archive/documents?type=catalogue', statusCode: 301 } },
@@ -570,7 +579,15 @@ export default defineNuxtConfig({
       globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
       // Exclude Highcharts routes from service worker caching
       // to prevent issues with client-side rendering
-      navigateFallbackDenylist: [/\/technical\/calculators\/needles/, /\/technical\/calculators\/gearbox/, /^\/t\//],
+      // /auth/callback is denylisted so the SW never serves the precached '/'
+      // shell when Supabase redirects there with a single-use ?code= — the
+      // shell HTML has no callback markup and the URL/code can be lost.
+      navigateFallbackDenylist: [
+        /\/technical\/calculators\/needles/,
+        /\/technical\/calculators\/gearbox/,
+        /^\/t\//,
+        /^\/auth\/callback/,
+      ],
       // Customize caching strategies
       runtimeCaching: [
         {


### PR DESCRIPTION
## The actual cause

The diagnostic patch from PR #598 surfaced \`no auth code in callback URL\` on the next failed sign-in. The DB still showed Supabase creating a valid \`flow_state\` row with an \`auth_code\`, so the OAuth round-trip was completing — but by the time client JS read \`window.location.search\`, the \`?code=\` was gone.

Two production signals lined up:

\`\`\`
$ curl -sI https://www.classicminidiy.com/auth/callback?code=fake
HTTP/2 200
content-disposition: inline; filename="callback"
last-modified: Sat, 23 May 2026 23:40:05 GMT
age: 94802
x-vercel-cache: HIT

$ ls .output/public/auth
callback
\`\`\`

The callback was being **prerendered as a static file** (\`auth/callback\`) and **served from Vercel's CDN cache** (~26h old). That's wrong shape for an auth callback whose entire purpose is reading a single-use, request-bound query string. Two paths can swallow the code:
- PWA service worker's \`navigateFallback: '/'\` serving the homepage shell on a precache miss
- Edge-case static handling where the static-file response for \`/auth/callback?code=X\` ends with the bundle reading an empty \`window.location.search\`

## Fix

- **\`routeRules['/auth/callback']\`**: \`prerender: false\` + \`cache-control: no-store, must-revalidate\`. Every callback hit is now freshly SSR'd by the Vercel function. No CDN cache, no static file in build output.
- **PWA \`navigateFallbackDenylist\`**: add \`^/auth/callback\` so the SW never serves the cached \`/\` shell here.
- **\`callback.vue\`**: prefer \`useRoute().query.code\` over \`window.location.search\`. Vue Router preserves the query from the routed navigation; \`window.location\` can be empty under the CDN/PWA paths above. Window search stays as a fallback signal.
- **Diagnostics expanded**: error card now also shows \`routeQueryHasCode=…\` + \`winSearchLen=…\` so any remaining failure tells us whether the code arrived to the router at all vs. was lost between router and \`window.location\`.

Verified \`.output/public/auth\` is no longer produced after \`bun run build\`.

## Test plan
- [ ] Once deployed (Vercel will rebuild), \`curl -sI https://www.classicminidiy.com/auth/callback\` should return \`x-vercel-cache: MISS\` and \`cache-control: no-store, must-revalidate\`
- [ ] Sign in with Google. New rows: 1 \`auth.flow_state\` created and then DELETED, 1 \`auth.sessions\` created
- [ ] If it still fails, the error card now shows \`routeQueryHasCode=true\` (router has it, our extraction is broken) or \`=false\` (truly arrived without code, look at SW/redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)