### PR TITLE
feat(analytics): comprehensive PostHog event coverage + user identity

### DIFF
--- a/app/components/Calculators/Compression.vue
+++ b/app/components/Calculators/Compression.vue
@@ -39,6 +39,15 @@
   const { capture } = usePostHog();
   const { track } = useAnalytics();
   let captureTimer: ReturnType<typeof setTimeout> | null = null;
+  // Debounced field-change tracking (signal only — no values)
+  let fieldChangeTimer: ReturnType<typeof setTimeout> | null = null;
+  function trackFieldChange(field: string) {
+    if (fieldChangeTimer) clearTimeout(fieldChangeTimer);
+    fieldChangeTimer = setTimeout(() => {
+      track('compression_input_changed', { field });
+    }, 600);
+  }
+
   watch([ratio, capacity], () => {
     if (captureTimer) clearTimeout(captureTimer);
     captureTimer = setTimeout(() => {
@@ -52,16 +61,8 @@
 
   onUnmounted(() => {
     if (captureTimer) clearTimeout(captureTimer);
-  });
-
-  // Debounced field-change tracking (signal only — no values)
-  let fieldChangeTimer: ReturnType<typeof setTimeout> | null = null;
-  function trackFieldChange(field: string) {
     if (fieldChangeTimer) clearTimeout(fieldChangeTimer);
-    fieldChangeTimer = setTimeout(() => {
-      track('compression_input_changed', { field });
-    }, 600);
-  }
+  });
 </script>
 
 <template>

--- a/app/components/Calculators/Compression.vue
+++ b/app/components/Calculators/Compression.vue
@@ -37,6 +37,7 @@
   });
 
   const { capture } = usePostHog();
+  const { track } = useAnalytics();
   let captureTimer: ReturnType<typeof setTimeout> | null = null;
   watch([ratio, capacity], () => {
     if (captureTimer) clearTimeout(captureTimer);
@@ -52,12 +53,21 @@
   onUnmounted(() => {
     if (captureTimer) clearTimeout(captureTimer);
   });
+
+  // Debounced field-change tracking (signal only — no values)
+  let fieldChangeTimer: ReturnType<typeof setTimeout> | null = null;
+  function trackFieldChange(field: string) {
+    if (fieldChangeTimer) clearTimeout(fieldChangeTimer);
+    fieldChangeTimer = setTimeout(() => {
+      track('compression_input_changed', { field });
+    }, 600);
+  }
 </script>
 
 <template>
   <div class="grid grid-cols-1 gap-6">
     <div class="col-span-1">
-      <button class="btn btn-primary mb-5" @click="showHelpModal = true">
+      <button class="btn btn-primary mb-5" @click="showHelpModal = true; track('help_opened', { tool: 'compression' })">
         <i class="fad fa-question-circle mr-2"></i>
         {{ t('help_button') }}
       </button>
@@ -103,7 +113,7 @@
           <i class="fad fa-engine"></i>
           {{ t('form_labels.piston_size') }}
         </legend>
-        <select v-model="bore" class="select select-bordered w-full">
+        <select v-model="bore" class="select select-bordered w-full" @change="trackFieldChange('piston_size')">
           <option v-for="opt in reactiveFormOptions.pistonOptions" :key="opt.label" :value="opt.value">
             {{ opt.label }}
           </option>
@@ -116,7 +126,7 @@
           <i class="fad fa-arrows-rotate fa-spin"></i>
           {{ t('form_labels.crankshaft') }}
         </legend>
-        <select v-model="stroke" class="select select-bordered w-full">
+        <select v-model="stroke" class="select select-bordered w-full" @change="trackFieldChange('crankshaft')">
           <option v-for="opt in reactiveFormOptions.crankshaftOptions" :key="opt.label" :value="opt.value">
             {{ opt.label }}
           </option>
@@ -132,7 +142,7 @@
             <i class="fad fa-head-side-gear"></i>
             {{ t('form_labels.head_gasket') }}
           </legend>
-          <select v-model.number="gasket" class="select select-bordered w-full">
+          <select v-model.number="gasket" class="select select-bordered w-full" @change="trackFieldChange('head_gasket')">
             <option v-for="opt in reactiveFormOptions.headGasketOptions" :key="opt.label" :value="opt.value">
               {{ opt.label }}
             </option>
@@ -151,6 +161,7 @@
               step="0.1"
               v-model.number="customGasket"
               class="input input-bordered w-full"
+              @change="trackFieldChange('custom_gasket')"
             />
           </fieldset>
         </div>
@@ -162,7 +173,7 @@
           <i class="fad fa-arrow-down-to-line"></i>
           {{ t('form_labels.decompression_plate') }}
         </legend>
-        <select v-model="decomp" class="select select-bordered w-full">
+        <select v-model="decomp" class="select select-bordered w-full" @change="trackFieldChange('decompression_plate')">
           <option v-for="opt in reactiveFormOptions.decompPlateOptions" :key="opt.label" :value="opt.value">
             {{ opt.label }}
           </option>
@@ -184,6 +195,7 @@
           max="20"
           step="0.1"
           class="input input-bordered w-full"
+          @change="trackFieldChange('piston_dish')"
         />
       </fieldset>
 
@@ -200,6 +212,7 @@
           max="35"
           step="0.1"
           class="input input-bordered w-full"
+          @change="trackFieldChange('head_volume')"
         />
       </fieldset>
 
@@ -216,6 +229,7 @@
           max="80"
           step="1"
           class="input input-bordered w-full"
+          @change="trackFieldChange('deck_height')"
         />
       </fieldset>
     </div>

--- a/app/components/Calculators/Gearbox.vue
+++ b/app/components/Calculators/Gearbox.vue
@@ -12,6 +12,7 @@
 
   const { t } = useI18n();
   const { capture } = usePostHog();
+  const { track } = useAnalytics();
   const { user, isAuthenticated } = useAuth();
   const {
     configs: savedConfigs,
@@ -319,7 +320,21 @@
       fetchConfigs();
     }
     showLoadModal.value = true;
+    track('gearbox_load_modal_opened');
   }
+
+  // Debounced input field tracking
+  let gearboxFieldTimer: ReturnType<typeof setTimeout> | null = null;
+  function trackGearboxField(field: string) {
+    if (gearboxFieldTimer) clearTimeout(gearboxFieldTimer);
+    gearboxFieldTimer = setTimeout(() => {
+      track('gearbox_input_changed', { field });
+    }, 600);
+  }
+
+  onUnmounted(() => {
+    if (gearboxFieldTimer) clearTimeout(gearboxFieldTimer);
+  });
 
   // Speedo table headers
   const tableHeadersSpeedos = [
@@ -347,18 +362,22 @@
       :max-rpm="maxRpm"
       @update:metric="
         metric = $event;
+        track('gearbox_input_changed', { field: 'metric', value: $event });
         triggerDebouncedUpdate();
       "
       @update:tire-type="
         tireType = $event;
+        trackGearboxField('tire_dimensions');
         triggerDebouncedUpdate();
       "
       @update:speedo-drive="
         speedoDrive = $event;
+        trackGearboxField('speedo_drive');
         triggerDebouncedUpdate();
       "
       @update:max-rpm="
         maxRpm = $event;
+        trackGearboxField('max_rpm');
         triggerDebouncedUpdate();
       "
     />

--- a/app/components/Calculators/Needles.vue
+++ b/app/components/Calculators/Needles.vue
@@ -278,6 +278,7 @@
   });
 
   const { capture } = usePostHog();
+  const { track } = useAnalytics();
 
   // Select a needle from dropdown
   const selectNeedle = (name: string, source: 'search' | 'relative_search' = 'search') => {
@@ -295,6 +296,7 @@
     isDropdownOpen.value = false;
     displayLimit.value = 50;
 
+    track('needle_added', { needle_name: name });
     capture('calculator_used', {
       calculator: 'needles',
       needle_count: selectedNeedles.value.length,
@@ -324,6 +326,23 @@
       result_count: relativeResults.value.length,
     });
   }
+
+  // needle_filter_changed tracking (debounced per field)
+  let needleFilterTimer: ReturnType<typeof setTimeout> | null = null;
+  function trackNeedleFilter(field: string, value: unknown) {
+    if (needleFilterTimer) clearTimeout(needleFilterTimer);
+    needleFilterTimer = setTimeout(() => {
+      track('needle_filter_changed', { field, value });
+    }, 400);
+  }
+
+  watch(referenceNeedleName, (val) => {
+    if (val) track('needle_filter_changed', { field: 'reference', value: val });
+  });
+  watch(showDiff, (val) => trackNeedleFilter('show_diff', val));
+  watch(relativeBand, (val) => trackNeedleFilter('band', val));
+  watch(relativeDirection, (val) => trackNeedleFilter('direction', val));
+  watch(relativeSameSize, (val) => trackNeedleFilter('same_size', val));
 
   // Fire one tracking event per unique (reference, band, direction) combo the
   // user settles on so we capture real queries but avoid spamming analytics
@@ -368,6 +387,10 @@
     if (relativeSearchDebounce) {
       clearTimeout(relativeSearchDebounce);
       relativeSearchDebounce = null;
+    }
+    if (needleFilterTimer) {
+      clearTimeout(needleFilterTimer);
+      needleFilterTimer = null;
     }
   });
 
@@ -506,7 +529,10 @@
 
   function removeArrayItem(currentItem: Needle) {
     const itemIndex = selectedNeedles.value.indexOf(currentItem);
-    if (itemIndex >= 0) selectedNeedles.value.splice(itemIndex, 1);
+    if (itemIndex >= 0) {
+      track('needle_removed', { needle_name: currentItem.name });
+      selectedNeedles.value.splice(itemIndex, 1);
+    }
   }
 
   // Re-seed selection when the underlying needle API data arrives.

--- a/app/components/Chat/AssistantMessage.vue
+++ b/app/components/Chat/AssistantMessage.vue
@@ -31,6 +31,7 @@
 
   import MarkdownText from './MarkdownText.vue';
   const { t } = useI18n();
+  const { track } = useAnalytics();
   const props = defineProps<AssistantMessageProps>();
 
   useStreamContext();
@@ -72,7 +73,7 @@
 
     try {
       await navigator.clipboard.writeText(text);
-      // You could add a toast notification here
+      track('assistant_message_copied', { message_length: text.length });
     } catch (error) {
       console.error('Failed to copy to clipboard:', error);
     }

--- a/app/components/Chat/ChatWindow.vue
+++ b/app/components/Chat/ChatWindow.vue
@@ -99,7 +99,7 @@
         <!-- Floating Scroll to Bottom Button -->
         <button
           v-if="showScrollButton"
-          @click="scrollToBottom"
+          @click="scrollToBottom(true)"
           class="btn btn-sm btn-outline btn-square absolute bottom-24 right-6 lg:right-80 shadow-lg hover:shadow-xl transition-all duration-200 z-10"
           :title="t('scroll_to_bottom')"
           :aria-label="t('scroll_to_bottom')"
@@ -310,6 +310,7 @@
   const isLoading = computed(() => streamContext?.isLoading.value || false);
 
   const { capture } = usePostHog();
+  const { track } = useAnalytics();
 
   async function handleSubmit() {
     if (!input.value.trim() || !streamContext || isLoading.value) return;
@@ -378,7 +379,10 @@
   });
 
   // Scroll to bottom function
-  function scrollToBottom() {
+  function scrollToBottom(fromButton = false) {
+    if (fromButton) {
+      track('chat_scroll_to_bottom');
+    }
     if (messagesContainer.value) {
       messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight;
     }
@@ -399,7 +403,7 @@
     () => {
       nextTick(() => {
         if (messagesContainer.value && !showScrollButton.value) {
-          scrollToBottom();
+          scrollToBottom(false);
         }
       });
     },
@@ -445,7 +449,7 @@
         inputRef.value.focus();
       }
       // Initial scroll to bottom
-      scrollToBottom();
+      scrollToBottom(false);
     });
   });
 </script>

--- a/app/components/Chat/UsefulLinks.vue
+++ b/app/components/Chat/UsefulLinks.vue
@@ -12,6 +12,7 @@
         target="_blank"
         rel="noopener noreferrer"
         class="block p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors border border-default hover:border-muted"
