### PR TITLE
fix: rate-limit public LangGraph proxy + MCP fail-closed auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,14 @@ For inline icons in templates, use the traditional Font Awesome class syntax:
 - **CDN Integration**: S3 static assets with intelligent tiering
 - **Bundle Optimization**: Tree shaking and dependency optimization
 
+### Security Invariants
+
+Load-bearing contracts — don't "fix" these without understanding why they're this way:
+
+- **`/api/langgraph/**` is intentionally UNAUTHENTICATED.** The AI chat must work for every anonymous site visitor (no login). Do NOT add `requireUserAuth`/login to this proxy — it would break public chat. Abuse is mitigated by per-IP rate limiting in `server/middleware/rate-limit.ts` (default 40 req/60s, tune via `LANGGRAPH_RATELIMIT_MAX` / `LANGGRAPH_RATELIMIT_WINDOW_MS`), not by auth. The privileged `NUXT_LANGSMITH_API_KEY` stays server-only (private `runtimeConfig`).
+- **`/mcp` auth fails closed.** Valid keys come ONLY from `MCP_API_KEY` / `MCP_API_KEYS` env vars — there is no hardcoded/default key. The old `dev-mcp-key-classic-mini-diy` default is in public git history and must never be re-accepted in any environment. For local dev, set `MCP_API_KEY` in `.env`.
+- **`SUPABASE_SERVICE_KEY` is server-only.** It lives in private `runtimeConfig` and is read only via `server/utils/supabase.ts#getServiceClient`. Never import that into `app/` or move the key to `runtimeConfig.public`.
+
 ## Environment Variables
 
 ### Required Runtime Config

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -432,8 +432,10 @@ export default defineNuxtConfig({
     validation_key: process.env.validation_key,
     NUXT_LANGGRAPH_API_URL: process.env.NUXT_LANGGRAPH_API_URL,
     NUXT_LANGSMITH_API_KEY: process.env.NUXT_LANGSMITH_API_KEY,
-    // MCP API Keys
-    MCP_API_KEY: process.env.MCP_API_KEY || 'dev-mcp-key-classic-mini-diy',
+    // MCP API Keys — no hardcoded fallback: an unset MCP_API_KEY must resolve to
+    // empty so the /mcp middleware fails closed rather than accepting a baked-in
+    // default. Set MCP_API_KEY (or MCP_API_KEYS) in .env for local development.
+    MCP_API_KEY: process.env.MCP_API_KEY || '',
     MCP_API_KEYS: process.env.MCP_API_KEYS || '',
     NODE_ENV: process.env.NODE_ENV || 'development',
   },

--- a/server/mcp/README.md
+++ b/server/mcp/README.md
@@ -28,11 +28,9 @@ MCP_API_KEYS=key1,key2,key3
 
 ### Development Mode
 
-In development, a default key is available:
-
-```
-dev-mcp-key-classic-mini-diy
-```
+There is no built-in default key — authentication fails closed in every
+environment. For local development, set `MCP_API_KEY` (or `MCP_API_KEYS`) in your
+`.env` and send that value as the Bearer token.
 
 ### Providing API Keys
 

--- a/server/middleware/mcp-auth.ts
+++ b/server/middleware/mcp-auth.ts
@@ -39,7 +39,13 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  // Get valid API keys from environment
+  // Build the set of accepted API keys strictly from configured env values.
+  // No hardcoded/default key is ever accepted: the former dev fallback
+  // ('dev-mcp-key-classic-mini-diy') is published in this repo's git history and
+  // is treated as permanently burned. If nothing is configured, validKeys stays
+  // empty and every request is rejected below — fail closed in ALL environments,
+  // including when NODE_ENV is unset. For local development, set MCP_API_KEY
+  // (or MCP_API_KEYS) in your .env.
   const validKeys: string[] = [];
 
   // Check for comma-separated API keys
@@ -55,12 +61,7 @@ export default defineEventHandler(async (event) => {
     validKeys.push(config.MCP_API_KEY);
   }
 
-  // In development, allow default dev key (always include it in dev mode)
-  if (config.NODE_ENV === 'development' || process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
-    validKeys.push('dev-mcp-key-classic-mini-diy');
-  }
-
-  // Validate the provided API key
+  // Validate the provided API key (fail closed: empty validKeys -> always 403)
   if (!validKeys.includes(providedKey)) {
     console.error(
       `[MCP Auth] Invalid API key. Provided key does not match any valid keys. Valid keys count: ${validKeys.length}`

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -21,9 +21,12 @@ export default defineEventHandler((event) => {
   const { pathname } = getRequestURL(event);
   if (!pathname.startsWith('/api/langgraph')) return;
 
-  // Vercel terminates TLS upstream, so the real client IP is the left-most
-  // x-forwarded-for entry — getRequestIP returns it when xForwardedFor is on.
-  const ip = getRequestIP(event, { xForwardedFor: true }) || 'unknown';
+  // Resolve the client IP for keying. On Vercel, 'x-real-ip' is set by the edge
+  // proxy and cannot be spoofed by the client, so it is preferred. The left-most
+  // 'x-forwarded-for' entry (what getRequestIP returns) IS client-controllable
+  // and would otherwise let an attacker rotate the header to dodge the limit;
+  // it is only the fallback for non-Vercel/local environments.
+  const ip = getHeader(event, 'x-real-ip') || getRequestIP(event, { xForwardedFor: true }) || 'unknown';
 
   const result = consumeRateLimit(`langgraph:${ip}`, { max: MAX, windowMs: WINDOW_MS });
 

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -1,0 +1,42 @@
+import { consumeRateLimit } from '../utils/rateLimit';
+
+/**
+ * Per-IP rate limiting for the public, UNAUTHENTICATED LangGraph AI proxy
+ * (/api/langgraph/**). The chat is intentionally open to every site visitor
+ * (no login required), so this throttle is the only thing between an anonymous
+ * scripted caller and unbounded LLM runs billed to our LangSmith key.
+ *
+ * Limits are deliberately generous: the chat makes ~1 request per user message
+ * (thread creation is folded into the stream call), so a real visitor never
+ * approaches them, while an abuse loop blows past in seconds. Tune without a
+ * code change via env: LANGGRAPH_RATELIMIT_MAX / LANGGRAPH_RATELIMIT_WINDOW_MS.
+ *
+ * Note: the counter is per warm serverless instance (see utils/rateLimit.ts),
+ * so this dampens abuse rather than enforcing a precise global quota.
+ */
+const WINDOW_MS = Number(process.env.LANGGRAPH_RATELIMIT_WINDOW_MS) || 60_000;
+const MAX = Number(process.env.LANGGRAPH_RATELIMIT_MAX) || 40;
+
+export default defineEventHandler((event) => {
+  const { pathname } = getRequestURL(event);
+  if (!pathname.startsWith('/api/langgraph')) return;
+
+  // Vercel terminates TLS upstream, so the real client IP is the left-most
+  // x-forwarded-for entry — getRequestIP returns it when xForwardedFor is on.
+  const ip = getRequestIP(event, { xForwardedFor: true }) || 'unknown';
+
+  const result = consumeRateLimit(`langgraph:${ip}`, { max: MAX, windowMs: WINDOW_MS });
+
+  setHeader(event, 'X-RateLimit-Limit', String(MAX));
+  setHeader(event, 'X-RateLimit-Remaining', String(result.remaining));
+  setHeader(event, 'X-RateLimit-Reset', String(Math.ceil(result.resetAt / 1000)));
+
+  if (result.limited) {
+    setHeader(event, 'Retry-After', String(result.retryAfter));
+    throw createError({
+      statusCode: 429,
+      statusMessage: 'Too Many Requests',
+      message: 'Too many AI chat requests from your network. Please wait a moment and try again.',
+    });
+  }
+});

--- a/server/utils/rateLimit.ts
+++ b/server/utils/rateLimit.ts
@@ -5,8 +5,13 @@
  * Vercel (Fluid Compute) the counter lives per warm function instance rather
  * than in shared storage, so it is an abuse *dampener*, not a hard global
  * quota — enough to stop a single client scripting thousands of requests/min
- * without standing up Redis/KV. Buckets self-expire and are swept lazily so
- * the map cannot grow unbounded under a flood of unique keys.
+ * without standing up Redis/KV.
+ *
+ * Memory is strictly bounded: the map never exceeds MAX_TRACKED_KEYS. Expired
+ * buckets are swept lazily (throttled to avoid an O(N) scan on every request),
+ * and if the map is still at capacity we evict the oldest entries in O(1) via
+ * Map insertion order. This prevents a flood of unique keys (e.g. spoofed IPs)
+ * from either leaking memory or blocking the event loop.
  */
 
 interface Bucket {
@@ -16,9 +21,13 @@ interface Bucket {
 
 const buckets = new Map<string, Bucket>();
 
-// Hard cap so a flood of distinct keys (e.g. spoofed IPs) cannot grow the map
-// without bound; we sweep expired entries before inserting past this size.
+// Hard ceiling on tracked keys; we never let the map grow past this.
 const MAX_TRACKED_KEYS = 50_000;
+
+// Throttle full sweeps so a saturated map can't trigger an O(N) scan on every
+// request (a self-inflicted DoS vector).
+const SWEEP_INTERVAL_MS = 10_000;
+let lastSweep = 0;
 
 export interface RateLimitOptions {
   /** Max requests allowed within the window. */
@@ -37,9 +46,25 @@ export interface RateLimitResult {
   retryAfter: number;
 }
 
+/** Remove expired buckets, at most once per SWEEP_INTERVAL_MS. */
 function sweepExpired(now: number): void {
+  if (now - lastSweep < SWEEP_INTERVAL_MS) return;
+  lastSweep = now;
   for (const [key, bucket] of buckets) {
     if (bucket.resetAt <= now) buckets.delete(key);
+  }
+}
+
+/** Strictly bound the map before inserting a new key. */
+function makeRoomForNewKey(now: number): void {
+  if (buckets.size < MAX_TRACKED_KEYS) return;
+  sweepExpired(now);
+  // If the (possibly throttled) sweep didn't free enough, evict oldest-inserted
+  // entries in O(1) until under the cap — never an O(N) search.
+  while (buckets.size >= MAX_TRACKED_KEYS) {
+    const oldestKey = buckets.keys().next().value;
+    if (oldestKey === undefined) break;
+    buckets.delete(oldestKey);
   }
 }
 
@@ -50,11 +75,10 @@ function sweepExpired(now: number): void {
 export function consumeRateLimit(key: string, opts: RateLimitOptions): RateLimitResult {
   const now = Date.now();
 
-  // Opportunistic cleanup before we risk inserting a brand-new key past the cap.
-  if (buckets.size >= MAX_TRACKED_KEYS) sweepExpired(now);
-
   let bucket = buckets.get(key);
   if (!bucket || bucket.resetAt <= now) {
+    // Only bound the map when we're about to add a genuinely new key.
+    if (bucket === undefined) makeRoomForNewKey(now);
     bucket = { count: 0, resetAt: now + opts.windowMs };
     buckets.set(key, bucket);
   }
@@ -68,7 +92,8 @@ export function consumeRateLimit(key: string, opts: RateLimitOptions): RateLimit
   return { limited, remaining, resetAt: bucket.resetAt, retryAfter };
 }
 
-/** Test/maintenance helper: clear all tracked buckets. */
+/** Test/maintenance helper: clear all tracked buckets and sweep state. */
 export function _resetRateLimitStore(): void {
   buckets.clear();
+  lastSweep = 0;
 }

--- a/server/utils/rateLimit.ts
+++ b/server/utils/rateLimit.ts
@@ -1,0 +1,74 @@
+/**
+ * Lightweight in-memory fixed-window rate limiter.
+ *
+ * Mirrors the in-memory approach already used by server/utils/cache.ts. On
+ * Vercel (Fluid Compute) the counter lives per warm function instance rather
+ * than in shared storage, so it is an abuse *dampener*, not a hard global
+ * quota — enough to stop a single client scripting thousands of requests/min
+ * without standing up Redis/KV. Buckets self-expire and are swept lazily so
+ * the map cannot grow unbounded under a flood of unique keys.
+ */
+
+interface Bucket {
+  count: number;
+  resetAt: number; // epoch ms when the current window ends
+}
+
+const buckets = new Map<string, Bucket>();
+
+// Hard cap so a flood of distinct keys (e.g. spoofed IPs) cannot grow the map
+// without bound; we sweep expired entries before inserting past this size.
+const MAX_TRACKED_KEYS = 50_000;
+
+export interface RateLimitOptions {
+  /** Max requests allowed within the window. */
+  max: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  limited: boolean;
+  /** Requests remaining in the current window (0 once limited). */
+  remaining: number;
+  /** Epoch ms at which the current window resets. */
+  resetAt: number;
+  /** Seconds until the window resets — suitable for a Retry-After header. */
+  retryAfter: number;
+}
+
+function sweepExpired(now: number): void {
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(key);
+  }
+}
+
+/**
+ * Record one hit against `key` and report whether it exceeds the limit.
+ * Calling this IS the increment — call it exactly once per request.
+ */
+export function consumeRateLimit(key: string, opts: RateLimitOptions): RateLimitResult {
+  const now = Date.now();
+
+  // Opportunistic cleanup before we risk inserting a brand-new key past the cap.
+  if (buckets.size >= MAX_TRACKED_KEYS) sweepExpired(now);
+
+  let bucket = buckets.get(key);
+  if (!bucket || bucket.resetAt <= now) {
+    bucket = { count: 0, resetAt: now + opts.windowMs };
+    buckets.set(key, bucket);
+  }
+
+  bucket.count += 1;
+
+  const limited = bucket.count > opts.max;
+  const remaining = Math.max(0, opts.max - bucket.count);
+  const retryAfter = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+
+  return { limited, remaining, resetAt: bucket.resetAt, retryAfter };
+}
+
+/** Test/maintenance helper: clear all tracked buckets. */
+export function _resetRateLimitStore(): void {
+  buckets.clear();
+}

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -51,7 +51,7 @@ const mockRouter = {
   youtubeAPIKey: 'test-youtube-key',
   NUXT_LANGGRAPH_API_URL: 'https://test-langgraph.api',
   NUXT_LANGSMITH_API_KEY: 'test-langsmith-key',
-  MCP_API_KEY: 'dev-mcp-key-classic-mini-diy',
+  MCP_API_KEY: 'test-mcp-key',
   MCP_API_KEYS: '',
   NODE_ENV: 'test',
 }));

--- a/tests/unit/server/middleware/mcp-auth.test.ts
+++ b/tests/unit/server/middleware/mcp-auth.test.ts
@@ -137,8 +137,11 @@ describe('server/middleware/mcp-auth', () => {
     });
   });
 
-  // ---------- 6. Accept dev key in development mode ----------
-  it('accepts the dev key when NODE_ENV is development (via config)', async () => {
+  // ---------- 6. Fail closed: no hardcoded/burned key is ever accepted ----------
+  // 'dev-mcp-key-classic-mini-diy' is published in this repo's git history. The
+  // middleware must reject it in EVERY environment, and with no keys configured
+  // every request is rejected (no fail-open when NODE_ENV is unset).
+  it('rejects the burned dev key in development when no key is configured (403)', async () => {
     mockGetRequestURL.mockReturnValue(new URL('https://example.com/mcp/tools'));
     mockGetHeader.mockReturnValue('Bearer dev-mcp-key-classic-mini-diy');
 
@@ -148,25 +151,12 @@ describe('server/middleware/mcp-auth', () => {
       NODE_ENV: 'development',
     });
 
-    await expect((handler as Function)(fakeEvent)).resolves.toBeUndefined();
-  });
-
-  it('accepts the dev key when process.env.NODE_ENV is development', async () => {
-    process.env.NODE_ENV = 'development';
-
-    mockGetRequestURL.mockReturnValue(new URL('https://example.com/mcp/tools'));
-    mockGetHeader.mockReturnValue('Bearer dev-mcp-key-classic-mini-diy');
-
-    mockUseRuntimeConfig.mockReturnValue({
-      MCP_API_KEY: '',
-      MCP_API_KEYS: '',
-      NODE_ENV: 'test', // config says test, but process.env says development
+    await expect((handler as Function)(fakeEvent)).rejects.toMatchObject({
+      statusCode: 403,
     });
-
-    await expect((handler as Function)(fakeEvent)).resolves.toBeUndefined();
   });
 
-  it('accepts the dev key when NODE_ENV is not set at all', async () => {
+  it('rejects the burned dev key when NODE_ENV is unset — no fail-open (403)', async () => {
     const originalEnv = process.env.NODE_ENV;
     delete process.env.NODE_ENV;
 
@@ -179,13 +169,15 @@ describe('server/middleware/mcp-auth', () => {
       NODE_ENV: undefined,
     });
 
-    await expect((handler as Function)(fakeEvent)).resolves.toBeUndefined();
+    await expect((handler as Function)(fakeEvent)).rejects.toMatchObject({
+      statusCode: 403,
+    });
 
     // Restore
     process.env.NODE_ENV = originalEnv;
   });
 
-  it('rejects the dev key in production mode', async () => {
+  it('rejects the burned dev key in production (403)', async () => {
     process.env.NODE_ENV = 'production';
 
     mockGetRequestURL.mockReturnValue(new URL('https://example.com/mcp/tools'));
@@ -200,6 +192,34 @@ describe('server/middleware/mcp-auth', () => {
     await expect((handler as Function)(fakeEvent)).rejects.toMatchObject({
       statusCode: 403,
     });
+  });
+
+  it('rejects ALL requests when no API keys are configured — fail closed (403)', async () => {
+    mockGetRequestURL.mockReturnValue(new URL('https://example.com/mcp/tools'));
+    mockGetHeader.mockReturnValue('Bearer any-key-at-all');
+
+    mockUseRuntimeConfig.mockReturnValue({
+      MCP_API_KEY: '',
+      MCP_API_KEYS: '',
+      NODE_ENV: 'development',
+    });
+
+    await expect((handler as Function)(fakeEvent)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it('still accepts a real configured key in development (dev works via env key)', async () => {
+    mockGetRequestURL.mockReturnValue(new URL('https://example.com/mcp/tools'));
+    mockGetHeader.mockReturnValue('Bearer my-local-dev-key');
+
+    mockUseRuntimeConfig.mockReturnValue({
+      MCP_API_KEY: 'my-local-dev-key',
+      MCP_API_KEYS: '',
+      NODE_ENV: 'development',
+    });
+
+    await expect((handler as Function)(fakeEvent)).resolves.toBeUndefined();
   });
 
   // ---------- 7. Case-insensitive bearer prefix ----------

--- a/tests/unit/server/middleware/rate-limit.test.ts
+++ b/tests/unit/server/middleware/rate-limit.test.ts
@@ -1,0 +1,93 @@
+/** @vitest-environment node */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---- Nitro global stubs + small limit (must be hoisted before source import) ----
+const { mockGetRequestURL, mockGetRequestIP, mockSetHeader } = vi.hoisted(() => {
+  // Force a tiny limit so we can drive the 429 path in a couple of calls.
+  process.env.LANGGRAPH_RATELIMIT_MAX = '3';
+  process.env.LANGGRAPH_RATELIMIT_WINDOW_MS = '60000';
+
+  const mockGetRequestURL = vi.fn();
+  const mockGetRequestIP = vi.fn();
+  const mockSetHeader = vi.fn();
+
+  (globalThis as any).defineEventHandler = (handler: Function) => handler;
+  (globalThis as any).getRequestURL = mockGetRequestURL;
+  (globalThis as any).getRequestIP = mockGetRequestIP;
+  (globalThis as any).setHeader = mockSetHeader;
+  (globalThis as any).createError = (opts: { statusCode: number; statusMessage?: string; message?: string }) => {
+    const e = new Error(opts.message || opts.statusMessage) as Error & { statusCode: number };
+    e.statusCode = opts.statusCode;
+    return e;
+  };
+
+  return { mockGetRequestURL, mockGetRequestIP, mockSetHeader };
+});
+
+import handler from '~/server/middleware/rate-limit';
+import { _resetRateLimitStore } from '~/server/utils/rateLimit';
+
+describe('server/middleware/rate-limit', () => {
+  const fakeEvent = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetRateLimitStore();
+    mockGetRequestIP.mockReturnValue('203.0.113.7');
+  });
+
+  it('ignores non-langgraph routes (no-op, no IP lookup)', async () => {
+    mockGetRequestURL.mockReturnValue(new URL('https://example.com/api/listings'));
+
+    const result = await (handler as Function)(fakeEvent);
+    expect(result).toBeUndefined();
+    expect(mockGetRequestIP).not.toHaveBeenCalled();
+    expect(mockSetHeader).not.toHaveBeenCalled();
+  });
+
+  // The handler is synchronous (returns void / throws via createError), so we
+  // assert with sync matchers — a thrown createError must be caught by expect's
+  // wrapper, not awaited.
+  const call = () => (handler as Function)(fakeEvent);
+  const callCatching = (): any => {
+    try {
+      call();
+      return undefined;
+    } catch (e) {
+      return e;
+    }
+  };
+
+  it('allows langgraph requests under the limit and sets rate-limit headers', () => {
+    mockGetRequestURL.mockReturnValue(new URL('https://example.com/api/langgraph/threads/new/runs/stream'));
+
+    expect(call()).toBeUndefined();
+    expect(mockSetHeader).toHaveBeenCalledWith(fakeEvent, 'X-RateLimit-Limit', '3');
+    expect(mockSetHeader).toHaveBeenCalledWith(fakeEvent, 'X-RateLimit-Remaining', '2');
+  });
+
+  it('throws 429 with Retry-After once the per-IP limit is exceeded', () => {
+    mockGetRequestURL.mockReturnValue(new URL('https://example.com/api/langgraph/threads'));
+
+    expect(call()).toBeUndefined(); // 1
+    expect(call()).toBeUndefined(); // 2
+    expect(call()).toBeUndefined(); // 3 (== max, still allowed)
+
+    expect(callCatching()).toMatchObject({ statusCode: 429 }); // 4
+    expect(mockSetHeader).toHaveBeenCalledWith(fakeEvent, 'Retry-After', expect.any(String));
+  });
+
+  it('keeps separate budgets per client IP', () => {
+    mockGetRequestURL.mockReturnValue(new URL('https://example.com/api/langgraph/threads'));
+
+    mockGetRequestIP.mockReturnValue('198.51.100.1');
+    call();
+    call();
+    call();
+    expect(callCatching()).toMatchObject({ statusCode: 429 });
+
+    // A different IP still has a fresh budget.
+    mockGetRequestIP.mockReturnValue('198.51.100.2');
+    expect(call()).toBeUndefined();
+  });
+});

--- a/tests/unit/server/middleware/rate-limit.test.ts
+++ b/tests/unit/server/middleware/rate-limit.test.ts
@@ -2,18 +2,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---- Nitro global stubs + small limit (must be hoisted before source import) ----
-const { mockGetRequestURL, mockGetRequestIP, mockSetHeader } = vi.hoisted(() => {
+const { mockGetRequestURL, mockGetRequestIP, mockGetHeader, mockSetHeader } = vi.hoisted(() => {
   // Force a tiny limit so we can drive the 429 path in a couple of calls.
   process.env.LANGGRAPH_RATELIMIT_MAX = '3';
   process.env.LANGGRAPH_RATELIMIT_WINDOW_MS = '60000';
 
   const mockGetRequestURL = vi.fn();
   const mockGetRequestIP = vi.fn();
+  const mockGetHeader = vi.fn();
   const mockSetHeader = vi.fn();
 
   (globalThis as any).defineEventHandler = (handler: Function) => handler;
   (globalThis as any).getRequestURL = mockGetRequestURL;
   (globalThis as any).getRequestIP = mockGetRequestIP;
+  (globalThis as any).getHeader = mockGetHeader;
   (globalThis as any).setHeader = mockSetHeader;
   (globalThis as any).createError = (opts: { statusCode: number; statusMessage?: string; message?: string }) => {
     const e = new Error(opts.message || opts.statusMessage) as Error & { statusCode: number };
@@ -21,7 +23,7 @@ const { mockGetRequestURL, mockGetRequestIP, mockSetHeader } = vi.hoisted(() => 
     return e;
   };
 
-  return { mockGetRequestURL, mockGetRequestIP, mockSetHeader };
+  return { mockGetRequestURL, mockGetRequestIP, mockGetHeader, mockSetHeader };
 });
 
 import handler from '~/server/middleware/rate-limit';
@@ -33,6 +35,8 @@ describe('server/middleware/rate-limit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetRateLimitStore();
+    // Default: no x-real-ip header, so keying falls back to getRequestIP.
+    mockGetHeader.mockReturnValue(undefined);
     mockGetRequestIP.mockReturnValue('203.0.113.7');
   });
 
@@ -89,5 +93,19 @@ describe('server/middleware/rate-limit', () => {
     // A different IP still has a fresh budget.
     mockGetRequestIP.mockReturnValue('198.51.100.2');
     expect(call()).toBeUndefined();
+  });
+
+  it('keys on the unspoofable x-real-ip when present, ignoring x-forwarded-for', () => {
+    mockGetRequestURL.mockReturnValue(new URL('https://example.com/api/langgraph/threads'));
+
+    // Attacker rotates the spoofable getRequestIP value each request, but the
+    // edge-set x-real-ip stays constant — so the limit must still bind.
+    mockGetHeader.mockReturnValue('192.0.2.50'); // x-real-ip (constant, trusted)
+    mockGetRequestIP.mockReturnValueOnce('1.1.1.1').mockReturnValueOnce('2.2.2.2').mockReturnValueOnce('3.3.3.3');
+
+    call();
+    call();
+    call();
+    expect(callCatching()).toMatchObject({ statusCode: 429 });
   });
 });

--- a/tests/unit/server/utils/rateLimit.test.ts
+++ b/tests/unit/server/utils/rateLimit.test.ts
@@ -1,0 +1,59 @@
+/** @vitest-environment node */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { consumeRateLimit, _resetRateLimitStore } from '~/server/utils/rateLimit';
+
+describe('server/utils/rateLimit', () => {
+  const opts = { max: 3, windowMs: 60_000 };
+
+  beforeEach(() => {
+    _resetRateLimitStore();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows requests up to max, then limits', () => {
+    expect(consumeRateLimit('ip-a', opts).limited).toBe(false); // 1
+    expect(consumeRateLimit('ip-a', opts).limited).toBe(false); // 2
+    expect(consumeRateLimit('ip-a', opts).limited).toBe(false); // 3 (== max)
+    expect(consumeRateLimit('ip-a', opts).limited).toBe(true); // 4 (> max)
+  });
+
+  it('reports remaining counting down to zero', () => {
+    expect(consumeRateLimit('ip-b', opts).remaining).toBe(2);
+    expect(consumeRateLimit('ip-b', opts).remaining).toBe(1);
+    expect(consumeRateLimit('ip-b', opts).remaining).toBe(0);
+    expect(consumeRateLimit('ip-b', opts).remaining).toBe(0); // stays 0 once over
+  });
+
+  it('tracks keys independently', () => {
+    consumeRateLimit('ip-c', opts);
+    consumeRateLimit('ip-c', opts);
+    consumeRateLimit('ip-c', opts);
+    expect(consumeRateLimit('ip-c', opts).limited).toBe(true);
+    // A different key has its own fresh budget.
+    expect(consumeRateLimit('ip-d', opts).limited).toBe(false);
+  });
+
+  it('resets after the window elapses', () => {
+    consumeRateLimit('ip-e', opts);
+    consumeRateLimit('ip-e', opts);
+    consumeRateLimit('ip-e', opts);
+    expect(consumeRateLimit('ip-e', opts).limited).toBe(true);
+
+    // Advance past the window — the bucket should be rebuilt fresh.
+    vi.advanceTimersByTime(opts.windowMs + 1);
+    expect(consumeRateLimit('ip-e', opts).limited).toBe(false);
+    expect(consumeRateLimit('ip-e', opts).remaining).toBe(1);
+  });
+
+  it('exposes a retryAfter of at least 1 second while limited', () => {
+    consumeRateLimit('ip-f', opts);
+    const res = consumeRateLimit('ip-f', opts);
+    expect(res.retryAfter).toBeGreaterThanOrEqual(1);
+    expect(res.retryAfter).toBeLessThanOrEqual(60);
+  });
+});


### PR DESCRIPTION
## Summary

API abuse-hardening from a full public-repo security audit. Two unrelated-but-adjacent fixes; no behavior change for real users.

### 1. Per-IP rate limiting on the public LangGraph AI proxy
`/api/langgraph/**` is intentionally **unauthenticated** — the AI chat must work for every anonymous visitor. It had no throttle, so an anonymous scripted caller could drive unbounded LLM runs on the server's `NUXT_LANGSMITH_API_KEY`.

- New `server/utils/rateLimit.ts` — in-memory fixed-window limiter (same pattern as `server/utils/cache.ts`; self-sweeping, capped key count).
- New `server/middleware/rate-limit.ts` — applies it to the `/api/langgraph` namespace, keyed by client IP (`x-forwarded-for` aware for Vercel).
- Default **40 req / 60s** — the chat makes ~1 request per user message, so a real visitor never approaches it. Tunable via `LANGGRAPH_RATELIMIT_MAX` / `LANGGRAPH_RATELIMIT_WINDOW_MS`.
- Returns `429` + `Retry-After` + `X-RateLimit-*` headers.
- Counter is per warm serverless instance (Fluid Compute reuses instances), so it dampens abuse without standing up Redis/KV — documented in the util.

### 2. MCP auth fails closed
`dev-mcp-key-classic-mini-diy` was a hardcoded default (and is in public git history). Because `nuxt.config` defaulted `MCP_API_KEY` to it and the middleware pushed it into `validKeys` unconditionally, an unset `MCP_API_KEY` in prod would silently accept the burned key as a valid bearer token.

- `nuxt.config.ts`: `MCP_API_KEY` falls back to `''`, not the literal.
- `mcp-auth.ts`: removed the dev-key push. Valid keys come **only** from `MCP_API_KEY` / `MCP_API_KEYS`; empty set → all requests rejected, in every environment.
- Local dev now requires `MCP_API_KEY` in `.env` (README updated).

## Docs
Added a **Security Invariants** section to `CLAUDE.md`: the langgraph proxy stays public (rate-limit, don't add auth), MCP fails closed, `SUPABASE_SERVICE_KEY` stays server-only.

## Testing
- 10 new tests (`rateLimit` util + `rate-limit` middleware); flipped the `mcp-auth` tests to assert fail-closed (burned key rejected even when `NODE_ENV` is unset).
- Full suite: **1470 passing**. `bun run build` exit 0 with the middleware bundled.

## Not in scope
The audit also found a Google/YouTube API key in old git history (commits `b0e6a444`→`645cc8fe`, 2019–2020) — already rotated, no action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
