### PR TITLE
fix(membership): claim pages must never be prerendered/CDN-cached — 'missing claim code' incident

### DIFF
--- a/app/pages/membership/claim.vue
+++ b/app/pages/membership/claim.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
   const { t } = useI18n();
   const route = useRoute();
+  const router = useRouter();
   const supabase = useSupabase();
   const { track } = useAnalytics();
   const { add: addToast } = useToast();
@@ -98,18 +99,43 @@
     }
   }
 
-  onMounted(async () => {
-    if (!code.value) {
-      state.value = 'missing_code';
-      track('membership_claim_failed', { source: 'web', reason: 'missing_code' });
-      return;
-    }
+  async function begin() {
+    state.value = 'checking';
     await waitForAuth();
     if (!isAuthenticated.value) {
       state.value = 'signin';
       return;
     }
     await redeem();
+  }
+
+  // Run exactly once, as soon as a code is available. The code can arrive
+  // late: when the PWA service worker serves the precached '/' shell (or a
+  // statically-served copy boots the app), the router can briefly disagree
+  // with the address bar — the same failure mode the /auth/callback
+  // routeRules entry documents. So: route.query first, location.search as
+  // the fallback, and a watcher to catch the router syncing up after mount.
+  let begun = false;
+  function tryBegin(): boolean {
+    if (begun || !code.value) return begun;
+    begun = true;
+    void begin();
+    return true;
+  }
+  watch(code, () => {
+    tryBegin();
+  });
+  onMounted(() => {
+    if (tryBegin()) return;
+    const locCode = (new URLSearchParams(window.location.search).get('code') ?? '').trim();
+    if (locCode) {
+      // The address bar has the code but the router lost it — re-sync the
+      // route (keeps `code`/`claimIntentPath` consistent); the watcher begins.
+      void router.replace({ query: { ...route.query, code: locCode } });
+      return;
+    }
+    state.value = 'missing_code';
+    track('membership_claim_failed', { source: 'web', reason: 'missing_code' });
   });
 
   // Transient page reached from a single-use emailed link — never index it.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -385,6 +385,19 @@ export default defineNuxtConfig({
       prerender: false,
       headers: { 'cache-control': 'no-store, must-revalidate' },
     },
+    // Same single-use-?code= contract as /auth/callback: the membership claim
+    // page and the Discord claim proxy are reached from emailed one-time
+    // links. Prerendering/CDN-caching them serves a static copy whose JS can
+    // boot with no code in the URL ("That link is missing its claim code"
+    // for every recipient — 2026-06-12 incident).
+    '/membership/claim': {
+      prerender: false,
+      headers: { 'cache-control': 'no-store, must-revalidate' },
+    },
+    '/discord/claim': {
+      prerender: false,
+      headers: { 'cache-control': 'no-store, must-revalidate' },
+    },
     '/archive/manuals': { redirect: { to: '/archive/documents?type=manual', statusCode: 301 } },
     '/archive/adverts': { redirect: { to: '/archive/documents?type=advert', statusCode: 301 } },
     '/archive/catalogues': { redirect: { to: '/archive/documents?type=catalogue', statusCode: 301 } },
@@ -609,6 +622,10 @@ export default defineNuxtConfig({
         /\/technical\/calculators\/gearbox/,
         /^\/t\//,
         /^\/auth\/callback/,
+        // Single-use emailed claim links — the precached '/' shell must never
+        // swallow their ?code=/?token= (see /auth/callback note above).
+        /^\/membership\/claim/,
+        /^\/discord\/claim/,
       ],
       // Customize caching strategies
       runtimeCaching: [

--- a/tests/unit/pages/membership-claim.test.ts
+++ b/tests/unit/pages/membership-claim.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
-import { ref, computed, nextTick } from 'vue';
+import { ref, computed, nextTick, reactive } from 'vue';
 import ClaimPage from '~/app/pages/membership/claim.vue';
 import { sanitizeRedirectPath } from '~/app/utils/redirect';
 
@@ -57,6 +57,7 @@ const mountStubs = {
 let toastAdd: ReturnType<typeof vi.fn>;
 let navigateToMock: ReturnType<typeof vi.fn>;
 let trackMock: ReturnType<typeof vi.fn>;
+let routerReplaceMock: ReturnType<typeof vi.fn>;
 
 function stubEnvironment({
   query = {} as Record<string, string>,
@@ -76,15 +77,24 @@ function stubEnvironment({
   vi.stubGlobal('useToast', () => ({ add: toastAdd }));
   vi.stubGlobal('useAnalytics', () => ({ track: trackMock }));
   vi.stubGlobal('navigateTo', navigateToMock);
-  vi.stubGlobal('useRoute', () => ({
+  const routeObj = reactive({
     path: '/membership/claim',
     fullPath: '/membership/claim',
     name: 'membership-claim',
     params: {},
     meta: {},
     matched: [],
-    query,
-  }));
+    query: { ...query } as Record<string, string>,
+  });
+  vi.stubGlobal('useRoute', () => routeObj);
+  // The page re-syncs a router-lost code via router.replace; mimic the real
+  // router by applying the new query to the (reactive) route.
+  routerReplaceMock = vi.fn((to: { query?: Record<string, string> }) => {
+    if (to?.query) routeObj.query = { ...to.query };
+    return Promise.resolve();
+  });
+  vi.stubGlobal('useRouter', () => ({ replace: routerReplaceMock }));
+  return { route: routeObj };
 }
 
 function mountPage() {
@@ -95,6 +105,7 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  window.history.replaceState({}, '', '/');
   (global as any).__resetNuxtState?.();
 });
 
@@ -288,5 +299,61 @@ describe('claim error states', () => {
       'membership_claim_redeemed',
       expect.objectContaining({ source: 'web', platform: 'ghost' })
     );
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Query-loss resilience — the PWA '/' shell / statically-served copy can boot
+// the app with the router briefly missing the ?code= even though the address
+// bar has it (the /auth/callback failure mode; 2026-06-12 incident: every
+// claim email recipient saw "missing its claim code").
+// ---------------------------------------------------------------------------
+describe('query-loss resilience (PWA shell / static serve)', () => {
+  it('falls back to window.location.search when the router lost the code, re-syncs, and redeems', async () => {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([{ data: [{ platform: 'patreon' }] }]);
+    window.history.replaceState({}, '', `/membership/claim?code=${CODE}`);
+    stubEnvironment({ query: {}, auth, supabase });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(routerReplaceMock).toHaveBeenCalledWith(expect.objectContaining({ query: expect.objectContaining({ code: CODE }) }));
+    expect(supabase.rpc).toHaveBeenCalledWith('claim_external_membership', { p_code: CODE });
+    expect(wrapper.html()).not.toContain('missing_code.title');
+  });
+
+  it('recovers from missing_code when the router syncs the code in late', async () => {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([{ data: [{ platform: 'ghost' }] }]);
+    const { route } = stubEnvironment({ query: {}, auth, supabase });
+
+    const wrapper = mountPage();
+    await flushPromises();
+    expect(wrapper.html()).toContain('missing_code.title');
+    expect(supabase.rpc).not.toHaveBeenCalled();
+
+    route.query = { code: CODE };
+    await nextTick();
+    await flushPromises();
+
+    expect(supabase.rpc).toHaveBeenCalledWith('claim_external_membership', { p_code: CODE });
+    expect(wrapper.html()).not.toContain('missing_code.title');
+  });
+
+  it('begins exactly once even if the code arrives via both location fallback and a late router sync', async () => {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub([{ data: [{ platform: 'patreon' }] }]);
+    window.history.replaceState({}, '', `/membership/claim?code=${CODE}`);
+    const { route } = stubEnvironment({ query: {}, auth, supabase });
+
+    mountPage();
+    await flushPromises();
+    route.query = { code: CODE };
+    await nextTick();
+    await flushPromises();
+
+    expect(supabase.rpc).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Production incident — every claim-email recipient blocked

All users clicking membership claim emails landed on **'That link is missing its claim code'**, consistently (reproduced: a hard load of `/membership/claim?code=<uuid>` rendered the missing-code card even though `window.location.search` AND the router's `currentRoute.query` held the code).

**Root cause:** `/membership/claim` was prerendered by the `crawlLinks: true` crawler and served as a static CDN file (`x-vercel-cache: HIT`, age 3.5h) — and for installed-PWA users the service worker's `'/'` `navigateFallback` swallows the single-use query. This is the **exact failure mode the `/auth/callback` routeRules entry already documents** — the claim pages just never got the same protection.

**Fix (mirrors /auth/callback):**
- `routeRules`: `prerender: false` + `cache-control: no-store` for `/membership/claim` **and** `/discord/claim`
- PWA `navigateFallbackDenylist`: both claim routes
- `claim.vue` belt-and-braces: `location.search` fallback when the router lost the code + a watcher that recovers from a late router sync (begins exactly once)

**Tests:** 3 new regression tests; full suite 67 files / 1,575 green; `bun run build` clean and `/membership/claim` no longer appears in `.output/public`.

**No email re-send needed:** the emailed links were always correct — once this deploys, the same links work (30-day expiry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)