+        @click="trackOutbound({ destination: link.url, label: link.title, group: 'chat_useful_link' })"
       >
         <div class="flex items-start justify-between gap-2">
           <div class="flex-1 min-w-0">
@@ -36,6 +37,7 @@
 
 <script setup lang="ts">
   const { t } = useI18n();
+  const { trackOutbound } = useAnalytics();
 
   interface UsefulLink {
     url: string;

--- a/app/components/Chat/UsefulLinksSidebar.vue
+++ b/app/components/Chat/UsefulLinksSidebar.vue
@@ -16,6 +16,7 @@
         target="_blank"
         rel="noopener noreferrer"
         class="block p-3 rounded-lg bg-default hover:bg-muted transition-colors border border-default hover:border-muted group"
+        @click="trackOutbound({ destination: link.url, label: link.title, group: 'chat_useful_link' })"
       >
         <div class="space-y-2">
           <!-- Title and Score -->
@@ -64,6 +65,7 @@
   }
 
   const { t } = useI18n();
+  const { trackOutbound } = useAnalytics();
 
   defineProps<Props>();
 

--- a/app/components/ColorModeButton.vue
+++ b/app/components/ColorModeButton.vue
@@ -7,6 +7,12 @@ const props = withDefaults(
 );
 
 const { isDark, toggle } = useColorMode();
