### PR TITLE
feat(models): rank first-party models above external in browse

### DIFF
--- a/server/api/models/index.get.ts
+++ b/server/api/models/index.get.ts
@@ -56,6 +56,12 @@ export default defineEventHandler(async (event) => {
   // Pricing only applies to first-party listings.
   if (pricing) builder = builder.eq('kind', 'first_party').eq('pricing_mode', pricing);
 
+  // First-party models always rank above external ("Around the Web") listings,
+  // within whatever sort the user picked — so e.g. "Newest" reads as newest
+  // first-party, then newest external. `kind` is the primary order key; the
+  // view's literals are fixed ('first_party' > 'external'), so DESC puts
+  // first-party first.
+  builder = builder.order('kind', { ascending: false });
   switch (sort) {
     case 'popular':
       builder = builder.order('engagement_count', { ascending: false }).order('sort_at', { ascending: false });

--- a/tests/unit/server/api/models/browse.test.ts
+++ b/tests/unit/server/api/models/browse.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // can assert the published-only filter and slug/id resolution.
 const eqSpy = vi.fn();
 const textSearchSpy = vi.fn();
+const orderSpy = vi.fn();
 let resultByTable: Record<string, any> = {};
 let singleByTable: Record<string, any> = {};
 
@@ -17,7 +18,10 @@ function makeBuilder(table: string) {
       return builder;
     },
     in: () => builder,
-    order: () => builder,
+    order: (...args: any[]) => {
+      orderSpy(...args);
+      return builder;
+    },
     range: () => builder,
     textSearch: (...args: any[]) => {
       textSearchSpy(...args);
@@ -66,6 +70,17 @@ describe('server/api/models browse + detail routes', () => {
       resultByTable['model_browse_cards'] = { data: [], count: 0, error: null };
       await listHandler({});
       expect(mockService.from).toHaveBeenCalledWith('model_browse_cards');
+    });
+
+    it('ranks first-party above external as the primary sort, for every sort type', async () => {
+      for (const sort of ['newest', 'popular', 'likes', 'featured']) {
+        orderSpy.mockClear();
+        (getQuery as any).mockReturnValue({ sort });
+        resultByTable['model_browse_cards'] = { data: [], count: 0, error: null };
+        await listHandler({});
+        // `kind` DESC must be the FIRST order key so first-party always wins.
+        expect(orderSpy.mock.calls[0]).toEqual(['kind', { ascending: false }]);
+      }
     });
 
     it('applies full-text search when q is present', async () => {


### PR DESCRIPTION
Within **every** sort on `/models`, first-party models now always rank above the "Around the Web" external listings.

So "Newest" reads as: newest first-party models, then newest external. The same applies to Most downloaded, Most liked, and Featured — the user's chosen sort orders within each group.

## Change
- `server/api/models/index.get.ts`: add `kind` DESC as the **primary** order key on the `model_browse_cards` query, before the per-sort keys. The view's `kind` literals are fixed (`'first_party' > 'external'`), so DESC puts first-party first. API-only — no migration, no schema change.
- Browse test: `order` is now a spy; a new case asserts `kind` DESC is the first order key for all four sort types.

Build clean, 1673 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)