### PR TITLE
feat(admin): comp membership management on /admin/users

### DIFF
--- a/app/composables/useAdminMembership.ts
+++ b/app/composables/useAdminMembership.ts
@@ -1,0 +1,50 @@
+/**
+ * useAdminMembership — admin-only helpers over the comp-membership RPCs
+ * (classicminidiy-supabase migration 20260608000002_comp_membership).
+ *
+ * Each RPC enforces public.is_admin() server-side, so these are called with the
+ * logged-in admin's Supabase client (their JWT carries admin). Non-admins hit a
+ * 42501 exception. This is the shared contract that TheMiniExchange's admin comp
+ * UI also calls — keep the names/shapes in sync.
+ */
+export interface AdminMembership {
+  /** Overall membership (user_has_subscription) — true via any active channel. */
+  is_member: boolean;
+  /** Platform of the row currently granting membership, or null. */
+  active_platform: 'apple' | 'google' | 'stripe' | 'comp' | null;
+  /** Whether an active comp row exists (drives the Revoke action). */
+  has_active_comp: boolean;
+  /** Comp expiry (ISO) or null = permanent. */
+  comp_expires_at: string | null;
+  /** Admin-supplied reason on the comp row. */
+  comp_note: string | null;
+}
+
+export const useAdminMembership = () => {
+  const supabase = useSupabase();
+
+  /** Snapshot of a user's membership for the admin UI. */
+  const getMembership = async (userId: string): Promise<AdminMembership> => {
+    const { data, error } = await supabase.rpc('admin_get_membership', { p_user_id: userId }).single();
+    if (error) throw error;
+    return data as AdminMembership;
+  };
+
+  /** Grant/refresh a complimentary membership. expiresAt null = permanent. */
+  const grantComp = async (userId: string, note: string | null, expiresAt: string | null): Promise<void> => {
+    const { error } = await supabase.rpc('grant_comp_membership', {
+      p_user_id: userId,
+      p_note: note,
+      p_expires_at: expiresAt,
+    });
+    if (error) throw error;
+  };
+
+  /** Revoke a user's comp membership (never touches paid apple/google/stripe rows). */
+  const revokeComp = async (userId: string): Promise<void> => {
+    const { error } = await supabase.rpc('revoke_comp_membership', { p_user_id: userId });
+    if (error) throw error;
+  };
+
+  return { getMembership, grantComp, revokeComp };
+};

--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -302,7 +302,17 @@
     membershipLoading.value = true;
     membershipError.value = '';
     try {
-      membershipData.value = await getMembership(userId);
+      const data = await getMembership(userId);
+      membershipData.value = data;
+      // Pre-populate the form from the existing comp so an update of one field
+      // doesn't blank the other (note vs expiry).
+      if (data.has_active_comp) {
+        compNote.value = data.comp_note || '';
+        compExpiry.value = data.comp_expires_at ? data.comp_expires_at.slice(0, 10) : '';
+      } else {
+        compNote.value = '';
+        compExpiry.value = '';
+      }
     } catch (error: any) {
       membershipError.value = error?.message || 'Failed to load membership';
     } finally {
@@ -331,12 +341,13 @@
     membershipLoading.value = true;
     membershipError.value = '';
     try {
-      const expiresAt = compExpiry.value ? new Date(`${compExpiry.value}T23:59:59`).toISOString() : null;
+      const expiresAt = compExpiry.value ? new Date(`${compExpiry.value}T23:59:59Z`).toISOString() : null;
       await grantComp(membershipUser.value.id, compNote.value.trim() || null, expiresAt);
       track('admin_action', { item_type: 'user', action: 'comp_granted' });
       await loadMembership(membershipUser.value.id);
     } catch (error: any) {
       membershipError.value = error?.message || 'Failed to grant comp membership';
+    } finally {
       membershipLoading.value = false;
     }
   }
@@ -351,6 +362,7 @@
       await loadMembership(membershipUser.value.id);
     } catch (error: any) {
       membershipError.value = error?.message || 'Failed to revoke comp membership';
+    } finally {
       membershipLoading.value = false;
     }
   }