+const { track } = useAnalytics();
+
+function handleToggle() {
+  toggle();
+  track('color_mode_toggled', { new_mode: isDark.value ? 'light' : 'dark' });
+}
 
 const sizeClass = computed(() => {
   switch (props.size) {
@@ -26,7 +32,7 @@ const sizeClass = computed(() => {
   <button
     :class="['btn btn-ghost btn-circle', sizeClass]"
     :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
-    @click="toggle"
+    @click="handleToggle"
   >
     <i v-if="isDark" class="fas fa-sun" aria-hidden="true"></i>
     <i v-else class="fas fa-moon" aria-hidden="true"></i>

--- a/app/components/FloatingChatInput.vue
+++ b/app/components/FloatingChatInput.vue
@@ -38,6 +38,7 @@
 
 <script setup lang="ts">
   const { t } = useI18n();
+  const { track } = useAnalytics();
   const input = ref('');
   const inputRef = ref<HTMLTextAreaElement>();
   const router = useRouter();
@@ -64,6 +65,7 @@
     if (!input.value.trim()) return;
 
     const message = input.value.trim();
+    track('floating_chat_submitted', { message_length: message.length });
 
     // Navigate to chat page with the input as a query parameter
     await router.push({

--- a/app/components/Footer.vue
+++ b/app/components/Footer.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
   import { SocialItems } from '../../data/models/generic';
 
+  const { track, trackOutbound } = useAnalytics();
   const { t } = useI18n({
     messages: {
       en: {
@@ -203,6 +204,7 @@
             class="social-pill"
             :title="t('social_link_aria', { platform: social.title })"
             :aria-label="t('social_link_aria', { platform: social.title })"
+            @click="trackOutbound({ destination: social.href, label: social.title, group: 'footer_social' })"
           >
             <i :class="social.icon" class="text-xl"></i>
           </NuxtLink>
@@ -219,6 +221,7 @@
             rel="noopener"
             :aria-label="t('youtube_link_aria')"
             class="link hover:underline"
+            @click="trackOutbound({ destination: 'https://youtube.com/c/classicminidiy?sub_confirmation=1', label: 'YouTube', group: 'footer_social' })"
           >
             {{ t('author_name') }}</NuxtLink
           >.
@@ -239,7 +242,7 @@
             <div class="divider my-4">{{ t('links_divider') }}</div>
 
             <div class="flex flex-wrap justify-center gap-3">
-              <NuxtLink to="/contact" class="link text-sm hover:underline">
+              <NuxtLink to="/contact" class="link text-sm hover:underline" @click="track('contact_cta_clicked', { location: 'footer' })">
                 {{ t('contact_link') }}
               </NuxtLink>
               <NuxtLink to="/privacy" class="link text-sm hover:underline">
@@ -250,6 +253,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="link text-sm hover:underline"
+                @click="trackOutbound({ destination: 'https://www.youtube.com/t/terms', label: 'YouTube Privacy Policy', group: 'footer' })"
               >
                 {{ t('privacy_links.youtube_privacy') }}
               </NuxtLink>
@@ -258,6 +262,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="link text-sm hover:underline"
+                @click="trackOutbound({ destination: 'http://www.google.com/policies/privacy', label: 'Google Privacy Policy', group: 'footer' })"
               >
                 {{ t('privacy_links.google_privacy') }}
               </NuxtLink>

--- a/app/components/Hero.vue
+++ b/app/components/Hero.vue
@@ -2,6 +2,7 @@
   import { HERO_TYPES } from '../../data/models/generic';
 
   const { t } = useI18n();
+  const { track, trackOutbound } = useAnalytics();
   let styleObject: any;
 
   const props = defineProps({
@@ -129,7 +130,7 @@
           </span>
         </h1>
         <div v-if="heroType === HERO_TYPES.HOME" class="mt-6 flex flex-wrap gap-2">
-          <NuxtLink to="/technical" class="btn btn-secondary">
+          <NuxtLink to="/technical" class="btn btn-secondary" @click="track('home_cta_clicked', { cta: 'toolbox', location: 'hero' })">
             <i class="fad fa-toolbox mr-2"></i>{{ t('cta_open_toolbox') }}
           </NuxtLink>
           <a
@@ -137,6 +138,7 @@
             target="_blank"
             rel="noopener"
             class="btn btn-outline text-white border-white/50 hover:bg-white/10 hover:border-white"
+            @click="trackOutbound({ destination: 'https://youtube.com/c/classicminidiy?sub_confirmation=1', group: 'youtube_channel', location: 'hero' })"
           >
             <i class="fab fa-youtube mr-2"></i>{{ t('cta_watch_channel') }}
           </a>

--- a/app/components/HomeToolCard.vue
+++ b/app/components/HomeToolCard.vue
@@ -59,6 +59,8 @@
   });
 
   const isExternal = computed(() => props.to.startsWith('http'));
+
+  const { track } = useAnalytics();
 </script>
 
 <template>
@@ -67,6 +69,7 @@
     :target="isExternal ? '_blank' : undefined"
     :external="isExternal || undefined"
     class="tool-card"
+    @click="track('tool_card_clicked', { tool_name: title, location: 'home' })"
   >
     <span class="tool-card__icn" :style="surfaceStyle">
       <i :class="['fad', icon]" :style="iconStyle" aria-hidden="true"></i>

--- a/app/components/MainNav.vue
+++ b/app/components/MainNav.vue
@@ -4,6 +4,7 @@
   const switchLocalePath = useSwitchLocalePath();
   const { t, locale, locales, setLocale } = useI18n();
   const { user, userProfile, isAuthenticated, isAdmin, signOut } = useAuth();
+  const { track, trackOutbound } = useAnalytics();
 
   const displayName = computed(() => {
     if (!user.value) return '';
@@ -104,6 +105,7 @@
   };
 
   const handleNavClick = (item: any) => {
+    track('nav_item_clicked', { label: item.label, surface: 'mobile' });
     if (!item.to?.startsWith('http')) {
       isMobileMenuOpen.value = false;
     }
@@ -150,6 +152,7 @@
               'btn btn-ghost btn-md font-bold',
               isActive(item.to as string) ? 'text-primary' : '',
             ]"
+            @click="track('nav_item_clicked', { label: item.label, surface: 'desktop' })"
           >
             <i :class="['fad', item.icon, 'mr-1']"></i>
             {{ item.label }}
@@ -167,7 +170,7 @@
               class="dropdown-content menu bg-base-100 rounded-box shadow-lg z-[60] mt-2 w-56 p-2 border border-base-300"
             >
               <li v-for="link in communityLinks" :key="link.to">
-                <a :href="link.to" target="_blank" rel="noopener noreferrer" @click="closeDropdowns">
+                <a :href="link.to" target="_blank" rel="noopener noreferrer" @click="closeDropdowns(); trackOutbound({ destination: link.to, label: link.label, group: 'community_nav' })">
                   <i :class="['fad', link.faIcon]"></i>
                   {{ link.label }}
                 </a>
@@ -220,31 +223,31 @@
               class="dropdown-content menu bg-base-100 rounded-box shadow-lg z-[60] mt-2 w-56 p-2 border border-base-300"
             >
               <li v-if="isAdmin">
-                <NuxtLink to="/admin" @click="closeDropdowns">
+                <NuxtLink to="/admin" @click="closeDropdowns(); track('nav_item_clicked', { label: t('profile.admin') })">
                   <i class="fas fa-shield-check"></i>
                   {{ t('profile.admin') }}
                 </NuxtLink>
               </li>
               <li>
-                <NuxtLink to="/dashboard" @click="closeDropdowns">
+                <NuxtLink to="/dashboard" @click="closeDropdowns(); track('nav_item_clicked', { label: t('profile.dashboard') })">
                   <i class="fas fa-gauge"></i>
                   {{ t('profile.dashboard') }}
                 </NuxtLink>
               </li>
               <li>
-                <NuxtLink to="/dashboard" @click="closeDropdowns">
+                <NuxtLink to="/dashboard" @click="closeDropdowns(); track('nav_item_clicked', { label: t('profile.submissions') })">
                   <i class="fas fa-file-lines"></i>
                   {{ t('profile.submissions') }}
                 </NuxtLink>
               </li>
               <li>
-                <NuxtLink to="/profile" @click="closeDropdowns">
+                <NuxtLink to="/profile" @click="closeDropdowns(); track('nav_item_clicked', { label: t('profile.profile') })">
                   <i class="fas fa-user"></i>
                   {{ t('profile.profile') }}
                 </NuxtLink>
               </li>
               <li>
-                <NuxtLink to="/contribute" @click="closeDropdowns">
+                <NuxtLink to="/contribute" @click="closeDropdowns(); track('nav_item_clicked', { label: t('profile.contribute') })">
                   <i class="fas fa-paper-plane"></i>
                   {{ t('profile.contribute') }}
                 </NuxtLink>
@@ -273,7 +276,7 @@
             type="button"
             class="btn btn-ghost btn-sm btn-square"
             :aria-label="t('mobile_menu_title')"
-            @click="isMobileMenuOpen = true"
+            @click="isMobileMenuOpen = true; track('mobile_menu_toggled', { state: 'open' })"
           >
             <i class="fad fa-bars text-xl"></i>
           </button>
@@ -302,7 +305,7 @@
                 type="button"
                 class="btn btn-ghost btn-sm btn-square"
                 :aria-label="t('close_menu')"
-                @click="isMobileMenuOpen = false"
+                @click="isMobileMenuOpen = false; track('mobile_menu_toggled', { state: 'closed' })"
               >
                 <i class="fas fa-xmark text-lg"></i>
               </button>
@@ -335,6 +338,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="btn btn-ghost btn-block justify-start font-bold"
+                @click="trackOutbound({ destination: link.to, label: link.label, group: 'community_nav' })"
               >
                 <i :class="['fad', link.faIcon, 'mr-2']"></i>
                 {{ link.label }}

--- a/app/components/RecentVideos.vue
+++ b/app/components/RecentVideos.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   const { t } = useI18n();
+  const { trackOutbound } = useAnalytics();
   const { data: videos, status, error } = await useFetch('/api/youtube/videos');
 </script>
 
@@ -26,7 +27,7 @@
         <h2 class="card-title font-semibold text-lg">{{ video.title }}</h2>
         <p class="text-sm text-base-content/70">{{ t('published_on') }} {{ video.publishedOn }}</p>
         <div class="card-actions justify-end">
-          <NuxtLink :to="video.videoUrl" target="_blank" class="btn btn-primary">{{ t('watch_button') }}</NuxtLink>
+          <NuxtLink :to="video.videoUrl" target="_blank" class="btn btn-primary" @click="trackOutbound({ destination: video.videoUrl, label: video.title, group: 'youtube_video' })">{{ t('watch_button') }}</NuxtLink>
         </div>
       </div>
     </div>

--- a/app/components/RegistryTable.vue
+++ b/app/components/RegistryTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   const { t } = useI18n();
+  const { track, trackSearch } = useAnalytics();
   import type { RegistryItem } from '../../data/models/registry';
   import { RegistryItemStatus } from '../../data/models/registry';
   import { useDebounce } from '../composables/useDebounce';
@@ -39,9 +40,12 @@
   // Debounced search to avoid excessive filtering
   const debouncedSearch = useDebounce(searchValue, 300);
 
-  // Reset to first page when search changes
-  watch(debouncedSearch, () => {
+  // Reset to first page when search changes, and track the search
+  watch(debouncedSearch, (query) => {
     currentPage.value = 1;
+    if (query) {
+      trackSearch('registry', query, filteredItems.value?.length);
+    }
   });
 
   // Helper function to get status priority for sorting
@@ -93,13 +97,20 @@
     return filteredItems.value.slice(startIndex, startIndex + pageSize.value);
   });
 
+  // Track page size changes
+  watch(pageSize, (newSize) => {
+    track('list_page_size_changed', { surface: 'registry', page_size: newSize });
+  });
+
   // Toggle expanded row
   const toggleExpanded = (id: string) => {
     const index = expanded.value.indexOf(id);
     if (index === -1) {
       expanded.value.push(id);
+      track('registry_row_expanded', { item_id: id, is_expanded: true });
     } else {
       expanded.value.splice(index, 1);
+      track('registry_row_expanded', { item_id: id, is_expanded: false });
     }
   };
 
@@ -108,6 +119,7 @@
     currentPage.value = page;
     // Reset expanded rows when changing pages
     expanded.value = [];
+    track('list_paginated', { surface: 'registry', page });
   };
 
   // Define type for pagination items

--- a/app/components/WheelGrid.vue
+++ b/app/components/WheelGrid.vue
@@ -72,11 +72,20 @@
     track('wheel_filters_cleared');
   }
 
-  // Track search after filteredWheels settles
+  // Track search after filteredWheels settles (debounced to avoid flooding
+  // analytics with partial queries on every keystroke)
+  let wheelSearchTimer: ReturnType<typeof setTimeout> | null = null;
   watch(filteredWheels, (results) => {
+    if (wheelSearchTimer) clearTimeout(wheelSearchTimer);
     if (search.value) {
-      trackSearch('wheels', search.value, results.length);
+      wheelSearchTimer = setTimeout(() => {
+        trackSearch('wheels', search.value, results.length);
+      }, 400);
     }
+  });
+
+  onUnmounted(() => {
+    if (wheelSearchTimer) clearTimeout(wheelSearchTimer);
   });
 
   // Track pagination

--- a/app/components/WheelGrid.vue
+++ b/app/components/WheelGrid.vue
@@ -3,6 +3,7 @@
   import Fuse from 'fuse.js';
 
   const { t } = useI18n();
+  const { track, trackSearch } = useAnalytics();
 
   // State management with proper typing
   const search = ref('');
@@ -68,7 +69,20 @@
     search.value = '';
     selectedOffsets.value = [];
     selectedMaterials.value = [];
+    track('wheel_filters_cleared');
   }
+
+  // Track search after filteredWheels settles
+  watch(filteredWheels, (results) => {
+    if (search.value) {
+      trackSearch('wheels', search.value, results.length);
+    }
+  });
+
+  // Track pagination
+  watch(page, (newPage) => {
+    track('list_paginated', { surface: 'wheels', page: newPage });
+  });
 
   // Default fallback image URL for reuse
   const DEFAULT_WHEEL_IMAGE = 'https://classicminidiy.s3.us-east-1.amazonaws.com/wheels/missing-wheel-image.png';
@@ -111,7 +125,7 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'list' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'list'"
+                @click="size = 'list'; track('wheel_filter_changed', { size_selected: 'list' })"
               >
                 {{ t('all_sizes') }}
               </button>
@@ -119,7 +133,7 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'ten' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'ten'"
+                @click="size = 'ten'; track('wheel_filter_changed', { size_selected: 'ten' })"
               >
                 {{ t('ten_inch_wheels') }}
               </button>
@@ -127,7 +141,7 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'twelve' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'twelve'"
+                @click="size = 'twelve'; track('wheel_filter_changed', { size_selected: 'twelve' })"
               >
                 {{ t('twelve_inch_wheels') }}
               </button>
@@ -135,7 +149,7 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'thirteen' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'thirteen'"
+                @click="size = 'thirteen'; track('wheel_filter_changed', { size_selected: 'thirteen' })"
               >
                 {{ t('thirteen_inch_wheels') }}
               </button>

--- a/app/components/WheelSubmit.vue
+++ b/app/components/WheelSubmit.vue
@@ -20,6 +20,14 @@
 
   const { t } = useI18n();
   const { getWheel: fetchWheel, submitWheel } = useWheels();
+  const { trackFormStarted } = useAnalytics();
+  const hasStarted = ref(false);
+
+  function onFormStart() {
+    if (hasStarted.value) return;
+    hasStarted.value = true;
+    trackFormStarted('wheel');
+  }
 
   // Reactive state
   const wheel = ref();
@@ -364,6 +372,7 @@
                   v-model="name"
                   type="text"
                   :placeholder="t('step1.wheel_name_placeholder')"
+                  @focus="onFormStart"
                   @blur="markFieldAsTouched('name')"
                 />
               </label>

--- a/app/components/archive/DocumentCard.vue
+++ b/app/components/archive/DocumentCard.vue
@@ -3,6 +3,7 @@
   import { shareArchiveItem } from '../../../data/models/helper-utils';
 
   const { t } = useI18n();
+  const { track, trackDownload } = useAnalytics();
 
   defineProps<{
     item: ArchiveDocumentItem;
@@ -59,7 +60,7 @@
       <p v-if="item.description" class="text-sm my-2 line-clamp-2">{{ item.description }}</p>
 
       <div class="card-actions justify-between gap-2 mt-auto">
-        <button class="btn btn-outline btn-sm" @click="shareArchiveItem(item.title, item.path)">
+        <button class="btn btn-outline btn-sm" @click="() => { shareArchiveItem(item.title, item.path); track('document_shared', { document_id: item.id, method: navigator.share ? 'web_share' : 'clipboard', location: 'card' }); }">
           <i class="fad fa-arrow-up-from-bracket mr-1"></i>
           {{ t('actions.share') }}
         </button>
@@ -69,6 +70,7 @@
           :to="item.download"
           target="_blank"
           class="btn btn-sm btn-primary"
+          @click="trackDownload({ document_id: item.id, file_type: item.download.split('.').pop()?.toUpperCase(), location: 'card', name: item.title })"
         >
           <i class="fad fa-download mr-1"></i> {{ t('actions.download') }}
         </NuxtLink>

--- a/app/components/archive/DocumentCard.vue
+++ b/app/components/archive/DocumentCard.vue
@@ -8,6 +8,12 @@
   defineProps<{
     item: ArchiveDocumentItem;
   }>();
+
+  function handleShare(item: ArchiveDocumentItem) {
+    shareArchiveItem(item.title, item.path);
+    const method = typeof navigator !== 'undefined' && navigator.share ? 'web_share' : 'clipboard';
+    track('document_shared', { document_id: item.id, method, location: 'card' });
+  }
 </script>
 
 <template>
@@ -60,7 +66,7 @@
       <p v-if="item.description" class="text-sm my-2 line-clamp-2">{{ item.description }}</p>
 
       <div class="card-actions justify-between gap-2 mt-auto">
-        <button class="btn btn-outline btn-sm" @click="() => { shareArchiveItem(item.title, item.path); track('document_shared', { document_id: item.id, method: navigator.share ? 'web_share' : 'clipboard', location: 'card' }); }">
+        <button class="btn btn-outline btn-sm" @click="handleShare(item)">
           <i class="fad fa-arrow-up-from-bracket mr-1"></i>
           {{ t('actions.share') }}
         </button>

--- a/app/components/contribute/FileUpload.vue
+++ b/app/components/contribute/FileUpload.vue
@@ -7,6 +7,7 @@
   import { humanFileSize } from '../../../data/models/helper-utils';
 
   const { t } = useI18n();
+  const { track, trackFormError } = useAnalytics();
 
   const props = withDefaults(
     defineProps<{
@@ -76,18 +77,21 @@
       // Check file count limit
       if (files.value.length + validFiles.length >= props.maxFiles) {
         error.value = t('max_files_reached', { max: props.maxFiles });
+        trackFormError('file_upload', 'too_many_files');
         break;
       }
 
       // Check file type
       if (!allowedTypes.value.includes(file.type)) {
         error.value = t('invalid_type', { name: file.name });
+        trackFormError('file_upload', 'invalid_type');
         continue;
       }
 
       // Check file size
       if (file.size > maxBytes) {
         error.value = t('file_too_large', { name: file.name, max: props.maxSizeMb });
+        trackFormError('file_upload', 'file_too_large');
         continue;
       }
 
@@ -97,6 +101,7 @@
     if (validFiles.length > 0) {
       files.value = [...files.value, ...validFiles];
       emit('update:files', files.value);
+      track('file_upload_started', { file_count: validFiles.length });
     }
   }
 

--- a/app/components/profile/SocialLinks.vue
+++ b/app/components/profile/SocialLinks.vue
@@ -7,6 +7,8 @@
     { size: 'md' }
   );
 
+  const { trackOutbound } = useAnalytics();
+
   const platformIcons: Record<string, string> = {
     instagram: 'fab fa-instagram',
     youtube: 'fab fa-youtube',
@@ -51,6 +53,7 @@
         class="inline-flex items-center justify-center rounded-full bg-muted hover:bg-primary hover:text-primary-content transition-colors"
         :class="size === 'sm' ? 'w-8 h-8 text-sm' : 'w-10 h-10 text-base'"
         :aria-label="platform as string"
+        @click="trackOutbound({ destination: normalizeUrl(platform as string, url), label: platform as string, group: 'profile_social' })"
       >
         <i :class="platformIcons[platform as string] || 'fas fa-link'"></i>
       </a>

--- a/app/composables/useAnalytics.ts
+++ b/app/composables/useAnalytics.ts
@@ -1,0 +1,109 @@
+/**
+ * useAnalytics — typed helpers over usePostHog() for consistent event capture.
+ *
+ * Use the specific helpers (trackOutbound, trackSearch, trackDownload, the
+ * form.* helpers) for the cross-cutting event families so properties stay
+ * uniform and queryable in PostHog. Use track() for one-off bespoke events.
+ *
+ * Domain events that predate this composable (calculator_used, decoder_used,
+ * chat_message_sent, gearbox_config_*, promo_*, language_changed, etc.) keep
+ * using capture() directly — don't churn them just to route through here.
+ */
+type Props = Record<string, unknown>;
+
+export function useAnalytics() {
+  const { capture, identify, reset } = usePostHog();
+
+  // ---- Identity -------------------------------------------------------
+  /** Tie all subsequent events to a known user. Call on auth success. */
+  function identifyUser(userId: string, props?: Props) {
+    if (!userId) return;
+    identify(userId, props);
+  }
+
+  /** Clear identity so the next session isn't merged with this one. Call on logout. */
+  function resetIdentity() {
+    reset();
+  }
+
+  // ---- Generic --------------------------------------------------------
+  /** Escape hatch for bespoke one-off events with no dedicated helper. */
+  function track(event: string, props?: Props) {
+    capture(event, props);
+  }
+
+  // ---- Outbound links -------------------------------------------------
+  /**
+   * Any click that leaves the site (YouTube, social, partner/affiliate,
+   * external reference). `group` buckets them (e.g. 'youtube_video',
+   * 'footer_social', 'community_nav', 'reference', 'partner', 'chat_useful_link').
+   */
+  function trackOutbound(opts: { destination: string; label?: string; group?: string; location?: string }) {
+    capture('outbound_link_clicked', {
+      destination: opts.destination,
+      label: opts.label,
+      group: opts.group,
+      location: opts.location,
+    });
+  }
+
+  // ---- Search ---------------------------------------------------------
+  /**
+   * Fuse.js / table search. Wire into the already-debounced handler and call
+   * after results are computed. Empty/whitespace queries are ignored.
+   */
+  function trackSearch(surface: string, query: string, resultsCount?: number, extra?: Props) {
+    const trimmed = (query ?? '').trim();
+    if (!trimmed) return;
+    capture('search_performed', {
+      surface,
+      query: trimmed,
+      results_count: resultsCount,
+      ...extra,
+    });
+  }
+
+  // ---- Downloads ------------------------------------------------------
+  /** Manual / document / diagram / map downloads — core value delivery. */
+  function trackDownload(opts: {
+    document_id?: string | number;
+    slug?: string;
+    file_type?: string;
+    name?: string;
+    location?: string;
+    group?: string;
+  }) {
+    capture('document_downloaded', { ...opts });
+  }
+
+  // ---- Forms / funnels ------------------------------------------------
+  /** Fire once on first meaningful interaction so abandonment is measurable. */
+  function trackFormStarted(form: string, props?: Props) {
+    capture('form_started', { form, ...props });
+  }
+  function trackFormStep(form: string, step: number | string, props?: Props) {
+    capture('form_step_changed', { form, step, ...props });
+  }
+  function trackFormSubmitted(form: string, props?: Props) {
+    capture('form_submitted', { form, ...props });
+  }
+  function trackFormError(form: string, field: string, props?: Props) {
+    capture('form_validation_error', { form, field, ...props });
+  }
+
+  return {
+    capture,
+    identify,
+    reset,
+    track,
+    identifyUser,
+    resetIdentity,
+    trackOutbound,
+    trackSearch,
+    trackDownload,
+    trackFormStarted,
+    trackFormStep,
+    trackFormSubmitted,
+    trackFormError,
+  };
+}

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -19,9 +19,22 @@ let clientInitialized = false;
 export const useAuth = () => {
   const supabase = useSupabase();
   const config = useRuntimeConfig();
+  const { identifyUser, resetIdentity } = useAnalytics();
   const user = useState<User | null>('user', () => null);
   const userProfile = useState<UserProfile | null>('user-profile', () => null);
   const loading = useState<boolean>('auth-loading', () => true);
+
+  // Tie PostHog's distinct_id to the authenticated user so all subsequent
+  // events are attributable. Reads from userProfile, so call AFTER
+  // fetchUserProfile has resolved. No-op on SSR ($posthog is client-only).
+  const syncPostHogIdentity = (userId: string) => {
+    const p = userProfile.value;
+    identifyUser(userId, {
+      email_domain: p?.email ? p.email.split('@')[1] : undefined,
+      trust_level: p?.trust_level,
+      is_admin: p?.is_admin,
+    });
+  };
 
   // Fetch user profile including admin status
   const fetchUserProfile = async (userId: string) => {
@@ -75,6 +88,7 @@ export const useAuth = () => {
         // Fetch profile if user is authenticated
         if (session?.user) {
           await fetchUserProfile(session.user.id);
+          syncPostHogIdentity(session.user.id);
         }
       } catch (error) {
         console.error('[initAuth] Error initializing auth:', error);
@@ -92,10 +106,15 @@ export const useAuth = () => {
         user.value = session?.user ?? null;
 
         if (session?.user) {
-          // Defer profile fetch to avoid auth lock deadlock
-          setTimeout(() => fetchUserProfile(session.user.id), 0);
+          // Defer profile fetch to avoid auth lock deadlock, then attach
+          // the PostHog identity once profile props are available.
+          setTimeout(() => {
+            fetchUserProfile(session.user.id).then(() => syncPostHogIdentity(session.user.id));
+          }, 0);
         } else {
           userProfile.value = null;
+          // Signed out — clear identity so the next session isn't merged in.
+          resetIdentity();
         }
       });
 

--- a/app/pages/admin/colors/review.vue
+++ b/app/pages/admin/colors/review.vue
@@ -27,6 +27,8 @@
     width?: string;
   }
 
+  const { track } = useAnalytics();
+
   // State
   const errorMessage = ref('');
   const isProcessing = ref(false);
@@ -168,6 +170,8 @@
       delete editingItems[item.id];
       delete editedData[item.id];
 
+      track('admin_action', { item_type: 'color', action: 'approve' });
+
       // Update item status to approved
       if (colorItems.value) {
         const index = colorItems.value.findIndex((i) => i.id === item.id);
@@ -213,6 +217,8 @@
           details: itemToReject,
         },
       });
+
+      track('admin_action', { item_type: 'color', action: 'reject' });
 
       // Update item status to rejected
       if (colorItems.value) {

--- a/app/pages/admin/queue.vue
+++ b/app/pages/admin/queue.vue
@@ -85,6 +85,8 @@
     default: () => [],
   });
 
+  const { track } = useAnalytics();
+
   // State
   const errorMessage = ref('');
   const isProcessing = ref(false);
@@ -390,6 +392,8 @@
         },
       });
 
+      track('admin_action', { item_type: 'queue', action: 'approve' });
+
       // Update item status locally
       if (items.value) {
         const index = items.value.findIndex((i) => i.id === itemToApprove.id);
@@ -429,6 +433,8 @@
           reviewerNotes: reviewerNotes.value || null,
         },
       });
+
+      track('admin_action', { item_type: 'queue', action: 'reject' });
 
       // Update item status locally
       if (items.value) {

--- a/app/pages/admin/registry/review.vue
+++ b/app/pages/admin/registry/review.vue
@@ -26,6 +26,8 @@
     width?: string;
   }
 
+  const { track } = useAnalytics();
+
   // State
   const errorMessage = ref('');
   const isProcessing = ref(false);
@@ -147,6 +149,8 @@
       editingItems.value.delete(item.uniqueId);
       editedData.value.delete(item.uniqueId);
 
+      track('admin_action', { item_type: 'registry', action: 'approve' });
+
       // Update item status to approved
       if (registryItems.value) {
         const index = registryItems.value.findIndex((i) => i.uniqueId === item.uniqueId);
@@ -190,6 +194,8 @@
       if (error.value) {
         throw new Error(error.value.data?.message || 'Failed to delete item');
       }
+
+      track('admin_action', { item_type: 'registry', action: 'reject' });
 
       // Update item status to rejected
       if (registryItems.value && selectedItem.value) {

--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -37,6 +37,8 @@
     value: string;
   }
 
+  const { track } = useAnalytics();
+
   // Current user
   const { user: currentUser } = useAuth();
 
@@ -218,6 +220,8 @@
         },
       });
 
+      track('admin_action', { item_type: 'user', action: 'trust_level_changed' });
+
       // Update trust level locally — is_admin is independent and not changed here
       if (response.value?.users) {
         const index = response.value.users.findIndex((u) => u.id === userToUpdate.id);
@@ -257,6 +261,8 @@
           isAdmin: newValue,
         },
       });
