### PR TITLE
fix(discord): self-serve claim for bare /discord/claim hits from the apps

### DIFF
--- a/app/pages/discord/connect.vue
+++ b/app/pages/discord/connect.vue
@@ -1,0 +1,223 @@
+<script lang="ts" setup>
+  const { t } = useI18n();
+  const supabase = useSupabase();
+  const { track } = useAnalytics();
+  const { isAuthenticated, waitForAuth } = useAuth();
+
+  // Self-serve Discord claim for signed-in Sustaining Members (keystone §5.3).
+  // The mobile apps' "Claim Discord Access" buttons (and any bookmark) open
+  // /discord/claim with no token; the server proxy routes those bare hits here.
+  // We mint a fresh claim token via /api/discord/reissue (discord-claim-reissue
+  // Edge Function — paid members only), then re-enter the normal tokened chain:
+  // /discord/claim?token= → discord-claim → Discord OAuth → role granted.
+  //
+  // App users arrive in the system browser with NO web session even though
+  // they're signed in to the app, so the signin card is the common first stop —
+  // the copy points them at using the same account as the app.
+
+  type ConnectState =
+    | 'checking' // resolving auth
+    | 'signin' // logged out — needs the login round trip first
+    | 'connecting' // reissue in flight / redirecting into Discord OAuth
+    | 'active' // already linked — nothing to claim
+    | 'not_member' // signed in but no active Sustaining Membership
+    | 'error'; // transient proxy/network failure — retryable
+  const state = ref<ConnectState>('checking');
+  const discordUrl = ref<string | null>(null);
+
+  const loginWithIntentHref = `/login?redirect=${encodeURIComponent('/discord/connect')}`;
+
+  async function getAccessToken(): Promise<string | null> {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    return session?.access_token ?? null;
+  }
+
+  async function connect() {
+    state.value = 'connecting';
+    try {
+      const token = await getAccessToken();
+      if (!token) {
+        // Session evaporated between the auth check and the claim — send them
+        // back through sign-in with the connect intent preserved.
+        navigateTo(loginWithIntentHref);
+        return;
+      }
+      const res = await $fetch<{ status?: string; claim_url?: string; discord_url?: string }>(
+        '/api/discord/reissue',
+        {
+          method: 'POST',
+          headers: { authorization: `Bearer ${token}` },
+        }
+      );
+      if (res?.status === 'active') {
+        discordUrl.value = res.discord_url ?? null;
+        state.value = 'active';
+        track('discord_claim_reissued', { source: 'web', result: 'already_active' });
+        return;
+      }
+      if (res?.status === 'pending' && res.claim_url) {
+        track('discord_claim_reissued', { source: 'web', result: 'pending' });
+        // Full document navigation into the OAuth chain — same external
+        // redirect convention as the Stripe checkout hand-off.
+        await navigateTo(res.claim_url, { external: true });
+        return;
+      }
+      throw new Error('Unexpected reissue response shape');
+    } catch (err: any) {
+      const status = err?.statusCode ?? err?.response?.status;
+      if (status === 403) {
+        state.value = 'not_member';
+        track('discord_claim_reissue_failed', { source: 'web', reason: 'not_member' });
+        return;
+      }
+      if (status === 401) {
+        navigateTo(loginWithIntentHref);
+        return;
+      }
+      console.error('Discord claim reissue failed:', err);
+      state.value = 'error';
+      track('discord_claim_reissue_failed', { source: 'web', reason: 'exception' });
+    }
+  }
+
+  onMounted(async () => {
+    await waitForAuth();
+    if (!isAuthenticated.value) {
+      state.value = 'signin';
+      return;
+    }
+    await connect();
+  });
+
+  // Transient claim-chain page — never index it.
+  useHead({
+    title: t('meta.title'),
+    meta: [{ name: 'robots', content: 'noindex, nofollow' }],
+  });
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-base-200 px-4">
+    <div class="card bg-base-100 shadow-md border border-base-300 w-full max-w-md">
+      <ClientOnly>
+        <div class="card-body items-center text-center">
+          <span class="eyebrow mb-1">{{ t('eyebrow') }}</span>
+
+          <!-- Resolving auth -->
+          <template v-if="state === 'checking'">
+            <span class="loading loading-spinner loading-lg text-primary mt-4"></span>
+            <p class="opacity-70 mt-3">{{ t('checking') }}</p>
+          </template>
+
+          <!-- Reissue in flight / redirecting to Discord -->
+          <template v-else-if="state === 'connecting'">
+            <span class="loading loading-spinner loading-lg text-primary mt-4"></span>
+            <h1 class="text-2xl font-bold mt-3">{{ t('connecting.title') }}</h1>
+            <p class="opacity-70">{{ t('connecting.body') }}</p>
+          </template>
+
+          <!-- Logged out: connect intent rides the existing /login?redirect= flow.
+               App users land here without a web session — same account as the app. -->
+          <template v-else-if="state === 'signin'">
+            <i class="fas fa-right-to-bracket text-4xl text-primary mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('signin.title') }}</h1>
+            <p class="opacity-70">{{ t('signin.body') }}</p>
+            <NuxtLink :to="loginWithIntentHref" class="btn btn-primary mt-4">
+              <i class="fas fa-right-to-bracket"></i>
+              {{ t('signin.cta') }}
+            </NuxtLink>
+          </template>
+
+          <!-- Already linked -->
+          <template v-else-if="state === 'active'">
+            <i class="fas fa-circle-check text-4xl text-success mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('active.title') }}</h1>
+            <p class="opacity-70">{{ t('active.body') }}</p>
+            <a v-if="discordUrl" :href="discordUrl" class="btn btn-primary mt-4">
+              <i class="fab fa-discord"></i>
+              {{ t('active.cta') }}
+            </a>
+          </template>
+
+          <!-- Signed in but not a paid Sustaining Member -->
+          <template v-else-if="state === 'not_member'">
+            <i class="fas fa-star text-4xl text-warning mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('not_member.title') }}</h1>
+            <p class="opacity-70">{{ t('not_member.body') }}</p>
+            <NuxtLink to="/membership" class="btn btn-primary mt-4">
+              <i class="fas fa-star"></i>
+              {{ t('not_member.cta') }}
+            </NuxtLink>
+          </template>
+
+          <!-- Transient failure -->
+          <template v-else>
+            <i class="fas fa-triangle-exclamation text-4xl text-error mt-2"></i>
+            <h1 class="text-2xl font-bold mt-3">{{ t('error.title') }}</h1>
+            <p class="opacity-70">{{ t('error.body') }}</p>
+            <button type="button" class="btn btn-primary mt-4" @click="connect">
+              <i class="fas fa-rotate-right"></i>
+              {{ t('error.retry') }}
+            </button>
+          </template>
+
+          <!-- Contact fallback on dead-end states -->
+          <p v-if="state === 'not_member' || state === 'error'" class="text-sm opacity-70 mt-4">
+            {{ t('contact_question') }}
+            <NuxtLink to="/contact" class="link link-primary">{{ t('contact_cta') }}</NuxtLink>
+          </p>
+        </div>
+
+        <template #fallback>
+          <!-- SSR / pre-hydration: matches the 'checking' state so there is no
+               flash between server render and the resolved client state. -->
+          <div class="card-body items-center text-center">
+            <span class="eyebrow mb-1">{{ t('eyebrow') }}</span>
+            <span class="loading loading-spinner loading-lg text-primary mt-4"></span>
+            <p class="opacity-70 mt-3">{{ t('checking') }}</p>
+          </div>
+        </template>
+      </ClientOnly>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "meta": {
+      "title": "Connect your Discord — Classic Mini DIY"
+    },
+    "eyebrow": "Members-only Discord",
+    "checking": "Checking your membership…",
+    "connecting": {
+      "title": "Connecting your Discord",
+      "body": "Hang tight — we're sending you to Discord to authorize your members-only access."
+    },
+    "signin": {
+      "title": "Sign in to claim your access",
+      "body": "Sign in with the same Classic Mini DIY account you use in the Toolbox app, and we'll connect your Discord right after.",
+      "cta": "Sign in"
+    },
+    "active": {
+      "title": "You're already connected",
+      "body": "Your Discord is linked and your members-only role is active. See you in there!",
+      "cta": "Open Discord"
+    },
+    "not_member": {
+      "title": "Membership required",
+      "body": "The members-only Discord is a Sustaining Member benefit. Check your membership status or become a member to join.",
+      "cta": "View membership"
+    },
+    "error": {
+      "title": "Something went wrong",
+      "body": "We couldn't start your Discord claim. Give it another try in a moment.",
+      "retry": "Try again"
+    },
+    "contact_question": "Still stuck?",
+    "contact_cta": "Contact us"
+  }
+}
+</i18n>