@@ -358,7 +370,14 @@
   const compExpiryLabel = computed(() => {
     const exp = membershipData.value?.comp_expires_at;
     if (!exp) return null;
-    return new Date(exp).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    // expiry is stored UTC; format in UTC so the displayed calendar date matches
+    // what was entered (no off-by-one in non-UTC timezones).
+    return new Date(exp).toLocaleDateString('en-US', {
+      timeZone: 'UTC',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
   });
 </script>
 

--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { nextTick } from 'vue';
   import { BREADCRUMB_VERSIONS } from '../../../data/models/generic';
+  import type { AdminMembership } from '~/composables/useAdminMembership';
 
   definePageMeta({
     layout: 'admin',
@@ -283,6 +284,82 @@
       currentPage.value = page;
     }
   }
+
+  // --- Comp membership (admin-granted Sustaining Member) ---
+  // Calls the is_admin()-gated RPCs directly with the admin's client (shared
+  // contract with TheMiniExchange). Granting a comp fans out the badge, Ghost
+  // Pro, Discord, and free TME listings via the subscriptions trigger.
+  const { getMembership, grantComp, revokeComp } = useAdminMembership();
+  const showMembershipModal = ref(false);
+  const membershipUser = ref<UserItem | null>(null);
+  const membershipData = ref<AdminMembership | null>(null);
+  const membershipLoading = ref(false);
+  const membershipError = ref('');
+  const compNote = ref('');
+  const compExpiry = ref(''); // YYYY-MM-DD, '' = permanent
+
+  async function loadMembership(userId: string) {
+    membershipLoading.value = true;
+    membershipError.value = '';
+    try {
+      membershipData.value = await getMembership(userId);
+    } catch (error: any) {
+      membershipError.value = error?.message || 'Failed to load membership';
+    } finally {
+      membershipLoading.value = false;
+    }
+  }
+
+  async function openMembershipModal(userItem: UserItem) {
+    membershipUser.value = userItem;
+    membershipData.value = null;
+    compNote.value = '';
+    compExpiry.value = '';
+    showMembershipModal.value = true;
+    await loadMembership(userItem.id);
+  }
+
+  async function closeMembershipModal() {
+    showMembershipModal.value = false;
+    await nextTick();
+    membershipUser.value = null;
+    membershipData.value = null;
+  }
+
+  async function submitGrantComp() {
+    if (!membershipUser.value) return;
+    membershipLoading.value = true;
+    membershipError.value = '';
+    try {
+      const expiresAt = compExpiry.value ? new Date(`${compExpiry.value}T23:59:59`).toISOString() : null;
+      await grantComp(membershipUser.value.id, compNote.value.trim() || null, expiresAt);
+      track('admin_action', { item_type: 'user', action: 'comp_granted' });
+      await loadMembership(membershipUser.value.id);
+    } catch (error: any) {
+      membershipError.value = error?.message || 'Failed to grant comp membership';
+      membershipLoading.value = false;
+    }
+  }
+
+  async function submitRevokeComp() {
+    if (!membershipUser.value) return;
+    membershipLoading.value = true;
+    membershipError.value = '';
+    try {
+      await revokeComp(membershipUser.value.id);
+      track('admin_action', { item_type: 'user', action: 'comp_revoked' });
+      await loadMembership(membershipUser.value.id);
+    } catch (error: any) {
+      membershipError.value = error?.message || 'Failed to revoke comp membership';
+      membershipLoading.value = false;
+    }
+  }
+
+  const compExpiryLabel = computed(() => {
+    const exp = membershipData.value?.comp_expires_at;
+    if (!exp) return null;
+    return new Date(exp).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  });
 </script>
 
 <template>
@@ -363,6 +440,7 @@
             <th class="text-center">Admin</th>
             <th>Submissions</th>
             <th>Joined</th>
+            <th class="text-center">Membership</th>
             <th class="text-center w-48">Change Trust Level</th>
           </tr>
         </thead>
@@ -429,6 +507,19 @@
             <!-- Joined -->
             <td>
               <span class="text-xs opacity-70">{{ formatDate(userItem.created_at) }}</span>
+            </td>
+
+            <!-- Membership / Comp -->
+            <td class="text-center">
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs"
+                :disabled="isProcessing"
+                @click="openMembershipModal(userItem)"
+              >
+                <i class="fas fa-star opacity-70"></i>
+                Manage
+              </button>
             </td>
 
             <!-- Actions -->
@@ -568,6 +659,124 @@
         </div>
       </div>
       <div class="modal-backdrop" @click="closeTrustModal"></div>
+    </dialog>
+
+    <!-- Comp Membership Modal -->
+    <dialog class="modal" :class="{ 'modal-open': showMembershipModal }">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Manage Membership</h3>
+
+        <!-- User summary -->
+        <div v-if="membershipUser" class="bg-base-200 p-4 rounded-lg mb-4">
+          <div class="flex items-center gap-3">
+            <div v-if="membershipUser.avatar_url" class="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+              <img
+                :src="membershipUser.avatar_url"
+                :alt="membershipUser.display_name || membershipUser.email"
+                class="w-full h-full object-cover"
+              />
+            </div>
+            <div
+              v-else
+              class="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-sm font-bold text-primary flex-shrink-0"
+            >
+              {{ getInitials(membershipUser.display_name) }}
+            </div>
+            <div>
+              <p class="font-medium">{{ membershipUser.display_name || 'No display name' }}</p>
+              <p class="text-sm opacity-60">{{ membershipUser.email }}</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Loading (initial) -->
+        <div v-if="membershipLoading && !membershipData" class="flex justify-center py-6">
+          <i class="fas fa-spinner fa-spin text-2xl text-primary"></i>
+        </div>
+
+        <!-- Error -->
+        <div v-if="membershipError" role="alert" class="alert alert-error mb-4">
+          <i class="fas fa-triangle-exclamation"></i>
+          <span>{{ membershipError }}</span>
+        </div>
+
+        <!-- Status + actions -->
+        <template v-if="membershipData">
+          <div class="mb-4 text-sm space-y-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="opacity-70">Status:</span>
+              <span v-if="membershipData.is_member" class="badge badge-success badge-sm">Sustaining Member</span>
+              <span v-else class="badge badge-ghost badge-sm">Not a member</span>
+              <span v-if="membershipData.active_platform" class="badge badge-outline badge-sm">
+                via {{ membershipData.active_platform }}
+              </span>
+            </div>
+            <div v-if="membershipData.has_active_comp" class="opacity-70">
+              Comp {{ compExpiryLabel ? `expires ${compExpiryLabel}` : 'is permanent' }}
+              <span v-if="membershipData.comp_note">&mdash; &ldquo;{{ membershipData.comp_note }}&rdquo;</span>
+            </div>
+          </div>
+
+          <!-- Revoke (only when an active comp exists) -->
+          <div v-if="membershipData.has_active_comp" class="mb-4">
+            <button
+              type="button"
+              class="btn btn-outline btn-error btn-sm"
+              :disabled="membershipLoading"
+              @click="submitRevokeComp"
+            >
+              <i class="fas fa-xmark"></i>
+              Revoke comp
+            </button>
+          </div>
+
+          <!-- Grant / update comp -->
+          <div class="border-t border-base-300 pt-4">
+            <p class="font-semibold text-sm mb-2">
+              {{ membershipData.has_active_comp ? 'Update comp' : 'Grant comp membership' }}
+            </p>
+            <label class="form-control mb-2">
+              <div class="label py-1"><span class="label-text text-xs">Reason / note (optional)</span></div>
+              <input
+                v-model="compNote"
+                type="text"
+                placeholder="e.g. Press, partner, giveaway"
+                class="input input-bordered input-sm w-full"
+                :disabled="membershipLoading"
+              />
+            </label>
+            <label class="form-control mb-3">
+              <div class="label py-1">
+                <span class="label-text text-xs">Expires (optional &mdash; blank = permanent)</span>
+              </div>
+              <input
+                v-model="compExpiry"
+                type="date"
+                class="input input-bordered input-sm w-full"
+                :disabled="membershipLoading"
+              />
+            </label>
+            <button
+              type="button"
+              class="btn btn-primary btn-sm btn-block"
+              :disabled="membershipLoading"
+              @click="submitGrantComp"
+            >
+              <i v-if="membershipLoading" class="fas fa-spinner fa-spin"></i>
+              <i v-else class="fas fa-star"></i>
+              {{ membershipData.has_active_comp ? 'Update comp' : 'Grant comp' }}
+            </button>
+          </div>
+        </template>
+
+        <!-- Actions -->
+        <div class="modal-action">
+          <button type="button" class="btn btn-outline" :disabled="membershipLoading" @click="closeMembershipModal">
+            Close
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" @click="closeMembershipModal"></div>
     </dialog>
   </div>
 </template>

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -104,6 +104,24 @@ const __nuxtStateStore: Record<string, ReturnType<typeof ref>> = {};
   reset: vi.fn(),
 }));
 