+
+      track('admin_action', { item_type: 'user', action: newValue ? 'admin_granted' : 'admin_revoked' });
 
       // Update locally
       if (response.value?.users) {

--- a/app/pages/admin/wheels/review.vue
+++ b/app/pages/admin/wheels/review.vue
@@ -17,6 +17,8 @@
     ],
   });
 
+  const { track } = useAnalytics();
+
   // State
   const errorMessage = ref('');
   const isProcessing = ref(false);
@@ -81,6 +83,8 @@
       // Clean up editing state
       editingItems.value.delete(item.uuid);
       editedData.value.delete(item.uuid);
+
+      track('admin_action', { item_type: 'wheel', action: 'approve' });
 
       // Update status in place instead of removing
       if (wheelsToReview.value) {
@@ -184,6 +188,8 @@
       if (error.value) {
         throw new Error(error.value.data?.message || 'Failed to delete item');
       }
+
+      track('admin_action', { item_type: 'wheel', action: 'reject' });
 
       // Update status to rejected instead of removing
       if (wheelsToReview.value && selectedItem.value) {

--- a/app/pages/archive/colors/[...color].vue
+++ b/app/pages/archive/colors/[...color].vue
@@ -32,6 +32,14 @@
     }
   }
 
+  function shareColor() {
+    const c = color?.value;
+    if (!c) return;
+    shareColorItem(c.pretty.Name, c.pretty.ID);
+    const method = typeof navigator !== 'undefined' && navigator.share ? 'web_share' : 'clipboard';
+    track('color_shared', { color_id: c.raw.id, method });
+  }
+
   useHead({
     title: t('title_template', {
       name: color.value?.pretty.Name,
@@ -208,7 +216,7 @@
                 {{ copied ? t('actions.copied') : t('actions.copy_link') }}
               </button>
 
-              <button type="button" class="btn btn-neutral" @click="() => { shareColorItem(color.pretty.Name, color.pretty.ID); track('color_shared', { color_id: color.raw.id, method: navigator.share ? 'web_share' : 'clipboard' }); }">
+              <button type="button" class="btn btn-neutral" @click="shareColor">
                 <i class="fas fa-share-nodes mr-2"></i>
                 {{ t('actions.share') }}
               </button>

--- a/app/pages/archive/colors/[...color].vue
+++ b/app/pages/archive/colors/[...color].vue
@@ -3,6 +3,7 @@
   import type { PrettyColor } from '../../../../data/models/colors';
 
   const { t } = useI18n();
+  const { track } = useAnalytics();
   const { params } = useRoute();
   const colorId = Array.isArray(params.color) ? params.color[0] : params.color;
   const { getColor } = useColors();
@@ -25,6 +26,7 @@
       await navigator.clipboard.writeText(url);
       copied.value = true;
       setTimeout(() => (copied.value = false), 1000);
+      track('color_link_copied', { color_id: color?.value?.raw.id, color_name: color?.value?.pretty.Name });
     } catch ($e) {
       copied.value = false;
     }
@@ -206,12 +208,12 @@
                 {{ copied ? t('actions.copied') : t('actions.copy_link') }}
               </button>
 
-              <button type="button" class="btn btn-neutral" @click="shareColorItem(color.pretty.Name, color.pretty.ID)">
+              <button type="button" class="btn btn-neutral" @click="() => { shareColorItem(color.pretty.Name, color.pretty.ID); track('color_shared', { color_id: color.raw.id, method: navigator.share ? 'web_share' : 'clipboard' }); }">
                 <i class="fas fa-share-nodes mr-2"></i>
                 {{ t('actions.share') }}
               </button>
 
-              <NuxtLink :to="`/contribute/color?color=${color.raw.id}`" class="btn btn-outline">
+              <NuxtLink :to="`/contribute/color?color=${color.raw.id}`" class="btn btn-outline" @click="track('contribute_cta_clicked', { type: 'color', location: 'color_detail' })">
                 <i class="fas fa-edit mr-2"></i>
                 {{ t('actions.contribute') }}
               </NuxtLink>

--- a/app/pages/archive/colors/index.vue
+++ b/app/pages/archive/colors/index.vue
@@ -3,6 +3,7 @@
   import { HERO_TYPES } from '../../../../data/models/generic';
 
   const { t } = useI18n();
+  const { track, trackSearch, trackOutbound } = useAnalytics();
   const { listColors } = useColors();
   const { data: colors, status } = await useAsyncData('colors-list', () => listColors());
   const pending = computed(() => status.value === 'pending');
@@ -79,9 +80,10 @@
     }
   };
 
-  // Reset to first page when debounced search changes
-  watch(debouncedSearch, () => {
+  // Reset to first page when debounced search changes; fire search analytics
+  watch(debouncedSearch, (query) => {
     currentPage.value = 1;
+    trackSearch('colors', query, filteredColors.value.length);
   });
 
   useHead({
@@ -176,7 +178,7 @@
                   <p class="text-sm opacity-70">{{ t('contribute_banner_description') }}</p>
                 </div>
               </div>
-              <NuxtLink to="/contribute/color" class="btn btn-primary btn-outline btn-sm">
+              <NuxtLink to="/contribute/color" class="btn btn-primary btn-outline btn-sm" @click="track('contribute_cta_clicked', { type: 'color', location: 'archive_colors' })">
                 {{ t('contribute_banner_button') }}
               </NuxtLink>
             </div>
@@ -191,7 +193,7 @@
             </p>
             <p>
               {{ t('description_text') }}
-              <a href="http://mini-colours.co.uk" class="link link-primary">{{ t('partner_link') }}</a>
+              <a href="http://mini-colours.co.uk" class="link link-primary" @click="trackOutbound({ destination: 'http://mini-colours.co.uk', group: 'partner', label: 'mini-colours' })">{{ t('partner_link') }}</a>
               {{ t('description_text_2') }}
             </p>
           </template>
@@ -342,7 +344,7 @@
               type="button"
               class="btn btn-outline join-item"
               :disabled="currentPage === 1"
-              @click="currentPage = Math.max(1, currentPage - 1)"
+              @click="() => { currentPage = Math.max(1, currentPage - 1); track('list_paginated', { surface: 'colors', page: currentPage }); }"
             >
               «
             </button>
@@ -353,7 +355,7 @@
               type="button"
               class="btn btn-outline join-item"
               :disabled="currentPage >= totalPages"
-              @click="currentPage = Math.min(totalPages, currentPage + 1)"
+              @click="() => { currentPage = Math.min(totalPages, currentPage + 1); track('list_paginated', { surface: 'colors', page: currentPage }); }"
             >
               »
             </button>

--- a/app/pages/archive/documents/[slug].vue
+++ b/app/pages/archive/documents/[slug].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   const { t } = useI18n();
+  const { track, trackDownload } = useAnalytics();
   const { isAuthenticated } = useAuth();
   const route = useRoute();
   const slug = route.params.slug as string;
@@ -117,6 +118,7 @@
       await navigator.clipboard.writeText(url);
       copied.value = true;
       setTimeout(() => (copied.value = false), 2000);
+      track('document_shared', { document_id: doc.value?.id, method: 'clipboard' });
     } catch {
       copied.value = false;
     }
@@ -131,6 +133,7 @@
         text: doc.value.description || t('seo.description_fallback', { title: doc.value.title }),
         url: `https://classicminidiy.com/archive/documents/${slug}`,
       });
+      track('document_shared', { document_id: doc.value.id, method: 'web_share' });
     } catch {
       // User cancelled or API not available — fall back to copy
       copyUrl();
@@ -353,7 +356,7 @@
                   <div class="font-semibold">{{ t('suggest_collection.prompt_title') }}</div>
                   <div class="text-sm">{{ t('suggest_collection.prompt_description') }}</div>
                 </div>
-                <button type="button" class="btn btn-info btn-outline btn-sm" @click="showSuggestEdit = true">
+                <button type="button" class="btn btn-info btn-outline btn-sm" @click="() => { showSuggestEdit = true; track('suggest_collection_opened', { document_id: doc.id }); }">
                   <i class="fad fa-folder-plus mr-2"></i>
                   {{ t('suggest_collection.cta') }}
                 </button>
@@ -385,7 +388,7 @@
             <!-- Actions Section -->
             <div class="divider my-6">{{ t('section.actions') }}</div>
             <div class="flex flex-wrap gap-4 justify-center">
-              <NuxtLink v-if="doc.download" class="btn btn-primary" :to="doc.download" target="_blank">
+              <NuxtLink v-if="doc.download" class="btn btn-primary" :to="doc.download" target="_blank" @click="trackDownload({ document_id: doc.id, slug, file_type: fileType || undefined, location: 'document_detail' })">
                 <i class="fas fa-download mr-2"></i>
                 {{ t('action.download') }}
               </NuxtLink>
@@ -402,7 +405,7 @@
                 </button>
               </ClientOnly>
 
-              <button v-if="isAuthenticated" type="button" class="btn btn-outline" @click="showSuggestEdit = true">
+              <button v-if="isAuthenticated" type="button" class="btn btn-outline" @click="() => { showSuggestEdit = true; track('suggest_edit_opened', { document_id: doc.id }); }">
                 <i class="fad fa-pen-to-square mr-2"></i>
                 {{ t('action.suggest_edit') }}
               </button>

--- a/app/pages/archive/documents/index.vue
+++ b/app/pages/archive/documents/index.vue
@@ -3,6 +3,7 @@
   import type { ArchiveDocumentItem } from '../../../composables/useArchiveDocuments';
 
   const { t } = useI18n();
+  const { track, trackSearch } = useAnalytics();
   const route = useRoute();
   const router = useRouter();
 
@@ -132,16 +133,27 @@
     });
   });
 
