### PR TITLE
chore(models): wire Microlink render key through runtimeConfig

### DIFF
--- a/docs/runbooks/2026-06-12-model-library-launch-checklist.md
+++ b/docs/runbooks/2026-06-12-model-library-launch-checklist.md
@@ -49,6 +49,12 @@ Branch: `feature/3d-models` → merges to `main` once this checklist is green.
 - [ ] `S3_MODELS_BUCKET`, `S3_MODELS_ACCESS_KEY_ID`, `S3_MODELS_SECRET_ACCESS_KEY`
       set in Vercel (and locally in `.env` for dev testing).
 - [ ] `supabaseUrl` / `supabaseKey` public runtime config present (already in use).
+- [ ] `MICROLINK_API_KEY` set in Vercel for the external-model scraper's render
+      fallback (Cloudflare-blocked sites: MakerWorld, Cults3D, Thangs,
+      MyMiniFactory). _Optional_ — the free public endpoint works without a key
+      but is rate-limited (~50 req/day), and each blocked-site submission uses ~2
+      (preview + submit). Recommended before promoting the "Around the Web"
+      feature. Thingiverse / Printables don't need it (direct fetch).
 
 ## 5. End-to-end smoke (Stripe test mode)
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -515,6 +515,11 @@ export default defineNuxtConfig({
     // default. Set MCP_API_KEY (or MCP_API_KEYS) in .env for local development.
     MCP_API_KEY: process.env.MCP_API_KEY || '',
     MCP_API_KEYS: process.env.MCP_API_KEYS || '',
+    // Microlink render-service key for the external-model scraper fallback
+    // (Cloudflare-blocked sites — MakerWorld etc.). Optional: the free public
+    // endpoint works without it but is rate-limited (~50 req/day). Set for the
+    // pro tier. Read server-side only and forwarded to renderExternalPage().
+    MICROLINK_API_KEY: process.env.MICROLINK_API_KEY || '',
     NODE_ENV: process.env.NODE_ENV || 'development',
   },
 

--- a/server/api/models/external/fetch.post.ts
+++ b/server/api/models/external/fetch.post.ts
@@ -19,7 +19,7 @@ export default defineEventHandler(async (event): Promise<ExternalModelPreview> =
   const url = typeof body?.url === 'string' ? body.url.trim() : '';
   if (!url) throw createError({ statusCode: 400, message: 'A model URL is required' });
 
-  const microlinkApiKey = useRuntimeConfig().MICROLINK_API_KEY as string;
+  const microlinkApiKey = useRuntimeConfig(event).MICROLINK_API_KEY as string;
   let scraped;
   try {
     scraped = await fetchExternalMetadata(url, { microlinkApiKey });

--- a/server/api/models/external/fetch.post.ts
+++ b/server/api/models/external/fetch.post.ts
@@ -19,9 +19,10 @@ export default defineEventHandler(async (event): Promise<ExternalModelPreview> =
   const url = typeof body?.url === 'string' ? body.url.trim() : '';
   if (!url) throw createError({ statusCode: 400, message: 'A model URL is required' });
 
+  const microlinkApiKey = useRuntimeConfig().MICROLINK_API_KEY as string;
   let scraped;
   try {
-    scraped = await fetchExternalMetadata(url);
+    scraped = await fetchExternalMetadata(url, { microlinkApiKey });
   } catch (err) {
     if (err instanceof ScrapeError) {
       throw createError({ statusCode: err.statusCode, message: err.message });

--- a/server/api/models/external/submit.post.ts
+++ b/server/api/models/external/submit.post.ts
@@ -47,9 +47,10 @@ export default defineEventHandler(async (event) => {
   if (!categorySlug) throw createError({ statusCode: 400, message: 'Category is required' });
 
   // Re-scrape: the source of truth for source_site / id / author / license / images.
+  const microlinkApiKey = useRuntimeConfig().MICROLINK_API_KEY as string;
   let scraped;
   try {
-    scraped = await fetchExternalMetadata(url);
+    scraped = await fetchExternalMetadata(url, { microlinkApiKey });
   } catch (err) {
     if (err instanceof ScrapeError) throw createError({ statusCode: err.statusCode, message: err.message });
     throw createError({ statusCode: 502, message: 'Could not read that page. Try again.' });

--- a/server/api/models/external/submit.post.ts
+++ b/server/api/models/external/submit.post.ts
@@ -47,7 +47,7 @@ export default defineEventHandler(async (event) => {
   if (!categorySlug) throw createError({ statusCode: 400, message: 'Category is required' });
 
   // Re-scrape: the source of truth for source_site / id / author / license / images.
-  const microlinkApiKey = useRuntimeConfig().MICROLINK_API_KEY as string;
+  const microlinkApiKey = useRuntimeConfig(event).MICROLINK_API_KEY as string;
   let scraped;
   try {
     scraped = await fetchExternalMetadata(url, { microlinkApiKey });

--- a/server/utils/external-models/index.ts
+++ b/server/utils/external-models/index.ts
@@ -49,6 +49,8 @@ export interface ScrapeDeps {
   fetchImpl?: typeof fetch;
   /** Injected for tests — stands in for the render-service fetch. */
   renderImpl?: typeof fetch;
+  /** Render-service API key, forwarded from runtimeConfig by the route. */
+  microlinkApiKey?: string;
 }
 
 /**
@@ -84,7 +86,7 @@ export async function fetchExternalMetadata(rawUrl: string, deps: ScrapeDeps = {
   // 2) Render-service fallback for blocked / JS-only / empty pages. Runs in
   //    production (no injected fetchImpl) or when a test supplies `renderImpl`.
   if (!og && (!deps.fetchImpl || deps.renderImpl)) {
-    og = await renderExternalPage(sourceUrl, deps.renderImpl); // throws ScrapeError if it also fails
+    og = await renderExternalPage(sourceUrl, deps.renderImpl, deps.microlinkApiKey); // throws ScrapeError if it also fails
   }
 
   if (!og) {

--- a/server/utils/external-models/render.ts
+++ b/server/utils/external-models/render.ts
@@ -28,9 +28,18 @@ interface MicrolinkResponse {
 
 const DEFAULT_ENDPOINT = 'https://api.microlink.io';
 
-/** Render `url` via the service and return OG-shaped metadata, or throw ScrapeError. */
-export async function renderExternalPage(url: string, fetchImpl?: typeof fetch): Promise<OgMetadata> {
-  const apiKey = process.env.MICROLINK_API_KEY;
+/**
+ * Render `url` via the service and return OG-shaped metadata, or throw ScrapeError.
+ * `apiKey` is forwarded from runtimeConfig by the caller (server-only); it falls
+ * back to MICROLINK_API_KEY in the environment so the function stays usable in
+ * isolation (e.g. unit tests).
+ */
+export async function renderExternalPage(
+  url: string,
+  fetchImpl?: typeof fetch,
+  apiKey?: string
+): Promise<OgMetadata> {
+  const key = apiKey || process.env.MICROLINK_API_KEY;
   const base = process.env.MICROLINK_API_URL || DEFAULT_ENDPOINT;
   const endpoint = `${base}?url=${encodeURIComponent(url)}`;
   const doFetch = fetchImpl ?? fetch;
@@ -38,7 +47,7 @@ export async function renderExternalPage(url: string, fetchImpl?: typeof fetch):
   let res: Response;
   try {
     res = await doFetch(endpoint, {
-      headers: { Accept: 'application/json', ...(apiKey ? { 'x-api-key': apiKey } : {}) },
+      headers: { Accept: 'application/json', ...(key ? { 'x-api-key': key } : {}) },
     });
   } catch {
     throw new ScrapeError('Couldn’t reach the preview service. Try again in a moment.', 502);

--- a/server/utils/external-models/render.ts
+++ b/server/utils/external-models/render.ts
@@ -39,7 +39,10 @@ export async function renderExternalPage(
   fetchImpl?: typeof fetch,
   apiKey?: string
 ): Promise<OgMetadata> {
-  const key = apiKey || process.env.MICROLINK_API_KEY;
+  // Strict undefined check: a forwarded '' (runtimeConfig default when unset)
+  // means "no key" and must NOT fall through to process.env. Only an omitted
+  // arg (e.g. a direct unit-test call) falls back.
+  const key = apiKey !== undefined ? apiKey : process.env.MICROLINK_API_KEY;
   const base = process.env.MICROLINK_API_URL || DEFAULT_ENDPOINT;
   const endpoint = `${base}?url=${encodeURIComponent(url)}`;
   const doFetch = fetchImpl ?? fetch;


### PR DESCRIPTION
Follow-up to the merged #619 (External 3D Model Listings).

The scraper's render fallback — which handles Cloudflare-blocked sites (MakerWorld, Cults3D, Thangs, MyMiniFactory) via Microlink — was reading `MICROLINK_API_KEY` directly from `process.env`. This moves it onto the project's `runtimeConfig` convention so the key is declared + documented like the other server-only secrets.

## Changes
- `nuxt.config.ts`: declare `MICROLINK_API_KEY` in `runtimeConfig` (server-only), with a comment on the free-tier/pro-tier tradeoff.
- `fetch.post` / `submit.post`: read `useRuntimeConfig().MICROLINK_API_KEY` and forward it via `ScrapeDeps.microlinkApiKey`.
- `render.ts`: `renderExternalPage(url, fetchImpl?, apiKey?)` — uses the forwarded key, falling back to `process.env.MICROLINK_API_KEY` so the util stays usable in isolation/tests.
- Launch checklist: note the optional `MICROLINK_API_KEY` (free public endpoint works without it but is ~50 req/day; recommended before promoting "Around the Web").

No behavior change when the key is unset — the free public endpoint is still used. Build clean, 1672 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)