### PR TITLE
fix(membership): pre-launch web polish — checkout race, intent, ghost/patreon manage (punch list PR D1)

### DIFF
--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -35,6 +35,20 @@
   const route = useRoute();
   const errorMessage = ref('');
 
+  // Post-auth redirect intent stashed by /login (?redirect=<internal path>).
+  // Consumed (read + cleared) only on a successful sign-in; re-validated here
+  // so a tampered localStorage value can't become an open redirect.
+  const POST_AUTH_REDIRECT_KEY = 'cmdiy-post-auth-redirect';
+  function consumeStoredRedirect(): string | null {
+    try {
+      const value = window.localStorage.getItem(POST_AUTH_REDIRECT_KEY);
+      if (value !== null) window.localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+      return value && value.startsWith('/') && !value.startsWith('//') ? value : null;
+    } catch {
+      return null;
+    }
+  }
+
   onMounted(async () => {
     try {
       // Manual PKCE code exchange. useSupabase has detectSessionInUrl: false,
@@ -119,9 +133,15 @@
           email_domain: user.value?.email ? user.value.email.split('@')[1] : undefined,
         });
 
+        // A preserved intent (e.g. /membership?subscribe=1) wins over the
+        // default admin/home destinations; first-timers carry it through the
+        // welcome page's existing ?redirect= mechanism.
+        const storedRedirect = consumeStoredRedirect();
         if (isFirstTime) {
-          const redirect = isAdmin.value ? '/admin' : '/';
+          const redirect = storedRedirect || (isAdmin.value ? '/admin' : '/');
           navigateTo(`/welcome?redirect=${encodeURIComponent(redirect)}`, { replace: true });
+        } else if (storedRedirect) {
+          navigateTo(storedRedirect, { replace: true });
         } else if (isAdmin.value) {
           navigateTo('/admin', { replace: true });
         } else {

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -22,6 +22,8 @@
 </template>
 
 <script setup lang="ts">
+  import { sanitizeRedirectPath } from '../../utils/redirect';
+
   const { t } = useI18n();
 
   useHead({
@@ -43,7 +45,9 @@
     try {
       const value = window.localStorage.getItem(POST_AUTH_REDIRECT_KEY);
       if (value !== null) window.localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
-      return value && value.startsWith('/') && !value.startsWith('//') ? value : null;
+      // Shared validator: rejects absolute URLs, //host, backslash variants,
+      // and control characters (see app/utils/redirect.ts).
+      return sanitizeRedirectPath(value);
     } catch {
       return null;
     }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -423,12 +423,12 @@
       "dismiss": "Dismiss"
     },
     "discord_errors": {
-      "missing_token": "This Discord invite link is incomplete. Open the Classic Mini DIY app to request a fresh one.",
-      "expired_link": "This Discord invite link has expired. Open the Classic Mini DIY app to request a new one.",
-      "link_not_found": "We couldn't find a Discord invite for your account. Make sure your Sustaining Membership is active, then try again.",
-      "link_superseded": "A newer Discord invite was issued. Use the most recent link from your email or the app.",
-      "not_active": "Your Discord access isn't active. An active Sustaining Membership is required to join the members-only Discord.",
-      "generic": "We couldn't complete your Discord invite. Please try again from the most recent link."
+      "missing_token": "This Discord invite link is incomplete. Use the most recent invite email, or reach out via the contact page and we'll send you a fresh one.",
+      "expired_link": "This Discord invite link has expired. Reach out via the contact page and we'll send you a new one.",
+      "link_not_found": "We couldn't find a Discord invite for your account. Check that your Sustaining Membership is active on the membership page, then reach out via the contact page if you still need an invite.",
+      "link_superseded": "A newer Discord invite was issued. Use the most recent link from your email, or reach out via the contact page if you can't find it.",
+      "not_active": "Your Discord access isn't active. An active Sustaining Membership is required to join the members-only Discord — check yours on the membership page.",
+      "generic": "We couldn't complete your Discord invite. Try the most recent link from your email, or reach out via the contact page and we'll sort it out."
     },
     "home": {
       "title": "Classic Mini DIY | Your Friendly Neighborhood Classic Mini Resource",

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -131,8 +131,18 @@
 
   const { signInWithEmail, signInWithGoogle, signInWithApple, isAuthenticated } = useAuth();
   const { track } = useAnalytics();
+  const route = useRoute();
 
   const emailDomain = (addr: string) => (addr.includes('@') ? addr.split('@')[1] : undefined);
+
+  // Post-auth redirect intent (e.g. /login?redirect=%2Fmembership%3Fsubscribe%3D1
+  // from the membership page). Internal paths only — never an absolute URL or
+  // protocol-relative //host, so the param can't be abused as an open redirect.
+  const POST_AUTH_REDIRECT_KEY = 'cmdiy-post-auth-redirect';
+  const requestedRedirect = computed(() => {
+    const r = route.query.redirect;
+    return typeof r === 'string' && r.startsWith('/') && !r.startsWith('//') ? r : null;
+  });
 
   // Reactive state
   const email = ref('');
@@ -143,12 +153,28 @@
   const turnstileRef = ref<{ reset: () => void } | null>(null);
   const hasError = computed(() => !!errorMessage.value);
 
-  // Redirect if already authenticated
+  // Redirect if already authenticated; otherwise stash the redirect intent so
+  // /auth/callback can honor it after the OAuth / magic-link round trip (the
+  // Supabase redirect lands on /auth/callback with no room for extra params).
   onMounted(async () => {
     const { initAuth } = useAuth();
     await initAuth();
     if (isAuthenticated.value) {
-      navigateTo('/admin', { replace: true });
+      try {
+        window.localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+      } catch {
+        // localStorage unavailable (private mode) — nothing to clear.
+      }
+      navigateTo(requestedRedirect.value || '/admin', { replace: true });
+      return;
+    }
+    if (requestedRedirect.value) {
+      try {
+        window.localStorage.setItem(POST_AUTH_REDIRECT_KEY, requestedRedirect.value);
+      } catch {
+        // localStorage unavailable — the user still lands on the site after
+        // auth, just without the preserved intent.
+      }
     }
   });
 

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -70,19 +70,11 @@
             </div>
 
             <div class="flex justify-center">
-              <NuxtTurnstile
-                ref="turnstileRef"
-                v-model="turnstileToken"
-                :options="{ theme: 'auto' }"
-              />
+              <NuxtTurnstile ref="turnstileRef" v-model="turnstileToken" :options="{ theme: 'auto' }" />
             </div>
 
             <div class="mt-6">
-              <button
-                type="submit"
-                class="btn btn-primary btn-block"
-                :disabled="isLoading || !turnstileToken"
-              >
+              <button type="submit" class="btn btn-primary btn-block" :disabled="isLoading || !turnstileToken">
                 <i v-if="isLoading" class="fas fa-spinner fa-spin"></i>
                 <i v-else class="fad fa-paper-plane"></i>
                 {{ isLoading ? t('sending') : t('send_magic_link') }}
@@ -112,6 +104,8 @@
 </template>
 
 <script setup lang="ts">
+  import { sanitizeRedirectPath } from '../utils/redirect';
+
   const { t } = useI18n();
 
   // SEO and meta
@@ -136,13 +130,12 @@
   const emailDomain = (addr: string) => (addr.includes('@') ? addr.split('@')[1] : undefined);
 
   // Post-auth redirect intent (e.g. /login?redirect=%2Fmembership%3Fsubscribe%3D1
-  // from the membership page). Internal paths only — never an absolute URL or
-  // protocol-relative //host, so the param can't be abused as an open redirect.
+  // from the membership page). Internal paths only — the shared validator
+  // rejects absolute URLs, protocol-relative //host, backslash variants
+  // (browsers normalize \ to /), and control characters, so the param can't
+  // be abused as an open redirect.
   const POST_AUTH_REDIRECT_KEY = 'cmdiy-post-auth-redirect';
-  const requestedRedirect = computed(() => {
-    const r = route.query.redirect;
-    return typeof r === 'string' && r.startsWith('/') && !r.startsWith('//') ? r : null;
-  });
+  const requestedRedirect = computed(() => sanitizeRedirectPath(route.query.redirect));
 
   // Reactive state
   const email = ref('');
@@ -168,13 +161,18 @@
       navigateTo(requestedRedirect.value || '/admin', { replace: true });
       return;
     }
-    if (requestedRedirect.value) {
-      try {
+    try {
+      if (requestedRedirect.value) {
         window.localStorage.setItem(POST_AUTH_REDIRECT_KEY, requestedRedirect.value);
-      } catch {
-        // localStorage unavailable — the user still lands on the site after
-        // auth, just without the preserved intent.
+      } else {
+        // No intent on this visit: clear any stale stash from an abandoned
+        // earlier attempt so a later unrelated sign-in can't replay it (e.g.
+        // surprise-launching a Stripe checkout).
+        window.localStorage.removeItem(POST_AUTH_REDIRECT_KEY);
       }
+    } catch {
+      // localStorage unavailable — the user still lands on the site after
+      // auth, just without the preserved intent.
     }
   });
 

--- a/app/pages/membership/claim.vue
+++ b/app/pages/membership/claim.vue
@@ -1,0 +1,283 @@
+<script lang="ts" setup>
+  const { t } = useI18n();
+  const route = useRoute();
+  const supabase = useSupabase();
+  const { track } = useAnalytics();
+  const { add: addToast } = useToast();
+  const { isAuthenticated, user, waitForAuth, fetchUserProfile } = useAuth();
+
+  // The emailed claim link (Ghost/Patreon inbound channels) lands here as
+  // /membership/claim?code=<claim_jti>. Redemption = claim_external_membership(p_code)
+  // while signed in: it writes the subscriptions row (fan-out: badge, Discord,
+  // Ghost comp, TME listings) and marks the pending row claimed. The RPC is
+  // idempotent for the same user re-clicking the same emailed link.
+  const code = computed(() => {
+    const raw = route.query.code;
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+  });
+
+  // Logged-out claim intent: same /login?redirect= round trip the membership
+  // page uses (login re-validates via sanitizeRedirectPath and stashes the path
+  // in localStorage; /auth/callback consumes it after the OAuth/magic-link
+  // round trip). Re-encode the code so the query survives both decode passes.
+  const claimIntentPath = computed(() =>
+    code.value ? `/membership/claim?code=${encodeURIComponent(code.value)}` : '/membership/claim'
+  );
+  const loginWithIntentHref = computed(() => `/login?redirect=${encodeURIComponent(claimIntentPath.value)}`);
+
+  type ClaimState =
+    | 'checking' // resolving auth / about to redeem
+    | 'missing_code' // no ?code= in the URL
+    | 'signin' // logged out — needs the login round trip first
+    | 'redeeming' // RPC in flight
+    | 'success' // membership attached
+    | 'invalid' // unknown / malformed code (P0002 generic, 22004)
+    | 'already_claimed' // code consumed by a different account
+    | 'expired' // stale link (>30 days) — reconciliation cron re-issues
+    | 'error'; // transient RPC/network failure — retryable
+  const state = ref<ClaimState>('checking');
+
+  // Let the user actually see the success card before landing on /membership.
+  const SUCCESS_REDIRECT_DELAY_MS = 1500;
+
+  // Map RPC failures onto distinct friendly states. All three business errors
+  // raise ERRCODE P0002 with distinct messages (see migration
+  // 20260609000001_inbound_membership_channels.sql), so the message is the
+  // discriminator; anything else is treated as transient and retryable.
+  function handleClaimError(error: { code?: string; message?: string } | null) {
+    const message = error?.message ?? '';
+    let reason: string;
+    if (message.includes('already been claimed')) {
+      state.value = 'already_claimed';
+      reason = 'already_claimed';
+    } else if (message.includes('expired') && message.includes('emailed')) {
+      state.value = 'expired';
+      reason = 'expired';
+    } else if (error?.code === 'P0002' || error?.code === '22004') {
+      state.value = 'invalid';
+      reason = 'invalid';
+    } else {
+      state.value = 'error';
+      reason = 'rpc_error';
+    }
+    track('membership_claim_failed', { source: 'web', reason, error_code: error?.code });
+  }
+
+  async function redeem() {
+    if (!code.value) return;
+    state.value = 'redeeming';
+    try {
+      // Cast the RPC name until types/database.ts is regenerated post-deploy
+      // (same precedent as get_my_membership on /membership).
+      const { data, error } = await supabase.rpc('claim_external_membership' as any, { p_code: code.value });
+      if (error) {
+        console.error('Membership claim failed:', error);
+        handleClaimError(error);
+        return;
+      }
+      // RETURNS TABLE → PostgREST hands back an array of rows.
+      const row = (Array.isArray(data) ? data[0] : data) as { platform?: string | null } | undefined;
+      track('membership_claim_redeemed', { source: 'web', platform: row?.platform ?? undefined });
+      state.value = 'success';
+      addToast({
+        title: t('toasts.success_title'),
+        description: t('toasts.success_body'),
+        color: 'success',
+        icon: 'i-fa6-solid-circle-check',
+        timeout: 8000,
+      });
+      // The RPC writes the subscriptions row synchronously — refresh the shared
+      // membership gate so /membership renders the member area on arrival.
+      if (user.value) await fetchUserProfile(user.value.id);
+      setTimeout(() => navigateTo('/membership'), SUCCESS_REDIRECT_DELAY_MS);
+    } catch (err) {
+      console.error('Membership claim failed:', err);
+      track('membership_claim_failed', { source: 'web', reason: 'exception' });
+      state.value = 'error';
+    }
+  }
+
+  onMounted(async () => {
+    if (!code.value) {
+      state.value = 'missing_code';
+      track('membership_claim_failed', { source: 'web', reason: 'missing_code' });
+      return;
+    }
+    await waitForAuth();
+    if (!isAuthenticated.value) {
+      state.value = 'signin';
+      return;
+    }
+    await redeem();
+  });
+
+  // Transient page reached from a single-use emailed link — never index it.
+  useHead({
+    title: t('meta.title'),
+    meta: [{ name: 'robots', content: 'noindex, nofollow' }],
+  });
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-base-200 px-4">
+    <div class="card bg-base-100 shadow-md border border-base-300 w-full max-w-md">
+      <ClientOnly>
+        <div class="card-body items-center text-center">
+          <span class="eyebrow mb-1">{{ t('eyebrow') }}</span>
+
+          <!-- Resolving auth -->
+          <template v-if="state === 'checking'">
+            <span class="loading loading-spinner loading-lg text-primary mt-4"></span>
+            <p class="opacity-70 mt-3">{{ t('checking') }}</p>
+          </template>
+
+          <!-- RPC in flight -->
+          <template v-else-if="state === 'redeeming'">
+            <span class="loading loading-spinner loading-lg text-primary mt-4"></span>
+            <h1 class="text-2xl font-bold mt-3">{{ t('redeeming.title') }}</h1>
+            <p class="opacity-70">{{ t('redeeming.body') }}</p>
+          </template>
+
+          <!-- Membership attached -->
+          <template v-else-if="state === 'success'">
+            <i class="fas fa-circle-check text-4xl text-success mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('success.title') }}</h1>
+            <p class="opacity-70">{{ t('success.body') }}</p>
+            <NuxtLink to="/membership" class="btn btn-primary mt-4">
+              <i class="fas fa-star"></i>
+              {{ t('success.cta') }}
+            </NuxtLink>
+          </template>
+
+          <!-- Logged out: claim intent rides the existing /login?redirect= flow -->
+          <template v-else-if="state === 'signin'">
+            <i class="fas fa-right-to-bracket text-4xl text-primary mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('signin.title') }}</h1>
+            <p class="opacity-70">{{ t('signin.body') }}</p>
+            <NuxtLink :to="loginWithIntentHref" class="btn btn-primary mt-4">
+              <i class="fas fa-right-to-bracket"></i>
+              {{ t('signin.cta') }}
+            </NuxtLink>
+          </template>
+
+          <!-- No ?code= in the URL -->
+          <template v-else-if="state === 'missing_code'">
+            <i class="fas fa-circle-exclamation text-4xl text-warning mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('missing_code.title') }}</h1>
+            <p class="opacity-70">{{ t('missing_code.body') }}</p>
+            <NuxtLink to="/membership" class="btn btn-primary mt-4">
+              <i class="fas fa-star"></i>
+              {{ t('membership_link') }}
+            </NuxtLink>
+          </template>
+
+          <!-- Code consumed by a different account -->
+          <template v-else-if="state === 'already_claimed'">
+            <i class="fas fa-user-lock text-4xl text-warning mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('already_claimed.title') }}</h1>
+            <p class="opacity-70">{{ t('already_claimed.body') }}</p>
+          </template>
+
+          <!-- Stale link (>30 days) — a fresh one is re-issued automatically -->
+          <template v-else-if="state === 'expired'">
+            <i class="fas fa-hourglass-half text-4xl text-warning mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('expired.title') }}</h1>
+            <p class="opacity-70">{{ t('expired.body') }}</p>
+          </template>
+
+          <!-- Unknown / malformed code -->
+          <template v-else-if="state === 'invalid'">
+            <i class="fas fa-circle-xmark text-4xl text-error mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('invalid.title') }}</h1>
+            <p class="opacity-70">{{ t('invalid.body') }}</p>
+          </template>
+
+          <!-- Transient RPC/network failure -->
+          <template v-else>
+            <i class="fas fa-triangle-exclamation text-4xl text-error mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('error.title') }}</h1>
+            <p class="opacity-70">{{ t('error.body') }}</p>
+            <button type="button" class="btn btn-primary mt-4" @click="redeem">
+              <i class="fas fa-rotate-right"></i>
+              {{ t('error.retry') }}
+            </button>
+          </template>
+
+          <!-- Contact fallback on every dead-end error state -->
+          <p
+            v-if="state === 'invalid' || state === 'already_claimed' || state === 'expired' || state === 'error'"
+            class="text-sm opacity-70 mt-4"
+          >
+            {{ t('contact_question') }}
+            <NuxtLink to="/contact" class="link link-primary">{{ t('contact_cta') }}</NuxtLink>
+          </p>
+        </div>
+
+        <template #fallback>
+          <!-- SSR / pre-hydration: matches the 'checking' state so there is no
+               flash between server render and the resolved client state. -->
+          <div class="card-body items-center text-center">
+            <span class="eyebrow mb-1">{{ t('eyebrow') }}</span>
+            <span class="loading loading-spinner loading-lg text-primary mt-4"></span>
+            <p class="opacity-70 mt-3">{{ t('checking') }}</p>
+          </div>
+        </template>
+      </ClientOnly>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "meta": {
+      "title": "Claim your membership — Classic Mini DIY"
+    },
+    "eyebrow": "SUSTAINING MEMBER",
+    "checking": "Checking your claim link…",
+    "redeeming": {
+      "title": "Activating your membership…",
+      "body": "Hang tight — we're attaching your Sustaining Membership to this account."
+    },
+    "signin": {
+      "title": "Sign in to claim your membership",
+      "body": "You're almost there — sign in (or create a free account) and we'll attach your Sustaining Membership to it. You'll come right back here afterwards.",
+      "cta": "Sign in to claim"
+    },
+    "success": {
+      "title": "Your membership is active!",
+      "body": "Welcome, Sustaining Member — your benefits are switched on across every Classic Mini DIY property.",
+      "cta": "See your benefits"
+    },
+    "missing_code": {
+      "title": "That link is missing its claim code",
+      "body": "This page only works from the claim link in your membership email. Open the email and click the button again — or learn more about Sustaining Membership below."
+    },
+    "already_claimed": {
+      "title": "This membership was already claimed",
+      "body": "This claim link has already been used on a different account. If that doesn't sound right — maybe you signed in with another email — we can move it for you."
+    },
+    "expired": {
+      "title": "This claim link has expired",
+      "body": "Claim links are valid for 30 days. No need to do anything — a fresh link is on its way to your inbox automatically."
+    },
+    "invalid": {
+      "title": "We couldn't find that claim code",
+      "body": "This claim link doesn't match a pending membership. Double-check you opened the most recent email — older links stop working once a newer one is issued."
+    },
+    "error": {
+      "title": "Something went wrong",
+      "body": "We couldn't reach the membership service just now. Your claim link is still valid — give it another try.",
+      "retry": "Try again"
+    },
+    "contact_question": "Something not right?",
+    "contact_cta": "Contact us and we'll sort it out.",
+    "membership_link": "About Sustaining Membership",
+    "toasts": {
+      "success_title": "Your membership is active!",
+      "success_body": "Thanks for supporting Classic Mini DIY — your benefits are live everywhere you sign in."
+    }
+  }
+}
+</i18n>

--- a/app/pages/membership/index.vue
+++ b/app/pages/membership/index.vue
@@ -24,6 +24,50 @@
   const authReady = ref(false);
   const checkoutLoading = ref(false);
 
+  // Logged-out subscribe intent (pre-launch punch list D1): route the visitor
+  // through sign-in with the intent preserved as ?subscribe=1, so after auth
+  // they land back here and checkout auto-starts (see onMounted). The login
+  // page persists the redirect across the OAuth/magic-link round trip.
+  const SUBSCRIBE_INTENT_PATH = '/membership?subscribe=1';
+  const loginWithIntentHref = `/login?redirect=${encodeURIComponent(SUBSCRIBE_INTENT_PATH)}`;
+
+  // Post-checkout activation poll (punch list D1): on return with ?subscribed=1
+  // the Stripe webhook may not have written the subscriptions row yet, so a
+  // single re-pull can still show the subscribe CTA to the user who just paid.
+  // Poll the membership gate every ~2s for up to ~30s, showing "Activating…"
+  // instead of the CTA; on timeout show a gentle refresh note. (The server-side
+  // double-billing guard is the backend half — punch list B1.)
+  const ACTIVATION_POLL_INTERVAL_MS = 2000;
+  const ACTIVATION_POLL_MAX_ATTEMPTS = 15; // ~30s total
+  const activationState = ref<'idle' | 'polling' | 'timeout'>('idle');
+  let activationStopped = false;
+  onUnmounted(() => {
+    activationStopped = true;
+  });
+
+  async function pollMembershipActivation() {
+    if (!user.value || isSustainingMember.value) return;
+    activationState.value = 'polling';
+    for (let attempt = 0; attempt < ACTIVATION_POLL_MAX_ATTEMPTS; attempt++) {
+      await fetchUserProfile(user.value.id);
+      if (activationStopped) return;
+      if (isSustainingMember.value) {
+        activationState.value = 'idle';
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, ACTIVATION_POLL_INTERVAL_MS));
+      if (activationStopped) return;
+    }
+    activationState.value = 'timeout';
+  }
+
+  // Hero price badge: gate on resolved auth so members never see a
+  // "$1.99/month" flash before membership resolves; also hidden while the
+  // activation poll runs (the user just paid).
+  const showPriceBadge = computed(
+    () => authReady.value && !isSustainingMember.value && activationState.value === 'idle'
+  );
+
   async function getAccessToken(): Promise<string | null> {
     const {
       data: { session },
@@ -36,7 +80,7 @@
   // users are routed through sign-in first so the webhook can attribute the row.
   async function subscribe() {
     if (!isAuthenticated.value) {
-      navigateTo('/login');
+      navigateTo(loginWithIntentHref);
       return;
     }
     checkoutLoading.value = true;
@@ -171,9 +215,10 @@
     await waitForAuth();
     authReady.value = true;
 
-    // Stripe returns to /membership?subscribed=1 or ?canceled=1. Process once,
-    // then strip the params so a refresh doesn't replay the toast.
-    if (route.query.subscribed || route.query.canceled) {
+    // Stripe returns to /membership?subscribed=1 or ?canceled=1; sign-in
+    // returns with ?subscribe=1 (preserved intent). Process once, then strip
+    // the params so a refresh doesn't replay the toast / checkout.
+    if (route.query.subscribed || route.query.canceled || route.query.subscribe) {
       if (route.query.subscribed) {
         track('membership_checkout_succeeded', { source: 'web' });
         addToast({
@@ -183,10 +228,11 @@
           icon: 'i-fa6-solid-circle-check',
           timeout: 8000,
         });
-        // The subscriptions row is written asynchronously by the webhook; re-pull
-        // profile + membership so the badge/management area reflects it soon.
-        if (user.value) fetchUserProfile(user.value.id);
-      } else {
+        // The subscriptions row is written asynchronously by the webhook; poll
+        // the membership gate until it flips (or gently time out) so the payer
+        // never sees the subscribe CTA again during the race window.
+        pollMembershipActivation();
+      } else if (route.query.canceled) {
         addToast({
           title: t('toasts.canceled_title'),
           description: t('toasts.canceled_body'),
@@ -194,8 +240,17 @@
           icon: 'i-fa6-solid-circle-info',
         });
       }
-      const { subscribed: _subscribed, canceled: _canceled, ...rest } = route.query;
+      // Restored sign-in intent: auto-start checkout for an authenticated
+      // non-member. Members and logged-out visitors just see the page.
+      const shouldAutoSubscribe =
+        route.query.subscribe === '1' &&
+        !route.query.subscribed &&
+        !route.query.canceled &&
+        isAuthenticated.value &&
+        !isSustainingMember.value;
+      const { subscribed: _subscribed, canceled: _canceled, subscribe: _subscribe, ...rest } = route.query;
       router.replace({ query: rest });
+      if (shouldAutoSubscribe) subscribe();
     }
   });
 
@@ -217,7 +272,7 @@
         <div class="max-w-2xl">
           <span class="eyebrow"><i class="fas fa-star mr-1 text-warning"></i>{{ t('hero.eyebrow') }}</span>
           <h1 class="text-4xl sm:text-5xl font-bold pt-2 pb-4">{{ t('hero.title') }}</h1>
-          <div v-if="!isSustainingMember" class="badge badge-warning badge-lg font-semibold gap-1 mb-4">
+          <div v-if="showPriceBadge" class="badge badge-warning badge-lg font-semibold gap-1 mb-4">
             <i class="fas fa-tag"></i> {{ t('hero.price') }}
           </div>
           <p class="text-lg opacity-80">{{ t('hero.subtitle') }}</p>
@@ -278,6 +333,15 @@
                   <span class="badge badge-sm ml-1" :class="discordBadgeClass">{{ discordStatusLabel }}</span>
                 </p>
                 <p class="text-sm opacity-70 mt-1">{{ discordGuidance }}</p>
+                <!-- No self-serve re-issue endpoint exists yet (backend
+                     follow-up); until then, support re-sends invites manually. -->
+                <p
+                  v-if="discordStatusKey === 'pending' || discordStatusKey === 'not_connected'"
+                  class="text-xs opacity-60 mt-2"
+                >
+                  {{ t('member.discord_lost_email') }}
+                  <NuxtLink to="/contact" class="link link-primary">{{ t('member.discord_contact_cta') }}</NuxtLink>
+                </p>
               </div>
               <!-- Pro blog access -->
               <div class="rounded-box border border-base-300 p-4">
@@ -321,6 +385,42 @@
             >
               <i class="fas fa-mobile-screen mr-2 text-primary"></i>{{ t('member.manage_note_store') }}
             </p>
+            <p v-else-if="membershipPlatform === 'ghost'" class="text-sm opacity-70 mt-4">
+              <i class="fas fa-book-open mr-2 text-primary"></i>{{ t('member.manage_note_ghost') }}
+            </p>
+            <p v-else-if="membershipPlatform === 'patreon'" class="text-sm opacity-70 mt-4">
+              <i class="fab fa-patreon mr-2 text-primary"></i>
+              <a
+                href="https://www.patreon.com/settings/memberships"
+                target="_blank"
+                rel="noopener"
+                class="link link-primary"
+                >{{ t('member.manage_note_patreon') }}</a
+              >
+            </p>
+            <!-- Unknown/null platform on an active member: never render an
+                 empty manage area (parity with TME). -->
+            <p v-else class="text-sm opacity-70 mt-4">
+              <i class="fas fa-circle-check mr-2 text-success"></i>{{ t('member.active_fallback') }}
+            </p>
+          </div>
+        </section>
+
+        <!-- Post-checkout webhook race window: "Activating…" instead of the
+             subscribe CTA while the membership gate is polled (punch list D1). -->
+        <section v-else-if="activationState === 'polling'" class="card bg-base-100 border border-base-300 shadow-md">
+          <div class="card-body items-center text-center py-12">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <h2 class="text-xl font-bold mt-3">{{ t('cta.activating_title') }}</h2>
+            <p class="opacity-60 max-w-lg">{{ t('cta.activating_body') }}</p>
+          </div>
+        </section>
+
+        <section v-else-if="activationState === 'timeout'" class="card bg-base-100 border border-base-300 shadow-md">
+          <div class="card-body items-center text-center py-12">
+            <i class="fas fa-hourglass-half text-3xl text-warning"></i>
+            <h2 class="text-xl font-bold mt-3">{{ t('cta.activation_timeout_title') }}</h2>
+            <p class="opacity-60 max-w-lg">{{ t('cta.activation_timeout_body') }}</p>
           </div>
         </section>
 
@@ -341,7 +441,7 @@
                 <i v-else class="fas fa-star"></i>
                 {{ t('cta.subscribe') }}
               </button>
-              <NuxtLink v-else to="/login" class="btn btn-primary btn-lg">
+              <NuxtLink v-else :to="loginWithIntentHref" class="btn btn-primary btn-lg">
                 <i class="fas fa-right-to-bracket"></i>
                 {{ t('cta.signin') }}
               </NuxtLink>
@@ -421,6 +521,10 @@
       "title": "Become a Sustaining Member",
       "subtitle": "$1.99/month, cancel anytime. Your membership unlocks benefits across every Classic Mini DIY property.",
       "checking": "Checking your membership…",
+      "activating_title": "Activating your membership…",
+      "activating_body": "Payment received — we're switching on your benefits. This usually takes a few seconds.",
+      "activation_timeout_title": "Taking longer than expected",
+      "activation_timeout_body": "Your payment went through, but activation is taking a little longer than usual. Refresh this page in a minute — if your membership still isn't active, reach out via the contact page and we'll sort it out.",
       "subscribe": "Become a Sustaining Member — $1.99/mo",
       "signin": "Sign in to become a member",
       "also_apps": "Also available in the iOS and Android apps."
@@ -446,10 +550,15 @@
       "blog_title": "Pro access to the blog",
       "blog_desc": "Complimentary access to subscriber content on the Classic Mini DIY blog.",
       "blog_cta": "Open the blog",
+      "discord_lost_email": "Lost the invite email?",
+      "discord_contact_cta": "Contact us and we'll resend it.",
       "manage": "Manage membership",
       "manage_note_stripe": "Manage or cancel your membership any time through Stripe.",
       "comp_note": "Your membership is complimentary — enjoy all the benefits, on us. There's nothing to manage.",
-      "manage_note_store": "Manage or cancel your subscription in the App Store or Google Play, wherever you subscribed."
+      "manage_note_store": "Manage or cancel your subscription in the App Store or Google Play, wherever you subscribed.",
+      "manage_note_ghost": "Manage your membership through your Ghost account billing email.",
+      "manage_note_patreon": "Manage your pledge on Patreon.",
+      "active_fallback": "Your membership is active."
     },
     "errors": {
       "checkout_title": "Checkout unavailable",

--- a/app/pages/membership/index.vue
+++ b/app/pages/membership/index.vue
@@ -49,6 +49,13 @@
     if (!user.value || isSustainingMember.value) return;
     activationState.value = 'polling';
     for (let attempt = 0; attempt < ACTIVATION_POLL_MAX_ATTEMPTS; attempt++) {
+      // Signed out (or session expired) mid-poll: there's nothing to activate
+      // for this browser anymore — stop quietly instead of crashing on a null
+      // user.
+      if (!user.value) {
+        activationState.value = 'idle';
+        return;
+      }
       await fetchUserProfile(user.value.id);
       if (activationStopped) return;
       if (isSustainingMember.value) {
@@ -88,7 +95,9 @@
     try {
       const token = await getAccessToken();
       if (!token) {
-        navigateTo('/login');
+        // Session evaporated between the auth check and checkout — send them
+        // back through sign-in with the subscribe intent preserved.
+        navigateTo(loginWithIntentHref);
         return;
       }
       const res = await $fetch<{ url?: string }>('/api/membership/checkout', {
@@ -286,11 +295,7 @@
         <p class="eyebrow text-center"><i class="fas fa-list-check mr-1"></i>{{ t('benefits.eyebrow') }}</p>
         <h2 class="text-3xl font-bold text-center pt-2 pb-8">{{ t('benefits.title') }}</h2>
         <ul class="benefits-list grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <li
-            v-for="benefit in benefits"
-            :key="benefit.key"
-            class="card bg-base-100 border border-base-300 shadow-sm"
-          >
+          <li v-for="benefit in benefits" :key="benefit.key" class="card bg-base-100 border border-base-300 shadow-sm">
             <div class="card-body p-5 flex-row items-start gap-4">
               <span class="text-2xl text-primary shrink-0 mt-1">
                 <i :class="benefit.icon"></i>
@@ -345,7 +350,9 @@
               </div>
               <!-- Pro blog access -->
               <div class="rounded-box border border-base-300 p-4">
-                <p class="font-semibold"><i class="fas fa-book-open mr-2 text-primary"></i>{{ t('member.blog_title') }}</p>
+                <p class="font-semibold">
+                  <i class="fas fa-book-open mr-2 text-primary"></i>{{ t('member.blog_title') }}
+                </p>
                 <p class="text-sm opacity-70 mt-1">{{ t('member.blog_desc') }}</p>
                 <a
                   v-if="blogUrl"
@@ -447,9 +454,7 @@
               </NuxtLink>
             </div>
 
-            <p class="text-sm opacity-60 mt-3">
-              <i class="fas fa-mobile-screen mr-1"></i>{{ t('cta.also_apps') }}
-            </p>
+            <p class="text-sm opacity-60 mt-3"><i class="fas fa-mobile-screen mr-1"></i>{{ t('cta.also_apps') }}</p>
           </div>
         </section>
 

--- a/app/pages/welcome.vue
+++ b/app/pages/welcome.vue
@@ -122,6 +122,8 @@
 </template>
 
 <script setup lang="ts">
+  import { sanitizeRedirectPath } from '../utils/redirect';
+
   const { t } = useI18n();
 
   // SEO and meta
@@ -151,14 +153,11 @@
   const saveError = ref('');
   const saveSuccess = ref(false);
 
-  // Redirect target from query param or default to home
-  const redirectTo = computed(() => {
-    const redirect = route.query.redirect;
-    if (typeof redirect === 'string' && redirect.startsWith('/')) {
-      return redirect;
-    }
-    return '/';
-  });
+  // Redirect target from query param or default to home. Validated with the
+  // shared internal-path validator — this page is directly linkable, so the
+  // param must never become an open redirect (rejects //host, backslashes,
+  // control characters, absolute URLs).
+  const redirectTo = computed(() => sanitizeRedirectPath(route.query.redirect) ?? '/');
 
   // Auth check on mount
   onMounted(async () => {

--- a/app/utils/redirect.ts
+++ b/app/utils/redirect.ts
@@ -1,0 +1,24 @@
+/**
+ * Post-auth redirect validation (pre-launch punch list D1).
+ *
+ * Accepts only same-site path redirects, rejecting every known open-redirect
+ * shape — used by /login (?redirect= → localStorage), /auth/callback
+ * (localStorage consume), and /welcome (?redirect=). Keep all three on this
+ * single validator so a bypass can't be reintroduced in one of them.
+ *
+ * Rejected shapes:
+ *  - absolute URLs (`https://evil.com`, `javascript:…`) — no leading `/`
+ *  - protocol-relative (`//evil.com`)
+ *  - backslash variants (`/\evil.com`, `/\\evil.com`) — browsers normalize
+ *    `\` to `/`, turning them protocol-relative
+ *  - control characters (tab/newline/NUL) — stripped by browser URL parsers,
+ *    which could resurrect a rejected shape
+ */
+const CONTROL_CHARS = /[\u0000-\u001F\u007F]/;
+
+export function sanitizeRedirectPath(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  if (!value.startsWith('/') || value.startsWith('//')) return null;
+  if (value.includes('\\') || CONTROL_CHARS.test(value)) return null;
+  return value;
+}

--- a/public/api/app-config.json
+++ b/public/api/app-config.json
@@ -1,4 +1,5 @@
 {
   "backend": "supabase",
-  "rollout_percent": 100
+  "rollout_percent": 100,
+  "tme_free_listings": true
 }

--- a/tests/unit/pages/membership-claim.test.ts
+++ b/tests/unit/pages/membership-claim.test.ts
@@ -1,0 +1,292 @@
+// @vitest-environment happy-dom
+/**
+ * Membership claim page (app/pages/membership/claim.vue) — inbound channels.
+ *
+ * The Ghost-direct / Patreon reconciliation emails link unmatched payers to
+ * /membership/claim?code=<claim_jti>. Covers:
+ *  - missing/blank ?code= → friendly error card, RPC never called
+ *  - logged out → /login?redirect=… intent that survives the encode/decode
+ *    round trip through sanitizeRedirectPath (the same validator /login and
+ *    /auth/callback use)
+ *  - signed in → claim_external_membership(p_code) → success card + toast +
+ *    navigate to /membership
+ *  - distinct error states: already-claimed (other account), invalid code,
+ *    expired link, transient RPC failure with a retry affordance
+ *
+ * The i18n mock returns translation keys verbatim, so assertions match keys.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref, computed, nextTick } from 'vue';
+import ClaimPage from '~/app/pages/membership/claim.vue';
+import { sanitizeRedirectPath } from '~/app/utils/redirect';
+
+const baseUser = { id: 'user-1', email: 'patron@example.com' };
+const CODE = '4f9d2c6a-1b3e-4a5d-9c7f-8e6b5a4d3c2b';
+
+interface AuthStubOptions {
+  user?: typeof baseUser | null;
+}
+
+function makeAuthStub({ user = baseUser }: AuthStubOptions = {}) {
+  const userRef = ref<typeof baseUser | null>(user);
+  const fetchUserProfile = vi.fn().mockResolvedValue(undefined);
+  const stub = {
+    user: userRef,
+    isAuthenticated: computed(() => !!userRef.value),
+    waitForAuth: vi.fn().mockResolvedValue(true),
+    fetchUserProfile,
+  };
+  return { stub, userRef, fetchUserProfile };
+}
+
+/** Stub supabase whose rpc() resolves with the given { data, error } shapes in order. */
+function makeSupabaseStub(results: Array<{ data?: unknown; error?: { code?: string; message?: string } | null }>) {
+  const rpc = vi.fn();
+  for (const result of results) {
+    rpc.mockResolvedValueOnce({ data: result.data ?? null, error: result.error ?? null });
+  }
+  return { rpc };
+}
+
+const mountStubs = {
+  NuxtLink: { name: 'NuxtLink', template: '<a :href="to"><slot /></a>', props: ['to'] },
+  ClientOnly: { name: 'ClientOnly', template: '<div><slot /></div>' },
+};
+
+let toastAdd: ReturnType<typeof vi.fn>;
+let navigateToMock: ReturnType<typeof vi.fn>;
+let trackMock: ReturnType<typeof vi.fn>;
+
+function stubEnvironment({
+  query = {} as Record<string, string>,
+  auth,
+  supabase,
+}: {
+  query?: Record<string, string>;
+  auth: ReturnType<typeof makeAuthStub>;
+  supabase?: ReturnType<typeof makeSupabaseStub>;
+}) {
+  toastAdd = vi.fn();
+  navigateToMock = vi.fn();
+  trackMock = vi.fn();
+
+  vi.stubGlobal('useAuth', () => auth.stub);
+  vi.stubGlobal('useSupabase', () => supabase ?? makeSupabaseStub([]));
+  vi.stubGlobal('useToast', () => ({ add: toastAdd }));
+  vi.stubGlobal('useAnalytics', () => ({ track: trackMock }));
+  vi.stubGlobal('navigateTo', navigateToMock);
+  vi.stubGlobal('useRoute', () => ({
+    path: '/membership/claim',
+    fullPath: '/membership/claim',
+    name: 'membership-claim',
+    params: {},
+    meta: {},
+    matched: [],
+    query,
+  }));
+}
+
+function mountPage() {
+  return mount(ClaimPage, { global: { stubs: mountStubs } });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  (global as any).__resetNuxtState?.();
+});
+
+// ---------------------------------------------------------------------------
+// Missing / blank ?code=
+// ---------------------------------------------------------------------------
+describe('missing claim code', () => {
+  it('shows the friendly missing-code card and never calls the RPC', async () => {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([]);
+    stubEnvironment({ auth, supabase });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.html()).toContain('missing_code.title');
+    expect(supabase.rpc).not.toHaveBeenCalled();
+    // Link back to the membership page, not a dead end.
+    expect(wrapper.find('a[href="/membership"]').exists()).toBe(true);
+    expect(trackMock).toHaveBeenCalledWith('membership_claim_failed', expect.objectContaining({ reason: 'missing_code' }));
+  });
+
+  it('treats a whitespace-only code as missing', async () => {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([]);
+    stubEnvironment({ query: { code: '   ' }, auth, supabase });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.html()).toContain('missing_code.title');
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Logged out → /login?redirect= round trip
+// ---------------------------------------------------------------------------
+describe('logged-out claim intent', () => {
+  it('routes through /login?redirect= preserving the encoded code end-to-end', async () => {
+    const auth = makeAuthStub({ user: null });
+    stubEnvironment({ query: { code: CODE }, auth });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.html()).toContain('signin.cta');
+    const expectedPath = `/membership/claim?code=${encodeURIComponent(CODE)}`;
+    const link = wrapper.find(`a[href="/login?redirect=${encodeURIComponent(expectedPath)}"]`);
+    expect(link.exists()).toBe(true);
+
+    // Simulate the full round trip: the router decodes ?redirect= once for
+    // /login (route.query.redirect), which re-validates it with the shared
+    // sanitizer before stashing; /auth/callback then navigateTo()s the path
+    // and the router decodes ?code= once more on arrival.
+    const href = link.attributes('href')!;
+    const redirectParam = new URL(href, 'https://classicminidiy.com').searchParams.get('redirect');
+    const sanitized = sanitizeRedirectPath(redirectParam);
+    expect(sanitized).toBe(expectedPath);
+    const restoredCode = new URL(sanitized!, 'https://classicminidiy.com').searchParams.get('code');
+    expect(restoredCode).toBe(CODE);
+  });
+
+  it('survives the round trip for codes containing reserved URL characters', async () => {
+    const trickyCode = 'Ab3/+=&?';
+    const auth = makeAuthStub({ user: null });
+    stubEnvironment({ query: { code: trickyCode }, auth });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    const link = wrapper.find('a[href^="/login?redirect="]');
+    expect(link.exists()).toBe(true);
+    const href = link.attributes('href')!;
+    const redirectParam = new URL(href, 'https://classicminidiy.com').searchParams.get('redirect');
+    const sanitized = sanitizeRedirectPath(redirectParam);
+    expect(sanitized).not.toBeNull();
+    const restoredCode = new URL(sanitized!, 'https://classicminidiy.com').searchParams.get('code');
+    expect(restoredCode).toBe(trickyCode);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signed in → success path
+// ---------------------------------------------------------------------------
+describe('successful claim', () => {
+  it('calls the RPC with p_code, shows success, toasts, and navigates to /membership', async () => {
+    vi.useFakeTimers();
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([
+      { data: [{ platform: 'patreon', status: 'active', expires_at: '2026-07-01T00:00:00Z' }], error: null },
+    ]);
+    stubEnvironment({ query: { code: CODE }, auth, supabase });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    expect(supabase.rpc).toHaveBeenCalledWith('claim_external_membership', { p_code: CODE });
+    expect(wrapper.html()).toContain('success.title');
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ color: 'success' }));
+    expect(trackMock).toHaveBeenCalledWith(
+      'membership_claim_redeemed',
+      expect.objectContaining({ source: 'web', platform: 'patreon' })
+    );
+    // Membership gate refreshed so /membership shows the member area on arrival.
+    expect(auth.fetchUserProfile).toHaveBeenCalledWith(baseUser.id);
+    // Redirect fires after the short success-card beat.
+    expect(navigateToMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(navigateToMock).toHaveBeenCalledWith('/membership');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Distinct error states
+// ---------------------------------------------------------------------------
+describe('claim error states', () => {
+  async function mountWithRpcError(error: { code?: string; message?: string }) {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([{ data: null, error }]);
+    stubEnvironment({ query: { code: CODE }, auth, supabase });
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+    return { wrapper, supabase };
+  }
+
+  it('already-claimed (by another account) gets its own state with a contact fallback', async () => {
+    const { wrapper } = await mountWithRpcError({
+      code: 'P0002',
+      message: 'This membership has already been claimed',
+    });
+
+    expect(wrapper.html()).toContain('already_claimed.title');
+    expect(wrapper.html()).not.toContain('invalid.title');
+    expect(wrapper.find('a[href="/contact"]').exists()).toBe(true);
+    expect(navigateToMock).not.toHaveBeenCalled();
+    expect(toastAdd).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      'membership_claim_failed',
+      expect.objectContaining({ reason: 'already_claimed' })
+    );
+  });
+
+  it('invalid/unknown code gets the invalid state with a contact fallback', async () => {
+    const { wrapper } = await mountWithRpcError({ code: 'P0002', message: 'Invalid or expired claim code' });
+
+    expect(wrapper.html()).toContain('invalid.title');
+    expect(wrapper.find('a[href="/contact"]').exists()).toBe(true);
+    expect(trackMock).toHaveBeenCalledWith('membership_claim_failed', expect.objectContaining({ reason: 'invalid' }));
+  });
+
+  it('a stale 30-day link gets the expired state (a fresh link is re-emailed)', async () => {
+    const { wrapper } = await mountWithRpcError({
+      code: 'P0002',
+      message: 'This claim link has expired; a new one will be emailed shortly',
+    });
+
+    expect(wrapper.html()).toContain('expired.title');
+    expect(wrapper.html()).not.toContain('invalid.title');
+    expect(trackMock).toHaveBeenCalledWith('membership_claim_failed', expect.objectContaining({ reason: 'expired' }));
+  });
+
+  it('a transient RPC failure offers a retry that can then succeed', async () => {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([
+      { data: null, error: { message: 'TypeError: Failed to fetch' } },
+      { data: [{ platform: 'ghost', status: 'active', expires_at: null }], error: null },
+    ]);
+    stubEnvironment({ query: { code: CODE }, auth, supabase });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.html()).toContain('error.retry');
+    expect(trackMock).toHaveBeenCalledWith('membership_claim_failed', expect.objectContaining({ reason: 'rpc_error' }));
+
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+    await nextTick();
+
+    expect(supabase.rpc).toHaveBeenCalledTimes(2);
+    expect(wrapper.html()).toContain('success.title');
+    expect(trackMock).toHaveBeenCalledWith(
+      'membership_claim_redeemed',
+      expect.objectContaining({ source: 'web', platform: 'ghost' })
+    );
+  });
+});

--- a/tests/unit/pages/membership.test.ts
+++ b/tests/unit/pages/membership.test.ts
@@ -210,6 +210,32 @@ describe('activation poll on ?subscribed=1', () => {
     expect(wrapper.html()).toContain('member.title');
   });
 
+  it('stops polling quietly (no crash) when the user signs out mid-poll', async () => {
+    vi.useFakeTimers();
+    const auth = makeAuthStub({ member: false });
+    // Session disappears right after the first gate re-pull.
+    auth.fetchUserProfile.mockImplementation(async () => {
+      auth.userRef.value = null;
+    });
+    stubEnvironment({ query: { subscribed: '1' }, auth });
+
+    const wrapper = mountPage();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushMicrotasks();
+    expect(auth.fetchUserProfile).toHaveBeenCalledTimes(1);
+
+    // Next tick of the loop sees the null user and bails to idle — previously
+    // this dereferenced user.value.id and threw (PR #608 review feedback).
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+
+    expect(auth.fetchUserProfile).toHaveBeenCalledTimes(1);
+    expect(wrapper.html()).not.toContain('cta.activating_title');
+    expect(wrapper.html()).not.toContain('cta.activation_timeout_title');
+    // Logged-out CTA (sign-in) renders instead of a dead activating card.
+    expect(wrapper.html()).toContain('cta.signin');
+  });
+
   it('shows the gentle timeout note after ~30s without activation', async () => {
     vi.useFakeTimers();
     const auth = makeAuthStub({ member: false });

--- a/tests/unit/pages/membership.test.ts
+++ b/tests/unit/pages/membership.test.ts
@@ -1,0 +1,315 @@
+// @vitest-environment happy-dom
+/**
+ * Membership page (app/pages/membership/index.vue) — pre-launch punch list D1.
+ *
+ * Covers:
+ *  - post-checkout activation poll on ?subscribed=1 (webhook race window):
+ *    "Activating…" instead of the subscribe CTA, member area once the gate
+ *    flips, gentle timeout note after ~30s
+ *  - platform-aware manage branches: ghost / patreon / unknown-null fallback
+ *  - hero "$1.99/month" badge gated on resolved auth (no member flash)
+ *  - logged-out subscribe intent carried via /login?redirect=…&auto-start
+ *
+ * The i18n mock returns translation keys verbatim, so assertions match keys.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref, computed, nextTick } from 'vue';
+import MembershipPage from '~/app/pages/membership/index.vue';
+
+const baseUser = { id: 'user-1', email: 'member@example.com' };
+
+interface AuthStubOptions {
+  user?: typeof baseUser | null;
+  member?: boolean;
+  waitForAuth?: () => Promise<boolean>;
+}
+
+function makeAuthStub({ user = baseUser, member = false, waitForAuth }: AuthStubOptions = {}) {
+  const userRef = ref<typeof baseUser | null>(user);
+  const memberRef = ref(member);
+  const fetchUserProfile = vi.fn().mockResolvedValue(undefined);
+  const stub = {
+    user: userRef,
+    isAuthenticated: computed(() => !!userRef.value),
+    isSustainingMember: computed(() => memberRef.value),
+    waitForAuth: waitForAuth ? vi.fn(waitForAuth) : vi.fn().mockResolvedValue(true),
+    fetchUserProfile,
+  };
+  return { stub, userRef, memberRef, fetchUserProfile };
+}
+
+function makeSupabaseStub({ platform = null as string | null } = {}) {
+  const rpcSingle = vi.fn().mockResolvedValue({ data: { platform }, error: null });
+  return {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'test-token' } }, error: null }),
+    },
+    rpc: vi.fn(() => ({ single: rpcSingle })),
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+    _rpcSingle: rpcSingle,
+  };
+}
+
+const mountStubs = {
+  ProfileSustainingBadge: true,
+  NuxtLink: { name: 'NuxtLink', template: '<a :href="to"><slot /></a>', props: ['to'] },
+  ClientOnly: { name: 'ClientOnly', template: '<div><slot /></div>' },
+};
+
+let routerReplace: ReturnType<typeof vi.fn>;
+let toastAdd: ReturnType<typeof vi.fn>;
+let navigateToMock: ReturnType<typeof vi.fn>;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function stubEnvironment({
+  query = {} as Record<string, string>,
+  auth,
+  supabase,
+}: {
+  query?: Record<string, string>;
+  auth: ReturnType<typeof makeAuthStub>;
+  supabase?: ReturnType<typeof makeSupabaseStub>;
+}) {
+  routerReplace = vi.fn();
+  toastAdd = vi.fn();
+  navigateToMock = vi.fn();
+  fetchMock = vi.fn().mockResolvedValue({});
+
+  vi.stubGlobal('useAuth', () => auth.stub);
+  vi.stubGlobal('useSupabase', () => supabase ?? makeSupabaseStub());
+  vi.stubGlobal('useToast', () => ({ add: toastAdd }));
+  vi.stubGlobal('navigateTo', navigateToMock);
+  vi.stubGlobal('$fetch', fetchMock);
+  vi.stubGlobal('useRoute', () => ({
+    path: '/membership',
+    fullPath: '/membership',
+    name: 'membership',
+    params: {},
+    meta: {},
+    matched: [],
+    query,
+  }));
+  vi.stubGlobal('useRouter', () => ({
+    push: vi.fn(),
+    replace: routerReplace,
+    back: vi.fn(),
+    forward: vi.fn(),
+    go: vi.fn(),
+    currentRoute: { value: { path: '/membership', params: {}, query, name: 'membership' } },
+  }));
+}
+
+function mountPage() {
+  return mount(MembershipPage, { global: { stubs: mountStubs } });
+}
+
+/** Drain pending microtask chains without relying on real timers. */
+async function flushMicrotasks(times = 10) {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+  await nextTick();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  (global as any).__resetNuxtState?.();
+});
+
+// ---------------------------------------------------------------------------
+// Hero price badge gating (no "$1.99/month" flash for members)
+// ---------------------------------------------------------------------------
+describe('hero price badge gating', () => {
+  it('hides the price badge until auth resolves, then shows it for non-members', async () => {
+    let resolveAuth!: (v: boolean) => void;
+    const auth = makeAuthStub({
+      member: false,
+      waitForAuth: () => new Promise<boolean>((resolve) => (resolveAuth = resolve)),
+    });
+    stubEnvironment({ auth });
+
+    const wrapper = mountPage();
+    await flushMicrotasks();
+
+    // Auth unresolved: no badge yet (this is the window where members used to
+    // see the price flash).
+    expect(wrapper.html()).not.toContain('hero.price');
+
+    resolveAuth(true);
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.html()).toContain('hero.price');
+  });
+
+  it('never shows the price badge to a resolved member', async () => {
+    const auth = makeAuthStub({ member: true });
+    stubEnvironment({ auth, supabase: makeSupabaseStub({ platform: 'stripe' }) });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.html()).not.toContain('hero.price');
+    expect(wrapper.html()).toContain('member.title');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-checkout activation poll (?subscribed=1)
+// ---------------------------------------------------------------------------
+describe('activation poll on ?subscribed=1', () => {
+  it('shows "Activating…" instead of the subscribe CTA while polling', async () => {
+    vi.useFakeTimers();
+    const auth = makeAuthStub({ member: false });
+    stubEnvironment({ query: { subscribed: '1' }, auth });
+
+    const wrapper = mountPage();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushMicrotasks();
+
+    // First gate re-pull happened immediately; polling state is live.
+    expect(auth.fetchUserProfile).toHaveBeenCalledWith(baseUser.id);
+    expect(wrapper.html()).toContain('cta.activating_title');
+    expect(wrapper.find('.loading-spinner').exists()).toBe(true);
+    // The non-member subscribe CTA and price badge are suppressed during the window.
+    expect(wrapper.html()).not.toContain('cta.subscribe');
+    expect(wrapper.html()).not.toContain('hero.price');
+    // The ?subscribed param was stripped so refresh doesn't replay.
+    expect(routerReplace).toHaveBeenCalledWith({ query: {} });
+    expect(toastAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips to the member area once the membership gate goes true', async () => {
+    vi.useFakeTimers();
+    const auth = makeAuthStub({ member: false });
+    // Webhook lands on the third poll.
+    auth.fetchUserProfile.mockImplementation(async () => {
+      if (auth.fetchUserProfile.mock.calls.length >= 3) auth.memberRef.value = true;
+    });
+    stubEnvironment({ query: { subscribed: '1' }, auth, supabase: makeSupabaseStub({ platform: 'stripe' }) });
+
+    const wrapper = mountPage();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushMicrotasks();
+    expect(wrapper.html()).toContain('cta.activating_title');
+
+    await vi.advanceTimersByTimeAsync(2000); // poll 2
+    await vi.advanceTimersByTimeAsync(2000); // poll 3 — gate flips
+    await flushMicrotasks();
+
+    expect(auth.fetchUserProfile).toHaveBeenCalledTimes(3);
+    expect(wrapper.html()).not.toContain('cta.activating_title');
+    expect(wrapper.html()).toContain('member.title');
+  });
+
+  it('shows the gentle timeout note after ~30s without activation', async () => {
+    vi.useFakeTimers();
+    const auth = makeAuthStub({ member: false });
+    stubEnvironment({ query: { subscribed: '1' }, auth });
+
+    const wrapper = mountPage();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushMicrotasks();
+
+    await vi.advanceTimersByTimeAsync(31000);
+    await flushMicrotasks();
+
+    // 15 attempts at ~2s spacing, then a soft landing — no subscribe CTA.
+    expect(auth.fetchUserProfile).toHaveBeenCalledTimes(15);
+    expect(wrapper.html()).toContain('cta.activation_timeout_title');
+    expect(wrapper.html()).not.toContain('cta.activating_title');
+    expect(wrapper.html()).not.toContain('cta.subscribe');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Platform-aware manage branches (get_my_membership().platform)
+// ---------------------------------------------------------------------------
+describe('manage area platform branches', () => {
+  async function mountAsMemberWithPlatform(platform: string | null) {
+    const auth = makeAuthStub({ member: true });
+    stubEnvironment({ auth, supabase: makeSupabaseStub({ platform }) });
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+    return wrapper;
+  }
+
+  it('ghost members are pointed at their Ghost billing email', async () => {
+    const wrapper = await mountAsMemberWithPlatform('ghost');
+    expect(wrapper.html()).toContain('member.manage_note_ghost');
+    expect(wrapper.html()).not.toContain('member.manage_note_stripe');
+  });
+
+  it('patreon members get a manage link to Patreon memberships settings', async () => {
+    const wrapper = await mountAsMemberWithPlatform('patreon');
+    expect(wrapper.html()).toContain('member.manage_note_patreon');
+    const link = wrapper.find('a[href="https://www.patreon.com/settings/memberships"]');
+    expect(link.exists()).toBe(true);
+  });
+
+  it('unknown/null platform on an active member renders the active fallback, not an empty area', async () => {
+    const wrapper = await mountAsMemberWithPlatform(null);
+    expect(wrapper.html()).toContain('member.active_fallback');
+    expect(wrapper.html()).not.toContain('member.manage_note_stripe');
+    expect(wrapper.html()).not.toContain('member.manage_note_store');
+  });
+
+  it('unrecognized future platform values also fall back to the active note', async () => {
+    const wrapper = await mountAsMemberWithPlatform('somethingnew');
+    expect(wrapper.html()).toContain('member.active_fallback');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Logged-out subscribe intent (?subscribe=1 round trip)
+// ---------------------------------------------------------------------------
+describe('subscribe intent preservation', () => {
+  it('logged-out sign-in CTA carries the subscribe intent through /login?redirect=…', async () => {
+    const auth = makeAuthStub({ user: null });
+    stubEnvironment({ auth });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    await nextTick();
+
+    const signin = wrapper.find(`a[href="/login?redirect=${encodeURIComponent('/membership?subscribe=1')}"]`);
+    expect(signin.exists()).toBe(true);
+  });
+
+  it('auto-starts checkout when an authenticated non-member returns with ?subscribe=1', async () => {
+    const auth = makeAuthStub({ member: false });
+    stubEnvironment({ query: { subscribe: '1' }, auth });
+    fetchMock.mockResolvedValue({ url: 'https://checkout.stripe.test/session' });
+
+    mountPage();
+    await flushPromises();
+
+    // Param stripped, checkout proxy hit, browser sent to Stripe.
+    expect(routerReplace).toHaveBeenCalledWith({ query: {} });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/membership/checkout',
+      expect.objectContaining({ method: 'POST', headers: { authorization: 'Bearer test-token' } })
+    );
+    expect(navigateToMock).toHaveBeenCalledWith('https://checkout.stripe.test/session', { external: true });
+  });
+
+  it('does not auto-start checkout for an already-active member with ?subscribe=1', async () => {
+    const auth = makeAuthStub({ member: true });
+    stubEnvironment({ query: { subscribe: '1' }, auth, supabase: makeSupabaseStub({ platform: 'stripe' }) });
+
+    mountPage();
+    await flushPromises();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(routerReplace).toHaveBeenCalledWith({ query: {} });
+  });
+});

--- a/tests/unit/utils/redirect.test.ts
+++ b/tests/unit/utils/redirect.test.ts
@@ -1,0 +1,61 @@
+/**
+ * sanitizeRedirectPath (app/utils/redirect.ts) — the single internal-path
+ * validator behind /login?redirect=, the /auth/callback localStorage consume,
+ * and /welcome?redirect=. Exercises the open-redirect attack shapes from the
+ * PR #608 review (protocol-relative, backslash normalization, encoded
+ * schemes, control characters).
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitizeRedirectPath } from '~/app/utils/redirect';
+
+describe('sanitizeRedirectPath', () => {
+  it('accepts plain internal paths', () => {
+    expect(sanitizeRedirectPath('/')).toBe('/');
+    expect(sanitizeRedirectPath('/admin')).toBe('/admin');
+    expect(sanitizeRedirectPath('/membership?subscribe=1')).toBe('/membership?subscribe=1');
+    expect(sanitizeRedirectPath('/archive/manuals#section-2')).toBe('/archive/manuals#section-2');
+  });
+
+  it('rejects non-string values (repeated query params arrive as arrays)', () => {
+    expect(sanitizeRedirectPath(undefined)).toBeNull();
+    expect(sanitizeRedirectPath(null)).toBeNull();
+    expect(sanitizeRedirectPath(['/a', '//evil.com'])).toBeNull();
+    expect(sanitizeRedirectPath(42)).toBeNull();
+  });
+
+  it('rejects absolute URLs and scheme-prefixed values', () => {
+    expect(sanitizeRedirectPath('https://evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('http://evil.com/')).toBeNull();
+    expect(sanitizeRedirectPath('javascript:alert(1)')).toBeNull();
+    expect(sanitizeRedirectPath('mailto:a@evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('')).toBeNull();
+    expect(sanitizeRedirectPath(' /evil.com')).toBeNull();
+  });
+
+  it('rejects protocol-relative //host shapes', () => {
+    expect(sanitizeRedirectPath('//evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('///evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('//evil.com/membership')).toBeNull();
+  });
+
+  it('rejects backslash variants that browsers normalize to forward slashes', () => {
+    expect(sanitizeRedirectPath('/\\evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('/\\\\evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('\\/evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('/membership\\..\\evil')).toBeNull();
+  });
+
+  it('rejects control characters that URL parsers strip', () => {
+    expect(sanitizeRedirectPath('/\tevil.com')).toBeNull();
+    expect(sanitizeRedirectPath('/\n/evil.com')).toBeNull();
+    expect(sanitizeRedirectPath('/membership\u0000')).toBeNull();
+    expect(sanitizeRedirectPath('/\u007Fevil.com')).toBeNull();
+  });
+
+  it('keeps percent-encoded values inert but unmodified (single-decode happens upstream)', () => {
+    // Once-decoded query values containing a literal backslash are rejected;
+    // still-encoded sequences are just opaque path characters for the router.
+    expect(sanitizeRedirectPath('/%5Cevil.com')).toBe('/%5Cevil.com');
+    expect(sanitizeRedirectPath('/%2F%2Fevil.com')).toBe('/%2F%2Fevil.com');
+  });
+});


### PR DESCRIPTION
Web half of the Sustaining Member pre-launch punch list (2026-06-10, P2 web items + checkout-race UX from B1).

## Fixes

- **Post-checkout race polish** — on return with `?subscribed=1`, `/membership` now polls the membership gate every ~2s for up to ~30s, showing an "Activating your membership…" state (daisyUI loading) instead of re-showing the subscribe CTA while the Stripe webhook races the redirect. On timeout, a gentle "taking longer than expected — refresh in a minute" note. (Server-side double-billing guard is in the backend PR; this is the UX half.)
- **Logged-out subscribe intent** — clicking Subscribe (or the sign-in CTA) while logged out now routes through `/login?redirect=%2Fmembership%3Fsubscribe%3D1`; the intent survives the OAuth/magic-link round trip via localStorage and `/auth/callback` consumes it (first-timers carry it through `/welcome?redirect=`). Back on `/membership?subscribe=1`, checkout auto-starts for authenticated non-members. Redirect values are validated to internal paths only — no open-redirect surface.
- **ghost/patreon manage branches** — the manage area now handles `platform='ghost'` ("Manage your membership through your Ghost account billing email.") and `platform='patreon'` ("Manage your pledge on Patreon." linking patreon.com/settings/memberships), plus an explicit "Your membership is active." fallback for unknown/null platform — the manage area no longer renders empty (parity with TME).
- **Discord invite re-request** — no Edge Function supports user-initiated claim re-issue (`sync-entitlements` is CRON_SECRET-gated fan-out only; `discord-claim` only consumes tokens), so no backend was built here (house rule: no migrations/functions in this repo). Instead: the `?discord_error` banner copy no longer points at the unreleased apps — it routes users to the membership page and the contact page — and the member Discord card gains a "Lost the invite email? Contact us and we'll resend it." line. **Backend follow-up:** a self-serve claim re-issue endpoint in `classicminidiy-supabase`.
- **app-config.json** — added `"tme_free_listings": true` (Android defaulted false, iOS true → divergent benefit copy; TME free listings are live).
- **Member hero flash** — the "$1.99/month" hero badge is now gated on resolved auth (and suppressed during activation polling), so members never see it flash.

## Tests

New `tests/unit/pages/membership.test.ts` (12 tests): activation poll (polling state, gate-flip to member area, ~30s timeout note, CTA suppression), ghost/patreon/unknown/future-platform manage branches, hero badge gating pre/post auth resolution and for members, subscribe-intent link and auto-start (including the already-member no-op).

Full suite: 58 files / 1483 tests passing. `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)