-  watch(search, () => {
+  let searchTrackTimeout: ReturnType<typeof setTimeout> | null = null;
+  watch(search, (query) => {
     currentPage.value = 1;
+    if (searchTrackTimeout) clearTimeout(searchTrackTimeout);
+    searchTrackTimeout = setTimeout(() => {
+      trackSearch('documents', query, filteredDocuments.value.length);
+    }, 400);
   });
 
   function prevPage() {
-    if (currentPage.value > 1) currentPage.value--;
+    if (currentPage.value > 1) {
+      currentPage.value--;
+      track('list_paginated', { surface: 'documents', page: currentPage.value });
+    }
   }
 
   function nextPage() {
-    if (currentPage.value < pageCount.value) currentPage.value++;
+    if (currentPage.value < pageCount.value) {
+      currentPage.value++;
+      track('list_paginated', { surface: 'documents', page: currentPage.value });
+    }
   }
 
   // Flat table data with manual expand/collapse (avoids UTable tree DOM patching bug)
@@ -165,12 +177,14 @@
 
   function toggleCollection(collectionId: string) {
     const next = new Set(expandedCollections.value);
+    const isExpanding = !next.has(collectionId);
     if (next.has(collectionId)) {
       next.delete(collectionId);
     } else {
       next.add(collectionId);
     }
     expandedCollections.value = next;
+    track('collection_row_expanded', { collection_id: collectionId, is_expanded: isExpanding });
   }
 
   const flatTableData = computed<FlatTableRow[]>(() => {
@@ -302,7 +316,7 @@
                   <p class="text-sm opacity-70">{{ t('contribute_banner_description') }}</p>
                 </div>
               </div>
-              <NuxtLink to="/contribute/document" class="btn btn-primary btn-outline btn-sm">
+              <NuxtLink to="/contribute/document" class="btn btn-primary btn-outline btn-sm" @click="track('contribute_cta_clicked', { type: 'document', location: 'archive_documents' })">
                 {{ t('contribute_banner_button') }}
               </NuxtLink>
             </div>
@@ -317,7 +331,7 @@
             type="button"
             class="btn btn-sm"
             :class="activeType === filter.value ? 'btn-primary' : 'btn-neutral btn-outline'"
-            @click="activeType = filter.value"
+            @click="() => { const prev = activeType; activeType = filter.value; track('document_filter_changed', { filter_type: filter.value, is_active: filter.value !== prev }); }"
           >
             {{ t(filter.labelKey) }} ({{ getFilterCount(filter.value) }})
           </button>
@@ -338,7 +352,7 @@
 
           <div class="flex gap-2">
             <!-- Sort Dropdown -->
-            <select v-model="sortBy" class="select select-bordered">
+            <select v-model="sortBy" class="select select-bordered" @change="track('document_list_changed', { sort_by: sortBy })">
               <option value="title">{{ t('sort.title') }}</option>
               <option value="newest">{{ t('sort.newest') }}</option>
               <option value="oldest">{{ t('sort.oldest') }}</option>
@@ -350,7 +364,7 @@
                 type="button"
                 class="btn join-item"
                 :class="viewMode === 'cards' ? 'btn-primary' : 'btn-neutral btn-outline'"
-                @click="viewMode = 'cards'"
+                @click="() => { viewMode = 'cards'; track('document_list_changed', { view_mode: 'cards' }); }"
               >
                 <i class="fad fa-grid-2"></i>
               </button>
@@ -358,7 +372,7 @@
                 type="button"
                 class="btn join-item"
                 :class="viewMode === 'table' ? 'btn-primary' : 'btn-neutral btn-outline'"
-                @click="viewMode = 'table'"
+                @click="() => { viewMode = 'table'; track('document_list_changed', { view_mode: 'table' }); }"
               >
                 <i class="fad fa-table"></i>
               </button>

--- a/app/pages/archive/documents/index.vue
+++ b/app/pages/archive/documents/index.vue
@@ -142,6 +142,10 @@
     }, 400);
   });
 