+// useAnalytics mock — typed helpers over usePostHog; consumed by useAuth and
+// many pages/components. No-op in unit tests, mirroring the usePostHog stub.
+(global as any).useAnalytics = vi.fn(() => ({
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+  track: vi.fn(),
+  identifyUser: vi.fn(),
+  resetIdentity: vi.fn(),
+  trackOutbound: vi.fn(),
+  trackSearch: vi.fn(),
+  trackDownload: vi.fn(),
+  trackFormStarted: vi.fn(),
+  trackFormStep: vi.fn(),
+  trackFormSubmitted: vi.fn(),
+  trackFormError: vi.fn(),
+}));
+
 // ===== Vue APIs as globals (Nuxt auto-imports) =====
 (global as any).computed = computed;
 (global as any).watch = watch;

--- a/tests/unit/composables/useAdminMembership.test.ts
+++ b/tests/unit/composables/useAdminMembership.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * useAdminMembership wraps the is_admin()-gated comp RPCs. These tests pin the
+ * RPC names + argument shapes (the contract shared with TheMiniExchange).
+ */
+
+// A supabase.rpc(...) return value that is both awaitable (grant/revoke) and
+// has .single() (admin_get_membership).
+function rpcResult(resolved: { data: any; error: any }) {
+  return {
+    single: vi.fn().mockResolvedValue(resolved),
+    then: (onF: any, onR: any) => Promise.resolve(resolved).then(onF, onR),
+  };
+}
+
+let rpc: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  rpc = vi.fn();
+  vi.stubGlobal('useSupabase', () => ({ rpc }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useAdminMembership', () => {
+  it('getMembership calls admin_get_membership and returns the snapshot', async () => {
+    const snapshot = {
+      is_member: true,
+      active_platform: 'comp',
+      has_active_comp: true,
+      comp_expires_at: null,
+      comp_note: 'press',
+    };
+    rpc.mockReturnValue(rpcResult({ data: snapshot, error: null }));
+
+    const { useAdminMembership } = await import('~/app/composables/useAdminMembership');
+    const result = await useAdminMembership().getMembership('user-1');
+
+    expect(rpc).toHaveBeenCalledWith('admin_get_membership', { p_user_id: 'user-1' });
+    expect(result).toEqual(snapshot);
+  });
+
+  it('grantComp forwards note + expiry to grant_comp_membership', async () => {
+    rpc.mockReturnValue(rpcResult({ data: {}, error: null }));
+
+    const { useAdminMembership } = await import('~/app/composables/useAdminMembership');
+    await useAdminMembership().grantComp('user-1', 'Press comp', '2026-12-31T23:59:59.000Z');
+
+    expect(rpc).toHaveBeenCalledWith('grant_comp_membership', {
+      p_user_id: 'user-1',
+      p_note: 'Press comp',
+      p_expires_at: '2026-12-31T23:59:59.000Z',
+    });
+  });
+
+  it('grantComp sends nulls for a permanent, note-less comp', async () => {
+    rpc.mockReturnValue(rpcResult({ data: {}, error: null }));
+
+    const { useAdminMembership } = await import('~/app/composables/useAdminMembership');
+    await useAdminMembership().grantComp('user-1', null, null);
+
+    expect(rpc).toHaveBeenCalledWith('grant_comp_membership', {
+      p_user_id: 'user-1',
+      p_note: null,
+      p_expires_at: null,
+    });
+  });
+
+  it('revokeComp calls revoke_comp_membership', async () => {
+    rpc.mockReturnValue(rpcResult({ data: {}, error: null }));
+
+    const { useAdminMembership } = await import('~/app/composables/useAdminMembership');
+    await useAdminMembership().revokeComp('user-1');
+
+    expect(rpc).toHaveBeenCalledWith('revoke_comp_membership', { p_user_id: 'user-1' });
+  });
+
+  it('throws when the RPC returns an error (e.g. non-admin)', async () => {
+    rpc.mockReturnValue(rpcResult({ data: null, error: { message: 'Not authorized' } }));
+
+    const { useAdminMembership } = await import('~/app/composables/useAdminMembership');
+    await expect(useAdminMembership().revokeComp('user-1')).rejects.toMatchObject({ message: 'Not authorized' });
+  });
+});