--- a/app/pages/discord/connect.vue
+++ b/app/pages/discord/connect.vue
@@ -41,7 +41,7 @@
       if (!token) {
         // Session evaporated between the auth check and the claim — send them
         // back through sign-in with the connect intent preserved.
-        navigateTo(loginWithIntentHref);
+        await navigateTo(loginWithIntentHref);
         return;
       }
       const res = await $fetch<{ status?: string; claim_url?: string; discord_url?: string }>(
@@ -66,7 +66,7 @@
       }
       throw new Error('Unexpected reissue response shape');
     } catch (err: any) {
-      const status = err?.statusCode ?? err?.response?.status;
+      const status = err?.statusCode ?? err?.status ?? err?.response?.status;
       if (status === 403) {
         state.value = 'not_member';
         track('discord_claim_reissue_failed', { source: 'web', reason: 'not_member' });
@@ -77,7 +77,7 @@
         // (deleted user, auth incident). Clear it first — otherwise /login
         // sees isAuthenticated, bounces straight back here, and we loop.
         await supabase.auth.signOut().catch(() => {});
-        navigateTo(loginWithIntentHref);
+        await navigateTo(loginWithIntentHref);
         return;
       }
       console.error('Discord claim reissue failed:', err);

--- a/app/pages/discord/connect.vue
+++ b/app/pages/discord/connect.vue
@@ -73,6 +73,10 @@
         return;
       }
       if (status === 401) {
+        // The local session looked valid but the server rejected the token
+        // (deleted user, auth incident). Clear it first — otherwise /login
+        // sees isAuthenticated, bounces straight back here, and we loop.
+        await supabase.auth.signOut().catch(() => {});
         navigateTo(loginWithIntentHref);
         return;
       }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -223,6 +223,10 @@ export default defineNuxtConfig({
       '/contribute/**',
       '/welcome',
       '/profile/**',
+      // Transient claim-chain pages (noindex via useHead, which the sitemap
+      // module can't see — exclude them here too to avoid mixed signals).
+      '/membership/claim',
+      '/discord/connect',
     ],
   },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -398,6 +398,12 @@ export default defineNuxtConfig({
       prerender: false,
       headers: { 'cache-control': 'no-store, must-revalidate' },
     },
+    // Session-dependent claim-chain page (self-serve Discord connect for the
+    // mobile apps' bare /discord/claim hits) — same no-static treatment.
+    '/discord/connect': {
+      prerender: false,
+      headers: { 'cache-control': 'no-store, must-revalidate' },
+    },
     '/archive/manuals': { redirect: { to: '/archive/documents?type=manual', statusCode: 301 } },
     '/archive/adverts': { redirect: { to: '/archive/documents?type=advert', statusCode: 301 } },
     '/archive/catalogues': { redirect: { to: '/archive/documents?type=catalogue', statusCode: 301 } },
@@ -625,7 +631,9 @@ export default defineNuxtConfig({
         // Single-use emailed claim links — the precached '/' shell must never
         // swallow their ?code=/?token= (see /auth/callback note above).
         /^\/membership\/claim/,
-        /^\/discord\/claim/,
+        // Also covers /discord/connect (the session-dependent self-serve page
+        // bare app hits redirect to) — keep the whole claim chain SW-free.
+        /^\/discord\//,
       ],
       // Customize caching strategies
       runtimeCaching: [

--- a/server/api/discord/reissue.post.ts
+++ b/server/api/discord/reissue.post.ts
@@ -1,0 +1,57 @@
+/**
+ * POST /api/discord/reissue
+ *
+ * Self-serve Discord claim proxy (keystone §5.3). Forwards the caller's
+ * Supabase access token to the `discord-claim-reissue` Edge Function, which
+ * verifies the paid Sustaining Membership, rotates the claim jti, and returns
+ * either the fresh claim URL (status 'pending') or the guild deep link when
+ * the member is already connected (status 'active'). /discord/connect
+ * redirects the browser to the claim URL, re-entering the normal
+ * /discord/claim?token= → Discord OAuth chain.
+ *
+ * The client must be signed in: it sends `Authorization: Bearer <access token>`
+ * — same pattern as /api/membership/checkout.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig();
+
+  const authorization = getHeader(event, 'authorization');
+  if (!authorization?.startsWith('Bearer ')) {
+    throw createError({ statusCode: 401, statusMessage: 'Sign in required to claim Discord access' });
+  }
+
+  const supabaseUrl = (config.public.supabaseUrl as string)?.replace(/\/$/, '');
+  const supabaseKey = config.public.supabaseKey as string;
+  if (!supabaseUrl) {
+    throw createError({ statusCode: 500, statusMessage: 'Supabase URL not configured' });
+  }
+
+  try {
+    const res = await $fetch<{ status?: string; claim_url?: string; discord_url?: string }>(
+      `${supabaseUrl}/functions/v1/discord-claim-reissue`,
+      {
+        method: 'POST',
+        headers: {
+          authorization,
+          apikey: supabaseKey,
+        },
+      }
+    );
+
+    if (res?.status !== 'active' && res?.status !== 'pending') {
+      throw createError({ statusCode: 502, statusMessage: 'Discord claim did not return a usable state' });
+    }
+
+    return res;
+  } catch (error: any) {
+    // Preserve the Edge Function's status (403 not_active drives the page's
+    // membership upsell state) but never leak its raw error body.
+    const status = error?.statusCode || error?.response?.status || 502;
+    const message =
+      status === 403
+        ? 'An active Sustaining Membership is required to join the members-only Discord'
+        : error?.statusMessage || 'Could not start the Discord claim';
+    console.error('[discord/reissue] edge function error:', error?.data || error?.message || error);
+    throw createError({ statusCode: status, statusMessage: message });
+  }
+});

--- a/server/api/discord/reissue.post.ts
+++ b/server/api/discord/reissue.post.ts
@@ -22,8 +22,8 @@ export default defineEventHandler(async (event) => {
 
   const supabaseUrl = (config.public.supabaseUrl as string)?.replace(/\/$/, '');
   const supabaseKey = config.public.supabaseKey as string;
-  if (!supabaseUrl) {
-    throw createError({ statusCode: 500, statusMessage: 'Supabase URL not configured' });
+  if (!supabaseUrl || !supabaseKey) {
+    throw createError({ statusCode: 500, statusMessage: 'Supabase configuration is incomplete' });
   }
 
   try {
@@ -46,7 +46,7 @@ export default defineEventHandler(async (event) => {
   } catch (error: any) {
     // Preserve the Edge Function's status (403 not_active drives the page's
     // membership upsell state) but never leak its raw error body.
-    const status = error?.statusCode || error?.response?.status || 502;
+    const status = error?.statusCode || error?.status || error?.response?.status || 502;
     const message =
       status === 403
         ? 'An active Sustaining Membership is required to join the members-only Discord'

--- a/server/routes/discord/claim.get.ts
+++ b/server/routes/discord/claim.get.ts
@@ -8,21 +8,29 @@
  * preserves clean 302 semantics with no client flash and keeps the proxy hop off
  * client JS.
  *
- * A missing token is forwarded as an empty token so the Edge Function remains the
- * single source of truth for the error copy (it redirects to
- * /?discord_error=missing_token).
+ * A bare hit with no token is NOT an email link — it's the mobile apps'
+ * hardcoded "Claim Discord Access" URL (iOS AppConstants.URLs.discordClaim,
+ * Android SustainingMemberCopy.DISCORD_CLAIM_URL) or a bookmark. Those go to
+ * the self-serve connect page, which mints a fresh claim token for the
+ * signed-in member (discord-claim-reissue) and re-enters this proxy with it.
+ * Forwarding an empty token instead would dead-end every app user at
+ * /?discord_error=missing_token.
  */
 export default defineEventHandler((event) => {
   const config = useRuntimeConfig();
   const supabaseUrl = (config.public.supabaseUrl as string)?.replace(/\/$/, '');
 
+  const token = getQuery(event).token;
+  const tokenParam = typeof token === 'string' ? token : '';
+
+  if (!tokenParam) {
+    return sendRedirect(event, '/discord/connect', 302);
+  }
+
   if (!supabaseUrl) {
     // Fall back to the home page's generic Discord error rather than 500.
     return sendRedirect(event, '/?discord_error=generic', 302);
   }
-
-  const token = getQuery(event).token;
-  const tokenParam = typeof token === 'string' ? token : '';
 
   // Transient redirect page — keep it out of search indexes.
   setHeader(event, 'X-Robots-Tag', 'noindex');

--- a/tests/unit/pages/discord-connect.test.ts
+++ b/tests/unit/pages/discord-connect.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment happy-dom
+/**
+ * Self-serve Discord connect page (app/pages/discord/connect.vue).
+ *
+ * The mobile apps' "Claim Discord Access" buttons open /discord/claim with no
+ * token; the server proxy routes those bare hits here. The page mints a fresh
+ * claim token via POST /api/discord/reissue and re-enters the tokened
+ * /discord/claim → Discord OAuth chain. Covers:
+ *  - logged out → sign-in card with /login?redirect=/discord/connect intent
+ *  - signed in + pending → external navigation to the returned claim URL
+ *  - signed in + already linked → "already connected" card with the guild link
+ *  - 403 (no active membership) → membership upsell card
+ *  - transient failure → error card with a retry that re-calls the proxy
+ *
+ * The i18n mock returns translation keys verbatim, so assertions match keys.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref, computed } from 'vue';
+import ConnectPage from '~/app/pages/discord/connect.vue';
+
+const baseUser = { id: 'user-1', email: 'member@example.com' };
+
+function makeAuthStub({ user = baseUser }: { user?: typeof baseUser | null } = {}) {
+  const userRef = ref<typeof baseUser | null>(user);
+  return {
+    user: userRef,
+    isAuthenticated: computed(() => !!userRef.value),
+    waitForAuth: vi.fn().mockResolvedValue(true),
+  };
+}
+
+/** Stub supabase whose getSession resolves with the given access token (or none). */
+function makeSupabaseStub(accessToken: string | null = 'access-token') {
+  return {
+    auth: {
+      getSession: vi
+        .fn()
+        .mockResolvedValue({ data: { session: accessToken ? { access_token: accessToken } : null } }),
+    },
+  };
+}
+
+const mountStubs = {
+  NuxtLink: { name: 'NuxtLink', template: '<a :href="to"><slot /></a>', props: ['to'] },
+  ClientOnly: { name: 'ClientOnly', template: '<div><slot /></div>' },
+};
+
+let navigateToMock: ReturnType<typeof vi.fn>;
+let trackMock: ReturnType<typeof vi.fn>;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function stubEnvironment({
+  auth,
+  supabase,
+  fetchImpl,
+}: {
+  auth: ReturnType<typeof makeAuthStub>;
+  supabase?: ReturnType<typeof makeSupabaseStub>;
+  fetchImpl?: (...args: unknown[]) => Promise<unknown>;
+}) {
+  navigateToMock = vi.fn();
+  trackMock = vi.fn();
+  fetchMock = vi.fn(fetchImpl ?? (() => Promise.resolve({})));
+
+  vi.stubGlobal('useAuth', () => auth);
+  vi.stubGlobal('useSupabase', () => supabase ?? makeSupabaseStub());
+  vi.stubGlobal('useAnalytics', () => ({ track: trackMock }));
+  vi.stubGlobal('navigateTo', navigateToMock);
+  vi.stubGlobal('$fetch', fetchMock);
+}
+
+function mountPage() {
+  return mount(ConnectPage, { global: { stubs: mountStubs } });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  (global as any).__resetNuxtState?.();
+});
+
+describe('logged out', () => {
+  it('shows the sign-in card with the connect intent and never calls the proxy', async () => {
+    const auth = makeAuthStub({ user: null });
+    stubEnvironment({ auth });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('signin.title');
+    const link = wrapper.find('a[href*="/login"]');
+    expect(link.exists()).toBe(true);
+    expect(link.attributes('href')).toBe(`/login?redirect=${encodeURIComponent('/discord/connect')}`);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('signed in', () => {
+  it('pending claim → sends the Bearer token and navigates externally to the claim URL', async () => {
+    const auth = makeAuthStub();
+    stubEnvironment({
+      auth,
+      supabase: makeSupabaseStub('tok-123'),
+      fetchImpl: () =>
+        Promise.resolve({ status: 'pending', claim_url: 'https://classicminidiy.com/discord/claim?token=abc' }),
+    });
+    mountPage();
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/discord/reissue',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { authorization: 'Bearer tok-123' },
+      })
+    );
+    expect(navigateToMock).toHaveBeenCalledWith('https://classicminidiy.com/discord/claim?token=abc', {
+      external: true,
+    });
+    expect(trackMock).toHaveBeenCalledWith('discord_claim_reissued', { source: 'web', result: 'pending' });
+  });
+
+  it('already linked → shows the connected card with the guild link', async () => {
+    const auth = makeAuthStub();
+    stubEnvironment({
+      auth,
+      fetchImpl: () => Promise.resolve({ status: 'active', discord_url: 'https://discord.com/channels/123' }),
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('active.title');
+    const guildLink = wrapper.find('a[href="https://discord.com/channels/123"]');
+    expect(guildLink.exists()).toBe(true);
+    expect(navigateToMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith('discord_claim_reissued', { source: 'web', result: 'already_active' });
+  });
+
+  it('no web session despite auth state → routes through sign-in with intent', async () => {
+    const auth = makeAuthStub();
+    stubEnvironment({ auth, supabase: makeSupabaseStub(null) });
+    mountPage();
+    await flushPromises();
+
+    expect(navigateToMock).toHaveBeenCalledWith(`/login?redirect=${encodeURIComponent('/discord/connect')}`);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('403 from the proxy → membership upsell card, no retry loop', async () => {
+    const auth = makeAuthStub();
+    stubEnvironment({
+      auth,
+      fetchImpl: () => Promise.reject(Object.assign(new Error('forbidden'), { statusCode: 403 })),
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('not_member.title');
+    expect(wrapper.find('a[href="/membership"]').exists()).toBe(true);
+    expect(trackMock).toHaveBeenCalledWith('discord_claim_reissue_failed', { source: 'web', reason: 'not_member' });
+  });
+
+  it('transient failure → error card whose retry re-calls the proxy', async () => {
+    const auth = makeAuthStub();
+    stubEnvironment({
+      auth,
+      fetchImpl: () => Promise.reject(Object.assign(new Error('boom'), { statusCode: 502 })),
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('error.title');
+    expect(trackMock).toHaveBeenCalledWith('discord_claim_reissue_failed', { source: 'web', reason: 'exception' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('unexpected response shape → error card', async () => {
+    const auth = makeAuthStub();
+    stubEnvironment({ auth, fetchImpl: () => Promise.resolve({ status: 'pending' }) });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('error.title');
+  });
+});

--- a/tests/unit/pages/discord-connect.test.ts
+++ b/tests/unit/pages/discord-connect.test.ts
@@ -37,6 +37,7 @@ function makeSupabaseStub(accessToken: string | null = 'access-token') {
       getSession: vi
         .fn()
         .mockResolvedValue({ data: { session: accessToken ? { access_token: accessToken } : null } }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
     },
   };
 }
@@ -158,6 +159,21 @@ describe('signed in', () => {
     expect(wrapper.text()).toContain('not_member.title');
     expect(wrapper.find('a[href="/membership"]').exists()).toBe(true);
     expect(trackMock).toHaveBeenCalledWith('discord_claim_reissue_failed', { source: 'web', reason: 'not_member' });
+  });
+
+  it('401 from the proxy → clears the stale session before the sign-in round trip (no loop)', async () => {
+    const auth = makeAuthStub();
+    const supabase = makeSupabaseStub('stale-token');
+    stubEnvironment({
+      auth,
+      supabase,
+      fetchImpl: () => Promise.reject(Object.assign(new Error('unauthorized'), { statusCode: 401 })),
+    });
+    mountPage();
+    await flushPromises();
+
+    expect(supabase.auth.signOut).toHaveBeenCalled();
+    expect(navigateToMock).toHaveBeenCalledWith(`/login?redirect=${encodeURIComponent('/discord/connect')}`);
   });
 
   it('transient failure → error card whose retry re-calls the proxy', async () => {


### PR DESCRIPTION
## Incident
Every member tapping **Claim Discord Access** in the iOS/Android apps lands on `/?discord_error=missing_token`. The apps hardcode `https://classicminidiy.com/discord/claim` with no token, but that server route was only ever an email-link proxy: it forwarded an **empty** token to the `discord-claim` Edge Function, which rejects it by design. There was no self-serve path at all.

(The "goes to Patreon the first time" half of the report is the adjacent **Manage Pledge on Patreon** button shown to patreon-channel members in the same Settings section — the claim chain itself never redirects to Patreon; verified with a live probe of the full redirect chain.)

## Fix — no app releases needed
The apps' URL is a constant, so making the bare hit work fixes both platforms instantly:

- `server/routes/discord/claim.get.ts` — bare hits (no `?token=`) now 302 to `/discord/connect` instead of dead-ending; tokened email links are completely unchanged.
- `app/pages/discord/connect.vue` — new self-serve page: resolves auth (login intent preserved via the existing `/login?redirect=` round trip — app users arrive in the system browser with no web session, so the copy says to sign in with the same account as the app), then POSTs `/api/discord/reissue` and externally navigates into the normal tokened `discord-claim → Discord OAuth` chain. Already-linked members get an "already connected" card with the guild link; non-members get the membership upsell; transient failures get a retry.
- `server/api/discord/reissue.post.ts` — thin Bearer-forwarding proxy to the new `discord-claim-reissue` Edge Function (same pattern as `/api/membership/checkout`), preserving the 403 that drives the upsell state.
- `nuxt.config.ts` — `/discord/connect` gets the claim-chain treatment (prerender off, `no-store`, PWA navigateFallback denylist widened to `/^\/discord\//`).

## Tests
New `tests/unit/pages/discord-connect.test.ts` (7 cases: signed-out intent, pending redirect with Bearer, already-active card, evaporated session, 403 upsell, retry, malformed response). Full suite: **1582 passing**.

## Deploy order
Depends on ClassicMiniDIY/classicminidiy-supabase#34 (`discord-claim-reissue` function) being deployed first — until then the new page degrades to the error card with retry, never worse than today's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)