+  onUnmounted(() => {
+    if (searchTrackTimeout) clearTimeout(searchTrackTimeout);
+  });
+
   function prevPage() {
     if (currentPage.value > 1) {
       currentPage.value--;

--- a/app/pages/archive/electrical.vue
+++ b/app/pages/archive/electrical.vue
@@ -3,6 +3,7 @@
   import Fuse from 'fuse.js';
 
   const { t } = useI18n();
+  const { trackSearch, trackDownload } = useAnalytics();
 
   const { data: diagrams, status } = await useFetch('/api/diagrams');
   const activePanel = ref<string | null>(null);
@@ -49,6 +50,11 @@
 
     // Return just the items (without Fuse.js metadata) sorted by score
     return searchResults.map((result) => result.item);
+  });
+
+  // Track search after results are computed (fires once per debounced result set)
+  watch(filteredResults, (results) => {
+    trackSearch('electrical', searchQuery.value, results.length);
   });
 
   useHead({
@@ -174,6 +180,7 @@
                     :href="result.link"
                     target="_blank"
                     class="flex justify-between py-4 hover:bg-base-200 rounded px-2 transition-colors"
+                    @click="trackDownload({ name: result.name, file_type: 'diagram', group: 'electrical', location: result.category })"
                   >
                     <div>
                       <div class="text-lg">{{ result.name }}</div>
@@ -232,6 +239,7 @@
                       :href="diagramItem.link"
                       target="_blank"
                       class="flex justify-between py-4 hover:bg-base-200 px-4 transition-colors"
+                      @click="trackDownload({ name: diagramItem.name, file_type: 'diagram', group: 'electrical', location: diagram.title })"
                     >
                       <div>
                         <div class="text-lg">{{ diagramItem.name }}</div>

--- a/app/pages/archive/engines.vue
+++ b/app/pages/archive/engines.vue
@@ -2,6 +2,7 @@
   import { HERO_TYPES } from '../../../data/models/generic';
 
   const { t } = useI18n();
+  const { track } = useAnalytics();
 
   const { data, status } = await useFetch('/api/engines');
   const tableHeaders: any[] = [
@@ -96,7 +97,11 @@
             />
           </div>
           <div class="col-span-12 md:col-span-4">
-            <NuxtLink :to="'/technical/compression'" :title="t('compression_card.link_title')">
+            <NuxtLink
+              :to="'/technical/compression'"
+              :title="t('compression_card.link_title')"
+              @click="track('tool_card_clicked', { tool_name: 'compression', location: 'archive_engines' })"
+            >
               <div class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-xl transition-shadow duration-300">
                 <div class="card-body">
                   <div class="flex items-start">

--- a/app/pages/archive/index.vue
+++ b/app/pages/archive/index.vue
@@ -2,6 +2,7 @@
   import { ArchiveItems, BREADCRUMB_VERSIONS, HERO_TYPES } from '../../../data/models/generic';
   const { path } = useRoute();
   const { capture } = usePostHog();
+  const { track } = useAnalytics();
   const { t } = useI18n();
 
   // Function to get translated archive item title
@@ -109,7 +110,11 @@
           <p>{{ t('description_text') }}</p>
         </div>
         <div class="flex flex-wrap gap-2">
-          <NuxtLink class="btn btn-primary btn-sm" to="/contribute">
+          <NuxtLink
+            class="btn btn-primary btn-sm"
+            to="/contribute"
+            @click="track('contribute_cta_clicked', { type: 'archive', location: 'archive_home' })"
+          >
             <i class="fad fa-paper-plane mr-1"></i>
             {{ t('contribute_to_archive') }}
           </NuxtLink>

--- a/app/pages/archive/registry/index.vue
+++ b/app/pages/archive/registry/index.vue
@@ -2,6 +2,7 @@
   import { HERO_TYPES } from '../../../../data/models/generic';
 
   const { t } = useI18n();
+  const { track } = useAnalytics();
   const { listApproved } = useRegistry();
 
   // Define table columns
@@ -99,7 +100,11 @@
                   <p class="text-sm opacity-70">{{ t('contribute_banner_description') }}</p>
                 </div>
               </div>
-              <NuxtLink to="/contribute/registry" class="btn btn-primary btn-outline btn-sm">
+              <NuxtLink
+                to="/contribute/registry"
+                class="btn btn-primary btn-outline btn-sm"
+                @click="track('contribute_cta_clicked', { type: 'registry', location: 'archive_registry' })"
+              >
                 {{ t('contribute_banner_button') }}
               </NuxtLink>
             </div>
@@ -117,13 +122,21 @@
               </template>
             </PageIntro>
             <p class="font-bold mt-4 mb-5">{{ t('submission_status_text') }}</p>
-            <NuxtLink to="/archive/registry/pending" class="btn btn-primary">
+            <NuxtLink
+              to="/archive/registry/pending"
+              class="btn btn-primary"
+              @click="track('contribute_cta_clicked', { type: 'registry', location: 'archive_registry' })"
+            >
               <i class="fa-duotone fa-clipboard-question mr-2"></i>
               {{ t('track_submission_button') }}
             </NuxtLink>
           </div>
           <div class="col-span-12 md:col-span-4">
-            <a href="#submitAnchor" class="block">
+            <a
+              href="#submitAnchor"
+              class="block"
+              @click="track('contribute_cta_clicked', { type: 'registry', location: 'archive_registry' })"
+            >
               <div class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-2xl transition-shadow duration-300">
                 <div class="card-body">
                   <div class="flex items-start space-x-4">

--- a/app/pages/archive/weights.vue
+++ b/app/pages/archive/weights.vue
@@ -2,6 +2,7 @@
   import { HERO_TYPES } from '../../../data/models/generic';
 
   const { t } = useI18n();
+  const { track, trackSearch } = useAnalytics();
 
   const { data: tables, status } = await useFetch('/api/weights');
   const activePanel = ref<string | null>(null);
@@ -62,6 +63,20 @@
     const queryLower = query.toLowerCase();
     return items.filter((item: any) => item.item.toLowerCase().includes(queryLower));
   };
+
+  // Track per-table searches
+  watch(
+    tableSearchQueries,
+    (queries) => {
+      Object.entries(queries).forEach(([tableName, query]) => {
+        if (!query) return;
+        const tableData = tables.value?.[tableName as keyof typeof tables.value] as any;
+        const results = tableData ? filterItems(tableData.items ?? [], tableName) : [];
+        trackSearch('weights', query, results.length, { table_name: tableName });
+      });
+    },
+    { deep: true }
+  );
 </script>
 
 <template>
@@ -78,7 +93,11 @@
               :description="t('description_text')"
               as="h2"
             />
-            <NuxtLink to="/contact" class="btn btn-outline mb-6">
+            <NuxtLink
+              to="/contact"
+              class="btn btn-outline mb-6"
+              @click="track('contact_cta_clicked', { location: 'archive_weights' })"
+            >
               <i class="fas fa-paper-plane mr-2"></i>
               {{ t('contact_button') }}
             </NuxtLink>

--- a/app/pages/archive/weights.vue
+++ b/app/pages/archive/weights.vue
@@ -64,19 +64,28 @@
     return items.filter((item: any) => item.item.toLowerCase().includes(queryLower));
   };
 
-  // Track per-table searches
+  // Track per-table searches (debounced per table so we don't flood analytics
+  // with partial queries on every keystroke)
+  const weightsSearchTimers: Record<string, ReturnType<typeof setTimeout>> = {};
   watch(
     tableSearchQueries,
     (queries) => {
       Object.entries(queries).forEach(([tableName, query]) => {
+        if (weightsSearchTimers[tableName]) clearTimeout(weightsSearchTimers[tableName]);
         if (!query) return;
-        const tableData = tables.value?.[tableName as keyof typeof tables.value] as any;
-        const results = tableData ? filterItems(tableData.items ?? [], tableName) : [];
-        trackSearch('weights', query, results.length, { table_name: tableName });
+        weightsSearchTimers[tableName] = setTimeout(() => {
+          const tableData = tables.value?.[tableName as keyof typeof tables.value] as any;
+          const results = tableData ? filterItems(tableData.items ?? [], tableName) : [];
+          trackSearch('weights', query, results.length, { table_name: tableName });
+        }, 400);
       });
     },
     { deep: true }
   );
+
+  onUnmounted(() => {
+    Object.values(weightsSearchTimers).forEach(clearTimeout);
+  });
 </script>
 
 <template>

--- a/app/pages/archive/wheels/[...wheel].vue
+++ b/app/pages/archive/wheels/[...wheel].vue
@@ -4,6 +4,7 @@
   import type { IWheelsData } from '../../../../data/models/wheels';
 
   const { t } = useI18n();
+  const { track } = useAnalytics();
 
   const { isAuthenticated } = useAuth();
   const route = useRoute();
@@ -32,6 +33,7 @@
     try {
       await navigator.clipboard.writeText(url);
       copied.value = true;
+      track('wheel_link_copied', { wheel_id: wheel.value?.uuid });
       setTimeout(() => (copied.value = false), 1000);
     } catch ($e) {
       copied.value = false;
@@ -229,16 +231,26 @@
                   v-if="wheel.name && wheel.uuid"
                   type="button"
                   class="btn btn-secondary btn-lg"
-                  @click="shareWheelItem(wheel.name, wheel.uuid)"
+                  @click="shareWheelItem(wheel.name, wheel.uuid); track('wheel_shared', { wheel_id: wheel.uuid, method: 'native_share' })"
                 >
                   <i class="fad fa-share mr-2"></i>
                   <span>{{ t('actions.share') }}</span>
                 </button>
-                <NuxtLink v-if="wheel.uuid" :to="`/contribute/wheel?uuid=${wheel.uuid}`" class="btn btn-outline btn-lg">
+                <NuxtLink
+                  v-if="wheel.uuid"
+                  :to="`/contribute/wheel?uuid=${wheel.uuid}`"
+                  class="btn btn-outline btn-lg"
+                  @click="track('contribute_cta_clicked', { type: 'wheel', location: 'wheel_detail' })"
+                >
                   <i class="fad fa-edit mr-2"></i>
                   <span>{{ t('actions.contribute') }}</span>
                 </NuxtLink>
-                <button v-if="isAuthenticated" type="button" class="btn btn-outline btn-sm" @click="showSuggestEdit = true">
+                <button
+                  v-if="isAuthenticated"
+                  type="button"
+                  class="btn btn-outline btn-sm"
+                  @click="showSuggestEdit = true; track('suggest_edit_opened', { wheel_id: wheel.uuid })"
+                >
                   <i class="fad fa-pen-to-square mr-2"></i>
                   <span>{{ t('suggest_edit') }}</span>
                 </button>

--- a/app/pages/archive/wheels/index.vue
+++ b/app/pages/archive/wheels/index.vue
@@ -2,6 +2,7 @@
   import { HERO_TYPES } from '../../../../data/models/generic';
 
   const { t } = useI18n();
+  const { track } = useAnalytics();
 
   useHead({
     title: t('title'),
@@ -91,7 +92,11 @@
                 <p class="text-sm opacity-70">{{ t('contribute_banner_description') }}</p>
               </div>
             </div>
-            <NuxtLink to="/contribute/wheel" class="btn btn-primary btn-outline btn-sm">
+            <NuxtLink
+              to="/contribute/wheel"
+              class="btn btn-primary btn-outline btn-sm"
+              @click="track('contribute_cta_clicked', { type: 'wheel', location: 'archive_wheels' })"
+            >
               {{ t('contribute_banner_button') }}
             </NuxtLink>
           </div>
@@ -108,7 +113,11 @@
             />
         </div>
         <div class="col-span-12 md:col-span-4">
-          <NuxtLink :to="'/contribute/wheel?newWheel=true'" :title="t('add_wheel_card.link_title')">
+          <NuxtLink
+            :to="'/contribute/wheel?newWheel=true'"
+            :title="t('add_wheel_card.link_title')"
+            @click="track('contribute_cta_clicked', { type: 'wheel', location: 'archive_wheels_sidebar' })"
+          >
             <div class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-2xl transition-shadow">
               <div class="card-body">
                 <div class="flex items-start">

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -30,7 +30,8 @@
   });
 
   const supabase = useSupabase();
-  const { initAuth, isAuthenticated, isAdmin, userProfile, waitForAuth } = useAuth();
+  const { initAuth, isAuthenticated, isAdmin, userProfile, waitForAuth, user } = useAuth();
+  const { track } = useAnalytics();
   const route = useRoute();
   const errorMessage = ref('');
 
@@ -112,7 +113,13 @@
         await waitForAuth();
 
         // First-time user: null display_name means they haven't onboarded
-        if (!userProfile.value?.display_name) {
+        const isFirstTime = !userProfile.value?.display_name;
+        track('login_success', {
+          is_first_time: isFirstTime,
+          email_domain: user.value?.email ? user.value.email.split('@')[1] : undefined,
+        });
+
+        if (isFirstTime) {
           const redirect = isAdmin.value ? '/admin' : '/';
           navigateTo(`/welcome?redirect=${encodeURIComponent(redirect)}`, { replace: true });
         } else if (isAdmin.value) {
@@ -144,11 +151,17 @@
           parts.push(`winSearchLen=${window.location.search.length}`);
         }
         errorMessage.value = parts.length ? parts.join(' | ') : 'Authentication failed. Please try again.';
+        track('login_failed', {
+          code_present: !!code,
+          error_code: exchangeError?.code,
+          error_status: exchangeError?.status,
+        });
       }
     } catch (e: any) {
       console.error('[auth/callback] thrown:', e);
       const label = [e.name, e.code, e.message].filter(Boolean).join(' | ');
       errorMessage.value = label || 'Authentication failed';
+      track('login_failed', { error_code: e.code, error_message: e.message, threw: true });
     }
   });
 </script>

--- a/app/pages/contact.vue
+++ b/app/pages/contact.vue
@@ -235,6 +235,7 @@
                 target="_blank"
                 rel="noopener"
                 class="btn btn-primary btn-lg"
+                @click="trackOutbound({ destination: 'https://www.patreon.com/classicminidiy', label: 'patreon', group: 'contact_support' })"
               >
                 <i class="fab fa-patreon mr-2"></i>
                 {{ t('support_patreon_button') }}
@@ -251,6 +252,7 @@
   import { HERO_TYPES } from '../../data/models/generic';
 
   const { t } = useI18n();