### PR DESCRIPTION
Adds admin-driven **comp** (complimentary) membership management to `/admin/users`, consuming the new RPCs from [classicminidiy-supabase#16](https://github.com/ClassicMiniDIY/classicminidiy-supabase/pull/16).

## What's here
- A **"Manage"** action per user → modal showing current membership (member? via which channel? comp specifics) and a grant/revoke comp form.
- **Grant** supports an optional reason note and optional expiry (blank = permanent); **Revoke** only ever cancels the comp row, never a real apple/google/stripe sub.
- New `useAdminMembership` composable wrapping the three `is_admin()`-gated RPCs (`grant_comp_membership`, `revoke_comp_membership`, `admin_get_membership`), called client-side with the admin's JWT — the **shared contract** TheMiniExchange's admin comp UI also uses.
- Granting a comp cascades the badge, Ghost Pro, members-only Discord, and free TME listings automatically via the subscriptions trigger.

## Notes
- Also stubs `useAnalytics` globally in `vitest.setup.ts` — fixes a pre-existing `useAuth` suite failure (`useAnalytics is not defined`) the PostHog merge introduced. (Same one-line fix as the membership-web PR; trivial conflict if both merge.)
- **Depends on** the supabase migration being deployed; afterward run `bun run gen:types` so the new RPCs are typed. Until then the untyped client calls them fine at runtime.
- The `/admin/users` page is admin-gated, so the authenticated modal view wasn't click-tested in CI — `bun run build` passes and the composable is unit-tested (5 cases).

✅ 1451 tests pass · build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