+  const { trackOutbound } = useAnalytics();
 
   // SEO and meta using proper Nuxt patterns
   useHead({

--- a/app/pages/contribute/color.vue
+++ b/app/pages/contribute/color.vue
@@ -3,6 +3,14 @@
 
   const { t } = useI18n();
   const { capture } = usePostHog();
+  const { trackFormStarted, trackFormError } = useAnalytics();
+  const hasStarted = ref(false);
+
+  function onFormStart() {
+    if (hasStarted.value) return;
+    hasStarted.value = true;
+    trackFormStarted('color');
+  }
   const { query } = useRoute();
   const { isAuthenticated } = useAuth();
   const { getColor } = useColors();
@@ -94,6 +102,9 @@
     if (!isFormValid.value) {
       apiError.value = true;
       apiMessage.value = t('form.error.validation_failed');
+      if (!formData.name.trim()) trackFormError('color', 'name');
+      if (!formData.code.trim()) trackFormError('color', 'code');
+      if (formData.hexValue && !isValidHex.value) trackFormError('color', 'hex_value');
       return;
     }
 
@@ -275,6 +286,7 @@
                       :class="{ 'input-error': touched.name && !formData.name.trim() }"
                       maxlength="100"
                       :disabled="processing"
+                      @focus="onFormStart"
                       @blur="touched.name = true"
                     />
                     <p v-if="touched.name && !formData.name.trim()" class="text-sm text-error mt-1">

--- a/app/pages/contribute/document.vue
+++ b/app/pages/contribute/document.vue
@@ -3,6 +3,14 @@
 
   const { t } = useI18n();
   const { capture } = usePostHog();
+  const { trackFormStarted, track } = useAnalytics();
+  const hasStarted = ref(false);
+
+  function onFormStart() {
+    if (hasStarted.value) return;
+    hasStarted.value = true;
+    trackFormStarted('document');
+  }
   const { isAuthenticated } = useAuth();
   const { submitNewItem } = useSubmissions();
 
@@ -280,7 +288,7 @@
                       :class="{ 'select-error': formData.type === '' && touchedFields.type }"
                       :disabled="processing"
                       @blur="touchedFields.type = true"
-                      @change="touchedFields.type = true"
+                      @change="touchedFields.type = true; onFormStart()"
                     >
                       <option value="" disabled>{{ t('form.fields.type.placeholder') }}</option>
                       <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
@@ -417,6 +425,7 @@
                         class="toggle toggle-primary"
                         v-model="isCollection"
                         :disabled="processing"
+                        @change="track('contribute_collection_toggled', { enabled: isCollection })"
                       />
                       <div>
                         <span class="text-sm font-medium">{{ t('form.collection.toggle') }}</span>

--- a/app/pages/contribute/index.vue
+++ b/app/pages/contribute/index.vue
@@ -3,6 +3,7 @@
 
   const { t } = useI18n();
   const { isAuthenticated, userProfile } = useAuth();
+  const { track } = useAnalytics();
 
   useHead({
     title: t('page_title'),
@@ -79,7 +80,7 @@
 
       <!-- 2x2 Contribution Type Grid -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl mx-auto">
-        <NuxtLink v-for="item in contributionTypes" :key="item.to" :to="item.to">
+        <NuxtLink v-for="item in contributionTypes" :key="item.to" :to="item.to" @click="track('contribute_type_selected', { type: item.to.split('/').pop() })">
           <div class="card bg-base-100 shadow-md h-full hover:shadow-xl transition-shadow">
             <div class="card-body text-center p-6">
               <i :class="item.icon" class="text-4xl text-primary mb-4 block"></i>

--- a/app/pages/contribute/registry.vue
+++ b/app/pages/contribute/registry.vue
@@ -3,6 +3,14 @@
 
   const { t } = useI18n();
   const { capture } = usePostHog();
+  const { trackFormStarted } = useAnalytics();
+  const hasStarted = ref(false);
+
+  function onFormStart() {
+    if (hasStarted.value) return;
+    hasStarted.value = true;
+    trackFormStarted('registry');
+  }
   const { isAuthenticated } = useAuth();
   const { submitNewItem } = useSubmissions();
 
@@ -229,6 +237,7 @@
                           class="input input-bordered w-full"
                           :class="{ 'input-error': !formData.year && touchedFields.year }"
                           :disabled="processing"
+                          @change="onFormStart"
                           @blur="touchedFields.year = true"
                         />
                         <p v-if="!formData.year && touchedFields.year" class="text-sm text-error mt-1">
@@ -251,6 +260,7 @@
                           class="input input-bordered w-full"
                           :class="{ 'input-error': formData.model === '' && touchedFields.model }"
                           :disabled="processing"
+                          @focus="onFormStart"
                           @blur="touchedFields.model = true"
                         />
                         <p v-if="formData.model === '' && touchedFields.model" class="text-sm text-error mt-1">

--- a/app/pages/contribute/wheel.vue
+++ b/app/pages/contribute/wheel.vue
@@ -5,6 +5,14 @@
   const { isAuthenticated } = useAuth();
   const { submitNewItem } = useSubmissions();
   const { capture } = usePostHog();
+  const { trackFormStarted } = useAnalytics();
+  const hasStarted = ref(false);
+
+  function onFormStart() {
+    if (hasStarted.value) return;
+    hasStarted.value = true;
+    trackFormStarted('wheel');
+  }
 
   useHead({
     title: t('page_title'),
@@ -260,6 +268,7 @@
                         v-model="name"
                         class="input input-bordered w-full"
                         :class="{ 'input-error': name.trim() === '' && touchedFields.name }"
+                        @focus="onFormStart"
                         @blur="touchedFields.name = true"
                       />
                       <p v-if="name.trim() === '' && touchedFields.name" class="text-sm text-error mt-1">

--- a/app/pages/contributors/[id].vue
+++ b/app/pages/contributors/[id].vue
@@ -4,6 +4,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const userId = route.params.id as string;
+  const { track } = useAnalytics();
 
   const { getContributorProfile, listContributions, getContributionStats } = useContributions();
 
@@ -16,6 +17,10 @@
   const profile = profileResult.data;
   const contributions = contributionsResult.data;
   const stats = statsResult.data;
+
+  if (profile.value) {
+    track('contributor_profile_viewed', { contributor_user_id: userId });
+  }
 
   const displayName = computed(() => profile.value?.displayName || t('profile.unknown'));
 

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -3,6 +3,7 @@
 
   const { t } = useI18n();
   const { isAuthenticated } = useAuth();
+  const { track } = useAnalytics();
   const { configs, loading, fetchConfigs, updateConfig, deleteConfig } = useGearConfigs();
   const { listMySubmissions } = useSubmissions();
 
@@ -108,10 +109,12 @@
 
   async function togglePublic(id: string, isPublic: boolean) {
     await updateConfig(id, { is_public: !isPublic });
+    track('gear_config_visibility_toggled', { config_id: id, is_public: !isPublic });
   }
 
   async function handleDelete(id: string) {
     await deleteConfig(id);
+    track('gear_config_deleted', { config_id: id });
   }
 
   useHead({

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
   const { t, tm, rt } = useI18n();
+  const { track, trackOutbound } = useAnalytics();
   // tm() returns the raw structure for translation arrays/objects. Guard
   // against a missing key or unexpected shape so an i18n drift never
   // crashes the home page.
@@ -131,7 +132,7 @@
         <h2 class="text-3xl md:text-4xl">{{ t('home.toolgrid.heading') }}</h2>
         <p>{{ t('home.toolgrid.subheading') }}</p>
       </div>
-      <NuxtLink to="/technical" class="btn btn-outline btn-sm">
+      <NuxtLink to="/technical" class="btn btn-outline btn-sm" @click="track('home_cta_clicked', { cta: 'all_tools' })">
         <i class="fad fa-table-cells mr-1"></i>{{ t('home.toolgrid.all_tools') }}
       </NuxtLink>
     </div>
@@ -197,7 +198,7 @@
               <span>{{ item }}</span>
             </li>
           </ul>
-          <NuxtLink to="/archive" class="btn btn-primary">
+          <NuxtLink to="/archive" class="btn btn-primary" @click="track('home_cta_clicked', { cta: 'archive' })">
             <i class="fad fa-books mr-2"></i>{{ t('home.archive_feature.cta') }}
           </NuxtLink>
         </div>
@@ -213,7 +214,7 @@
         <h2 class="text-3xl md:text-4xl">{{ t('home.wheel_preview.heading') }}</h2>
         <p>{{ t('home.wheel_preview.subheading') }}</p>
       </div>
-      <NuxtLink to="/contribute/wheels" class="btn btn-secondary btn-sm">
+      <NuxtLink to="/contribute/wheels" class="btn btn-secondary btn-sm" @click="track('home_cta_clicked', { cta: 'wheel_registry' })">
         <i class="fad fa-paper-plane mr-1"></i>{{ t('home.wheel_preview.cta') }}
       </NuxtLink>
     </div>
@@ -223,6 +224,7 @@
         :key="wheel.uuid"
         :to="`/archive/wheels/${wheel.uuid}`"
         class="wheel-card"
+        @click="track('wheel_card_clicked', { wheel_uuid: wheel.uuid, wheel_name: wheel.name })"
       >
         <div
           class="wheel-card__ph"
@@ -274,6 +276,7 @@
           rel="noopener"
           href="https://patreon.com/classicminidiy"
           target="_blank"
+          @click="trackOutbound({ destination: 'https://patreon.com/classicminidiy', group: 'support', label: 'patreon' })"
         >
           <i class="fab fa-patreon mr-2" />
           {{ t('common.donate') }}
@@ -283,6 +286,7 @@
           rel="noopener"
           href="https://github.com/somethingnew71/classicminidiy"
           target="_blank"
+          @click="trackOutbound({ destination: 'https://github.com/somethingnew71/classicminidiy', group: 'support', label: 'github' })"
         >
           <i class="fab fa-github mr-2" />
           {{ t('common.contribute') }}

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -130,6 +130,9 @@
   });
 
   const { signInWithEmail, signInWithGoogle, signInWithApple, isAuthenticated } = useAuth();
+  const { track } = useAnalytics();
+
+  const emailDomain = (addr: string) => (addr.includes('@') ? addr.split('@')[1] : undefined);
 
   // Reactive state
   const email = ref('');
@@ -167,9 +170,11 @@
     try {
       await signInWithEmail(email.value, turnstileToken.value);
       magicLinkSent.value = true;
+      track('magic_link_sent', { email_domain: emailDomain(email.value) });
     } catch (error: any) {
       console.error('Login error:', error);
       errorMessage.value = error.message || t('login_error');
+      track('auth_failed', { method: 'magic_link', error_message: error.message });
       // Tokens are single-use. Reset the widget so the next attempt gets a fresh challenge.
       turnstileToken.value = '';
       turnstileRef.value?.reset();
@@ -182,11 +187,13 @@
   const handleGoogleLogin = async () => {
     isLoading.value = true;
     errorMessage.value = '';
+    track('oauth_initiated', { provider: 'google' });
     try {
       await signInWithGoogle();
     } catch (error: any) {
       console.error('Google login error:', error);
       errorMessage.value = error.message || t('oauth_error');
+      track('auth_failed', { method: 'oauth', provider: 'google', error_message: error.message });
       isLoading.value = false;
     }
   };
@@ -195,11 +202,13 @@
   const handleAppleLogin = async () => {
     isLoading.value = true;
     errorMessage.value = '';
+    track('oauth_initiated', { provider: 'apple' });
     try {
       await signInWithApple();
     } catch (error: any) {
       console.error('Apple login error:', error);
       errorMessage.value = error.message || t('oauth_error');
+      track('auth_failed', { method: 'oauth', provider: 'apple', error_message: error.message });
       isLoading.value = false;
     }
   };

--- a/app/pages/profile/edit.vue
+++ b/app/pages/profile/edit.vue
@@ -3,6 +3,7 @@
 
   const { t } = useI18n();
   const toast = useToast();
+  const { track } = useAnalytics();
   const { isAuthenticated, user, userProfile, fetchUserProfile, waitForAuth } = useAuth();
   const { fetchProfile, updateProfile, uploadAvatar } = useProfile();
 
@@ -150,6 +151,7 @@
       // Only call updateProfile if there are changes to save
       if (Object.keys(updates).length > 0) {
         await updateProfile(updates);
+        track('profile_updated', { fields_changed: Object.keys(updates) });
       }
 
       // Update the snapshot to reflect saved state
@@ -315,7 +317,7 @@
                     <p class="font-medium">{{ t('privacy.public_profile') }}</p>
                     <p class="text-sm opacity-60">{{ t('privacy.public_description') }}</p>
                   </div>
-                  <input type="checkbox" v-model="isPublic" class="toggle toggle-primary" />
+                  <input type="checkbox" v-model="isPublic" class="toggle toggle-primary" @change="track('privacy_setting_changed', { field: 'is_public', value: isPublic })" />
                 </div>
 
                 <div v-if="isPublic" class="flex items-center justify-between">
@@ -323,7 +325,7 @@
                     <p class="font-medium">{{ t('privacy.show_vehicles') }}</p>
                     <p class="text-sm opacity-60">{{ t('privacy.vehicles_description') }}</p>
                   </div>
-                  <input type="checkbox" v-model="showVehicles" class="toggle toggle-primary" />
+                  <input type="checkbox" v-model="showVehicles" class="toggle toggle-primary" @change="track('privacy_setting_changed', { field: 'show_vehicles', value: showVehicles })" />
                 </div>
               </div>
             </div>

--- a/app/pages/profile/index.vue
+++ b/app/pages/profile/index.vue
@@ -5,6 +5,7 @@
 
   const { t } = useI18n();
   const { isAuthenticated, user, waitForAuth } = useAuth();
+  const { track } = useAnalytics();
   const { fetchProfile, getPublicProfile, getPublicProfileVehicles } = useProfile();
   const { fetchPublicConfigs } = useGearConfigs();
 
@@ -63,6 +64,7 @@
 
   function copyShareUrl() {
     navigator.clipboard.writeText(shareUrl.value);
+    track('profile_share_url_copied');
   }
 
   useHead({

--- a/app/pages/technical/chassis-decoder.vue
+++ b/app/pages/technical/chassis-decoder.vue
@@ -4,6 +4,7 @@
 
   const { t } = useI18n();
   const { capture } = usePostHog();
+  const { track, trackOutbound } = useAnalytics();
 
   interface ChassisPosition {
     position: number;
@@ -113,11 +114,16 @@
     }
   }
 
+  watch(yearRange, (val) => {
+    track('chassis_year_range_changed', { year_range: val });
+  });
+
   function resetForm() {
     chassisNumber.value = '';
     yearRange.value = yearRangeOptions[0] || '';
     decodedResult.value = null;
     errorMessage.value = '';
+    track('chassis_decoder_reset');
   }
 
   function getPositionColorClass(position: number): string {
@@ -430,6 +436,7 @@
               target="_blank"
               rel="noopener noreferrer"
               class="link link-primary"
+              @click="trackOutbound({ destination: 'https://www.minimania.com/Mini_Chassis_VIN_and_Commission_Numbers__Part_I__Revised_', group: 'reference', label: 'mini_mania' })"
             >
               {{ t('attribution.link_text') }}</a
             >

--- a/app/pages/technical/clearance.vue
+++ b/app/pages/technical/clearance.vue
@@ -2,6 +2,7 @@
   import { BREADCRUMB_VERSIONS, HERO_TYPES } from '../../../data/models/generic';
 
   const { t } = useI18n();
+  const { trackSearch, track } = useAnalytics();
 
   interface ClearanceItem {
     name: string;
@@ -26,9 +27,34 @@
     expandedRows.value[id] = !expandedRows.value[id];
   };
 
-  const toggleTable = (id: string) => {
+  const toggleTable = (id: string, tableName: string) => {
     expandedTables.value[id] = !expandedTables.value[id];
+    track('reference_table_toggled', { surface: 'clearance', table_name: tableName });
   };
+
+  // Debounced search tracking
+  let clearanceSearchTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(searchValue, (val) => {
+    if (clearanceSearchTimer) clearTimeout(clearanceSearchTimer);
+    clearanceSearchTimer = setTimeout(() => {
+      const query = val.toLowerCase();
+      const totalResults = tables.value
+        ? Object.values(tables.value).reduce(
+            (sum, table) =>
+              sum +
+              table.items.filter((item: ClearanceItem) =>
+                Object.values(item).some((v) => String(v).toLowerCase().includes(query))
+              ).length,
+            0
+          )
+        : 0;
+      trackSearch('clearance', val, totalResults);
+    }, 400);
+  });
+
+  onUnmounted(() => {
+    if (clearanceSearchTimer) clearTimeout(clearanceSearchTimer);
+  });
 
   // Function to filter items based on search
   const filterItems = (items: ClearanceItem[], tableName: string) => {
@@ -182,7 +208,7 @@
         <input
           type="checkbox"
           :checked="!!expandedTables[name]"
-          @change="toggleTable(name)"
+          @change="toggleTable(name, table.title)"
           :aria-label="table.title"
         />
         <div class="collapse-title text-lg font-semibold">{{ table.title }}</div>

--- a/app/pages/technical/needles.vue
+++ b/app/pages/technical/needles.vue
@@ -2,6 +2,7 @@
   import { BREADCRUMB_VERSIONS, HERO_TYPES } from '../../../data/models/generic';
 
   const { t } = useI18n();
+  const { trackOutbound } = useAnalytics();
   // Track calculator loading state
   const isCalculatorLoaded = ref(false);
 
@@ -123,6 +124,7 @@
             href="https://www.7ent.com/pages/articles-tech-tips/chart-carburetor-needle.html"
             target="_blank"
             class="link link-primary"
+            @click="trackOutbound({ destination: 'https://www.7ent.com/pages/articles-tech-tips/chart-carburetor-needle.html', group: 'reference', label: 'seven_mini_parts' })"
             >{{ t('ui.seven_mini_parts_link') }}</a
           >
         </h3>

--- a/app/pages/technical/parts.vue
+++ b/app/pages/technical/parts.vue
@@ -2,6 +2,7 @@
   import { BREADCRUMB_VERSIONS, HERO_TYPES } from '../../../data/models/generic';
 
   const { t } = useI18n();
+  const { trackSearch, trackOutbound, track } = useAnalytics();
 
   interface PartItem {
     brand: string;
@@ -25,7 +26,32 @@
 
   const togglePanel = (panel: string) => {
     activePanels.value[panel] = !activePanels.value[panel];
+    track('reference_table_toggled', { surface: 'parts', table_name: panel });
   };
+
+  // Debounced search tracking
+  let partsSearchTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(searchValue, (val) => {
+    if (partsSearchTimer) clearTimeout(partsSearchTimer);
+    partsSearchTimer = setTimeout(() => {
+      const query = val.toLowerCase();
+      const totalResults = tables.value
+        ? Object.values(tables.value).reduce(
+            (sum, table) =>
+              sum +
+              table.items.filter((item: PartItem) =>
+                Object.values(item).some((v) => String(v).toLowerCase().includes(query))
+              ).length,
+            0
+          )
+        : 0;
+      trackSearch('parts', val, totalResults);
+    }, 400);
+  });
+
+  onUnmounted(() => {
+    if (partsSearchTimer) clearTimeout(partsSearchTimer);
+  });
 
   // Function to filter items based on search
   const filterItems = (items: PartItem[]) => {
@@ -263,7 +289,7 @@
                 </ul>
               </div>
             </div>
-            <NuxtLink :to="mailtoLink" class="btn btn-primary btn-lg">
+            <NuxtLink :to="mailtoLink" class="btn btn-primary btn-lg" @click="trackOutbound({ destination: mailtoLink, group: 'parts_submit', label: 'email' })">
               <i class="fas fa-envelope mr-2"></i>
               {{ t('submissions.submit_button') }}
             </NuxtLink>

--- a/app/pages/technical/torque.vue
+++ b/app/pages/technical/torque.vue
@@ -2,13 +2,37 @@
   import { BREADCRUMB_VERSIONS, HERO_TYPES } from '../../../data/models/generic';
 
   const { t } = useI18n();
+  const { trackSearch, track } = useAnalytics();
   const { data: tables, status } = await useFetch('/api/torque');
   const tableSearchQueries = ref<Record<string, string>>({});
   const expandedTables = ref<Record<string, boolean>>({});
 
-  const toggleTable = (key: string) => {
+  const toggleTable = (key: string, tableName: string) => {
     expandedTables.value[key] = !expandedTables.value[key];
+    track('reference_table_toggled', { surface: 'torque', table_name: tableName });
   };
+
+  // Per-table debounced search tracking
+  const torqueSearchTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+  watch(
+    tableSearchQueries,
+    (queries) => {
+      for (const [key, val] of Object.entries(queries)) {
+        if (torqueSearchTimers[key]) clearTimeout(torqueSearchTimers[key]);
+        torqueSearchTimers[key] = setTimeout(() => {
+          const tableData = (tables.value as any)?.[key];
+          const tableName = tableData?.title || key;
+          const resultsCount = tableData ? filterItems(tableData.items, key).length : 0;
+          trackSearch('torque', val, resultsCount, { table_name: tableName });
+        }, 400);
+      }
+    },
+    { deep: true }
+  );
+
+  onUnmounted(() => {
+    Object.values(torqueSearchTimers).forEach(clearTimeout);
+  });
 
   useHead({
     title: t('title'),
@@ -138,7 +162,7 @@
             :key="key"
             class="collapse collapse-arrow border border-base-300 bg-base-100 rounded-lg"
           >
-            <input type="checkbox" :checked="expandedTables[key]" @change="toggleTable(key)" />
+            <input type="checkbox" :checked="expandedTables[key]" @change="toggleTable(key, table.title)" />
             <div class="collapse-title text-lg font-semibold py-4">
               {{ table.title }}
             </div>

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -5,6 +5,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const { getPublicProfile, getPublicProfileVehicles } = useProfile();
+  const { track } = useAnalytics();
   const { fetchPublicConfigs } = useGearConfigs();
 
   const identifier = route.params.id as string;
@@ -31,6 +32,7 @@
       }
 
       profile.value = result.profile;
+      track('public_profile_viewed', { target_user_id: result.profile.id });
 
       // Fetch gear configs and vehicles in parallel
       const [configs, vehiclesData] = await Promise.all([

--- a/app/pages/welcome.vue
+++ b/app/pages/welcome.vue
@@ -140,6 +140,7 @@
   });
 
   const { isAuthenticated, userProfile, initAuth, fetchUserProfile, user } = useAuth();
+  const { track } = useAnalytics();
   const supabase = useSupabase();
   const route = useRoute();
 
@@ -202,6 +203,10 @@
         await fetchUserProfile(user.value!.id);
       }
 
+      track('profile_setup_completed', {
+        filled_display_name: !!displayName.value.trim(),
+        filled_bio: !!bio.value.trim(),
+      });
       navigateTo(redirectTo.value, { replace: true });
     } catch (error) {
       console.error('Error saving profile:', error);
@@ -213,6 +218,7 @@
 
   // Skip profile setup and navigate
   const handleSkip = () => {
+    track('profile_setup_skipped');
     navigateTo(redirectTo.value, { replace: true });
   };
 </script>

--- a/app/plugins/posthog.ts
+++ b/app/plugins/posthog.ts
@@ -24,12 +24,19 @@ export default defineNuxtPlugin({
       },
     });
 
+    // Manual SPA pageviews. router.afterEach does not fire for the initial
+    // (hydrated) navigation, so capture the entry route explicitly. The
+    // last-path guard prevents double-counting if afterEach also fires for it.
+    let lastTrackedPath = '';
+    const trackPageview = (fullPath: string) => {
+      if (fullPath === lastTrackedPath) return;
+      lastTrackedPath = fullPath;
+      posthog.capture('$pageview', { current_url: fullPath });
+    };
+
+    nextTick(() => trackPageview(router.currentRoute.value.fullPath));
     router.afterEach((to) => {
-      nextTick(() => {
-        posthog.capture('$pageview', {
-          current_url: to.fullPath,
-        });
-      });
+      nextTick(() => trackPageview(to.fullPath));
     });
 
     return {


### PR DESCRIPTION
## What

Expands PostHog coverage from **18 to ~100 events** and fixes the structural gaps that were making the existing data largely unusable.

### Foundation
- **`app/composables/useAnalytics.ts`** (new) — typed helpers: `trackOutbound`, `trackSearch`, `trackDownload`, `trackForm*`, `identifyUser`/`resetIdentity`, `track`. New events route through these so properties stay uniform and queryable.
- **Identity** (`useAuth.ts`) — `identify()` now fires on auth success (with `trust_level`/`is_admin`) and `reset()` on sign-out. Previously neither was called, so under `person_profiles: 'identified_only'` almost **no person profiles were being created** — analytics were effectively anonymous.
- **Pageviews** (`plugins/posthog.ts`) — explicitly captures the initial entry pageview (`router.afterEach` skips the hydrated first navigation) with a last-path dedupe guard.

### Coverage added
- **Auth funnel:** `oauth_initiated`, `magic_link_sent`, `auth_failed`, `login_success` (w/ `is_first_time`), `login_failed`, `profile_setup_completed/skipped`.
- **Outbound** (`outbound_link_clicked`, bucketed by `group`): YouTube, footer social, community nav, partner/reference links, profile social, chat useful-links, support.
- **Search** (`search_performed`): every Fuse.js + reference-table surface.
- **Downloads** (`document_downloaded`): documents, electrical diagrams, document cards.
- **Funnels:** `form_started` on all contribute forms, `contribute_type_selected`, file-upload start/errors.
- **Tool depth:** calculator field changes, needle add/remove/filters, chat copy/scroll/floating input, profile edits, privacy toggles, dashboard config actions, public-profile views.
- **Admin:** consolidated `admin_action`.

## Verification
- Production build passes.
- Key routes SSR clean (200) — identity wiring and `useAnalytics()` don't throw server-side.
- No new client console errors. (A pre-existing ColorModeButton dark/light hydration mismatch was surfaced but is unrelated — tracked separately.)

## Notes
- Skipped where no actionable hook exists without a refactor: electrical accordion toggle (native checkbox), wheel image carousel (hash-anchor links), maps feature matrix (static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)