### PR TITLE
feat(models): interleave first-party + external 2:1 in browse

### DIFF
--- a/server/api/models/index.get.ts
+++ b/server/api/models/index.get.ts
@@ -8,8 +8,14 @@
  * combined `search` vector), `category`, `pricing` (first-party only), `source`
  * (`all` | `first_party` | `external` | a specific site slug), `sort`, and
  * pagination. Returns a mixed `BrowseCard[]`.
+ *
+ * In the default mixed view, results are INTERLEAVED 2:1 (first-party : external)
+ * so first-party lead every page while external stay visible — never buried off
+ * the end (see server/utils/browseInterleave.ts). When a filter restricts to a
+ * single kind (`source` or `pricing`), it falls back to one straight query.
  */
 import { getServiceClient } from '../../utils/supabase';
+import { planInterleave, type BrowseKind } from '../../utils/browseInterleave';
 import type { ModelCard, PricingMode } from '../../../data/models/model-library';
 import type { BrowseCard, ExternalModelCard } from '../../../data/models/external-models';
 import { SUPPORTED_SOURCE_SITES, type ExternalSourceSite } from '../../../data/models/external-sources';
@@ -19,6 +25,9 @@ const SORTS = ['newest', 'popular', 'likes', 'featured'];
 const SOURCES = ['all', 'first_party', 'external', ...SUPPORTED_SOURCE_SITES];
 const DEFAULT_LIMIT = 24;
 const MAX_LIMIT = 48;
+
+const SELECT_COLS =
+  'kind, id, slug, title, summary, category_slug, created_at, published_at, like_count, comment_count, download_count, click_count, pricing_mode, price_cents, min_price_cents, currency, license_code, safety_critical, is_featured, author_id, source_site, source_url, source_author_name, primary_image_path';
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -36,50 +45,88 @@ export default defineEventHandler(async (event) => {
   const imageUrl = (path: string | null) =>
     path ? `${supabaseUrl}/storage/v1/object/public/model-images/${path}` : null;
 
-  let builder = service
-    .from('model_browse_cards')
-    .select(
-      'kind, id, slug, title, summary, category_slug, created_at, published_at, like_count, comment_count, download_count, click_count, pricing_mode, price_cents, min_price_cents, currency, license_code, safety_critical, is_featured, author_id, source_site, source_url, source_author_name, primary_image_path',
-      { count: 'exact' }
-    );
+  const applyFilters = (b: any) => {
+    if (category) b = b.eq('category_slug', category);
+    if (q) b = b.textSearch('search', q, { type: 'websearch', config: 'english' });
+    return b;
+  };
+  const applySort = (b: any) => {
+    switch (sort) {
+      case 'popular':
+        return b.order('engagement_count', { ascending: false }).order('sort_at', { ascending: false });
+      case 'likes':
+        return b.order('like_count', { ascending: false }).order('sort_at', { ascending: false });
+      case 'featured':
+        return b.order('is_featured', { ascending: false }).order('sort_at', { ascending: false });
+      default:
+        return b.order('sort_at', { ascending: false });
+    }
+  };
+  const kindRows = (kind: BrowseKind) =>
+    applySort(applyFilters(service.from('model_browse_cards').select(SELECT_COLS).eq('kind', kind)));
+  const kindCount = (kind: BrowseKind) =>
+    applyFilters(service.from('model_browse_cards').select('id', { count: 'exact', head: true }).eq('kind', kind));
 
-  if (category) builder = builder.eq('category_slug', category);
-  if (q) builder = builder.textSearch('search', q, { type: 'websearch', config: 'english' });
-
-  // Source scoping.
-  if (source === 'first_party') builder = builder.eq('kind', 'first_party');
-  else if (source === 'external') builder = builder.eq('kind', 'external');
+  // A single-kind filter (explicit source, or pricing → first-party only) skips
+  // interleaving and runs one straight query.
+  let restrictKind: BrowseKind | null = null;
+  let siteFilter: string | null = null;
+  if (source === 'first_party') restrictKind = 'first_party';
+  else if (source === 'external') restrictKind = 'external';
   else if (SUPPORTED_SOURCE_SITES.includes(source as ExternalSourceSite)) {
-    builder = builder.eq('kind', 'external').eq('source_site', source);
+    restrictKind = 'external';
+    siteFilter = source;
+  }
+  if (pricing) {
+    restrictKind = 'first_party';
+    siteFilter = null;
   }
 
-  // Pricing only applies to first-party listings.
-  if (pricing) builder = builder.eq('kind', 'first_party').eq('pricing_mode', pricing);
+  const offset = (page - 1) * limit;
+  let list: any[] = [];
+  let total = 0;
 
-  switch (sort) {
-    case 'popular':
-      builder = builder.order('engagement_count', { ascending: false }).order('sort_at', { ascending: false });
-      break;
-    case 'likes':
-      builder = builder.order('like_count', { ascending: false }).order('sort_at', { ascending: false });
-      break;
-    case 'featured':
-      builder = builder.order('is_featured', { ascending: false }).order('sort_at', { ascending: false });
-      break;
-    default:
-      builder = builder.order('sort_at', { ascending: false });
+  if (restrictKind) {
+    let b = applySort(applyFilters(service.from('model_browse_cards').select(SELECT_COLS, { count: 'exact' }).eq('kind', restrictKind)));
+    if (siteFilter) b = b.eq('source_site', siteFilter);
+    if (pricing) b = b.eq('pricing_mode', pricing);
+    const { data, count, error } = await b.range(offset, offset + limit - 1);
+    if (error) {
+      console.error('[models/index] query failed:', error.message);
+      throw createError({ statusCode: 500, statusMessage: 'Failed to load models' });
+    }
+    list = data ?? [];
+    total = count ?? 0;
+  } else {
+    // Mixed view: interleave first-party + external 2:1.
+    const [fpC, extC] = await Promise.all([kindCount('first_party'), kindCount('external')]);
+    if (fpC.error || extC.error) {
+      console.error('[models/index] count failed:', (fpC.error || extC.error)?.message);
+      throw createError({ statusCode: 500, statusMessage: 'Failed to load models' });
+    }
+    const fpTotal = fpC.count ?? 0;
+    const extTotal = extC.count ?? 0;
+    total = fpTotal + extTotal;
+
+    const plan = planInterleave(fpTotal, extTotal, offset, limit);
+    const [fpRes, extRes] = await Promise.all([
+      plan.fpCount
+        ? kindRows('first_party').range(plan.fpStart, plan.fpStart + plan.fpCount - 1)
+        : Promise.resolve({ data: [], error: null }),
+      plan.extCount
+        ? kindRows('external').range(plan.extStart, plan.extStart + plan.extCount - 1)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+    if (fpRes.error || extRes.error) {
+      console.error('[models/index] query failed:', (fpRes.error || extRes.error)?.message);
+      throw createError({ statusCode: 500, statusMessage: 'Failed to load models' });
+    }
+    const fpData = (fpRes.data ?? []) as any[];
+    const extData = (extRes.data ?? []) as any[];
+    let fi = 0;
+    let ei = 0;
+    list = plan.order.map((k) => (k === 'first_party' ? fpData[fi++] : extData[ei++])).filter(Boolean);
   }
-
-  const from = (page - 1) * limit;
-  builder = builder.range(from, from + limit - 1);
-
-  const { data: rows, count, error } = await builder;
-  if (error) {
-    console.error('[models/index] query failed:', error.message);
-    throw createError({ statusCode: 500, statusMessage: 'Failed to load models' });
-  }
-
-  const list = rows ?? [];
 
   // Batch author profiles for the first-party rows only.
   const ownerIds = [...new Set(list.filter((m) => m.author_id).map((m) => m.author_id as string))];
@@ -139,6 +186,5 @@ export default defineEventHandler(async (event) => {
     return card;
   });
 
-  const total = count ?? 0;
-  return { models: cards, total, page, limit, hasMore: from + cards.length < total };
+  return { models: cards, total, page, limit, hasMore: offset + cards.length < total };
 });

--- a/server/utils/browseInterleave.ts
+++ b/server/utils/browseInterleave.ts
@@ -1,0 +1,82 @@
+/**
+ * Plan one page of an interleaved browse list that LEADS with first-party models
+ * but keeps external ("Around the Web") listings visible on every page — so
+ * first-party are prioritized without ever burying external off the end.
+ *
+ * The merged sequence repeats a group of [first-party × FP_PER_GROUP, external ×
+ * EXT_PER_GROUP] (2:1 by default), each kind consumed in its own sorted rank
+ * order. When one kind runs out, the remainder of the other fills the rest, so
+ * pages stay full and nothing is hidden. Pagination is stateless: given the two
+ * kind totals + offset/limit, it returns the rank ranges to fetch per kind and
+ * the exact placement order for the page.
+ */
+export const FP_PER_GROUP = 2;
+export const EXT_PER_GROUP = 1;
+
+export type BrowseKind = 'first_party' | 'external';
+
+export interface InterleavePlan {
+  /** Placement order for the page — one entry per slot, length ≤ limit. */
+  order: BrowseKind[];
+  /** 0-based rank offset + count to fetch from each kind for this page. */
+  fpStart: number;
+  fpCount: number;
+  extStart: number;
+  extCount: number;
+}
+
+export function planInterleave(
+  fpTotal: number,
+  extTotal: number,
+  offset: number,
+  limit: number,
+  fpPerGroup = FP_PER_GROUP,
+  extPerGroup = EXT_PER_GROUP
+): InterleavePlan {
+  const order: BrowseKind[] = [];
+  let fpUsed = 0;
+  let extUsed = 0;
+  let pos = 0;
+  let fpStart = -1;
+  let fpCount = 0;
+  let extStart = -1;
+  let extCount = 0;
+  const end = offset + Math.max(0, limit);
+
+  const emit = (kind: BrowseKind) => {
+    if (pos >= offset && pos < end) {
+      order.push(kind);
+      if (kind === 'first_party') {
+        if (fpStart < 0) fpStart = fpUsed;
+        fpCount++;
+      } else {
+        if (extStart < 0) extStart = extUsed;
+        extCount++;
+      }
+    }
+    if (kind === 'first_party') fpUsed++;
+    else extUsed++;
+    pos++;
+  };
+
+  while (pos < end && (fpUsed < fpTotal || extUsed < extTotal)) {
+    let progressed = false;
+    for (let k = 0; k < fpPerGroup && fpUsed < fpTotal && pos < end; k++) {
+      emit('first_party');
+      progressed = true;
+    }
+    for (let k = 0; k < extPerGroup && extUsed < extTotal && pos < end; k++) {
+      emit('external');
+      progressed = true;
+    }
+    if (!progressed) break; // page window starts past all rows
+  }
+
+  return {
+    order,
+    fpStart: fpStart < 0 ? 0 : fpStart,
+    fpCount,
+    extStart: extStart < 0 ? 0 : extStart,
+    extCount,
+  };
+}

--- a/tests/unit/server/api/models/browse.test.ts
+++ b/tests/unit/server/api/models/browse.test.ts
@@ -1,19 +1,26 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// A chainable Supabase query-builder mock: every builder method returns the
-// builder, and awaiting it resolves to a per-table result. `eq` is a spy so we
-// can assert the published-only filter and slug/id resolution.
+// A chainable Supabase query-builder mock. The browse handler queries the
+// `model_browse_cards` view once per kind (a head count + a row range), so the
+// view results are keyed by the `kind` filter; head queries return only a count.
 const eqSpy = vi.fn();
 const textSearchSpy = vi.fn();
+let viewByKind: Record<string, { rows?: any[]; count?: number; error?: any }> = {};
 let resultByTable: Record<string, any> = {};
 let singleByTable: Record<string, any> = {};
 
 function makeBuilder(table: string) {
+  let kind: string | null = null;
+  let head = false;
   const builder: any = {
-    select: () => builder,
+    select: (_cols?: any, opts?: any) => {
+      if (opts?.head) head = true;
+      return builder;
+    },
     eq: (...args: any[]) => {
       eqSpy(table, ...args);
+      if (args[0] === 'kind') kind = args[1];
       return builder;
     },
     in: () => builder,
@@ -24,7 +31,16 @@ function makeBuilder(table: string) {
       return builder;
     },
     maybeSingle: () => Promise.resolve(singleByTable[table] ?? { data: null, error: null }),
-    then: (resolve: any) => resolve(resultByTable[table] ?? { data: [], count: 0, error: null }),
+    then: (resolve: any) => {
+      if (table === 'model_browse_cards') {
+        const v = viewByKind[kind ?? ''] ?? {};
+        if (v.error) return resolve({ data: null, count: null, error: v.error });
+        const count = v.count ?? v.rows?.length ?? 0;
+        if (head) return resolve({ data: null, count, error: null });
+        return resolve({ data: v.rows ?? [], count, error: null });
+      }
+      return resolve(resultByTable[table] ?? { data: [], count: 0, error: null });
+    },
   };
   return builder;
 }
@@ -47,12 +63,43 @@ vi.stubGlobal('createError', (opts: any) => {
 const runtimeConfig = vi.fn();
 vi.stubGlobal('useRuntimeConfig', runtimeConfig);
 
+function mkRow(kind: 'first_party' | 'external', id: string, over: Record<string, any> = {}) {
+  return {
+    kind,
+    id,
+    slug: id,
+    title: id,
+    summary: null,
+    category_slug: 'misc',
+    created_at: '2026-06-11T00:00:00Z',
+    published_at: kind === 'external' ? '2026-06-11T00:00:00Z' : null,
+    like_count: 0,
+    comment_count: 0,
+    download_count: kind === 'first_party' ? 0 : null,
+    click_count: kind === 'external' ? 0 : null,
+    pricing_mode: kind === 'first_party' ? 'free' : null,
+    price_cents: null,
+    min_price_cents: null,
+    currency: kind === 'first_party' ? 'usd' : null,
+    license_code: kind === 'first_party' ? 'CC0-1.0' : null,
+    safety_critical: false,
+    is_featured: false,
+    author_id: null,
+    source_site: kind === 'external' ? 'thingiverse' : null,
+    source_url: kind === 'external' ? 'https://www.thingiverse.com/thing:1' : null,
+    source_author_name: null,
+    primary_image_path: null,
+    ...over,
+  };
+}
+
 describe('server/api/models browse + detail routes', () => {
   let listHandler: Function;
   let detailHandler: Function;
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    viewByKind = {};
     resultByTable = {};
     singleByTable = {};
     runtimeConfig.mockReturnValue({ public: { supabaseUrl: 'https://x.supabase.co' } });
@@ -63,84 +110,36 @@ describe('server/api/models browse + detail routes', () => {
 
   describe('GET /api/models (browse)', () => {
     it('reads the unified model_browse_cards view', async () => {
-      resultByTable['model_browse_cards'] = { data: [], count: 0, error: null };
+      viewByKind = { first_party: { count: 0 }, external: { count: 0 } };
       await listHandler({});
       expect(mockService.from).toHaveBeenCalledWith('model_browse_cards');
     });
 
     it('applies full-text search when q is present', async () => {
       (getQuery as any).mockReturnValue({ q: 'gauge pod' });
-      resultByTable['model_browse_cards'] = { data: [], count: 0, error: null };
+      viewByKind = { first_party: { count: 0 }, external: { count: 0 } };
       await listHandler({});
       expect(textSearchSpy).toHaveBeenCalledWith('search', 'gauge pod', expect.objectContaining({ type: 'websearch' }));
     });
 
-    it('scopes to external listings of a given source site', async () => {
+    it('scopes to external listings of a given source site (single-kind path)', async () => {
       (getQuery as any).mockReturnValue({ source: 'thingiverse' });
-      resultByTable['model_browse_cards'] = { data: [], count: 0, error: null };
+      viewByKind = { external: { rows: [], count: 0 } };
       await listHandler({});
       expect(eqSpy).toHaveBeenCalledWith('model_browse_cards', 'kind', 'external');
       expect(eqSpy).toHaveBeenCalledWith('model_browse_cards', 'source_site', 'thingiverse');
     });
 
     it('maps first-party + external rows to discriminated cards', async () => {
-      resultByTable['model_browse_cards'] = {
-        data: [
-          {
-            kind: 'first_party',
-            id: 'm1',
-            slug: 'gauge-pod',
-            title: 'Gauge Pod',
-            summary: null,
-            category_slug: 'dash-gauges',
-            created_at: '2026-06-11T00:00:00Z',
-            published_at: null,
-            like_count: 2,
-            comment_count: 0,
-            download_count: 9,
-            click_count: null,
-            pricing_mode: 'free',
-            price_cents: null,
-            min_price_cents: null,
-            currency: 'usd',
-            license_code: 'CC-BY-4.0',
-            safety_critical: false,
-            is_featured: false,
-            author_id: 'u1',
-            source_site: null,
-            source_url: null,
-            source_author_name: null,
-            primary_image_path: 'm1/a.webp',
-          },
-          {
-            kind: 'external',
-            id: 'e1',
-            slug: 'cool-knob',
-            title: 'Cool Knob',
-            summary: 'shiny',
-            category_slug: 'interior',
-            created_at: '2026-06-12T00:00:00Z',
-            published_at: '2026-06-13T00:00:00Z',
-            like_count: 5,
-            comment_count: 0,
-            download_count: null,
-            click_count: 12,
-            pricing_mode: null,
-            price_cents: null,
-            min_price_cents: null,
-            currency: null,
-            license_code: null,
-            safety_critical: false,
-            is_featured: false,
-            author_id: null,
-            source_site: 'thingiverse',
-            source_url: 'https://www.thingiverse.com/thing:1',
-            source_author_name: 'Bob',
-            primary_image_path: 'external/e1/x.webp',
-          },
-        ],
-        count: 2,
-        error: null,
+      viewByKind = {
+        first_party: {
+          rows: [mkRow('first_party', 'm1', { slug: 'gauge-pod', category_slug: 'dash-gauges', author_id: 'u1', download_count: 9, like_count: 2, primary_image_path: 'm1/a.webp' })],
+          count: 1,
+        },
+        external: {
+          rows: [mkRow('external', 'e1', { slug: 'cool-knob', summary: 'shiny', click_count: 12, source_author_name: 'Bob', primary_image_path: 'external/e1/x.webp' })],
+          count: 1,
+        },
       };
       resultByTable['profiles'] = { data: [{ id: 'u1', display_name: 'Cole', username: 'cole', avatar_url: null }] };
 
@@ -155,8 +154,21 @@ describe('server/api/models browse + detail routes', () => {
       expect(ext.primaryImage).toContain('/storage/v1/object/public/model-images/external/e1/x.webp');
     });
 
-    it('500s when the query errors', async () => {
-      resultByTable['model_browse_cards'] = { data: null, count: null, error: { message: 'boom' } };
+    it('leads with two first-party then one external (2:1 interleave)', async () => {
+      const fpRows = [0, 1, 2, 3, 4].map((i) => mkRow('first_party', `f${i}`));
+      const extRows = [0, 1, 2, 3, 4].map((i) => mkRow('external', `e${i}`));
+      viewByKind = {
+        first_party: { rows: fpRows, count: 5 },
+        external: { rows: extRows, count: 5 },
+      };
+      const res = await listHandler({});
+      expect(res.total).toBe(10);
+      // 2 first-party, then 1 external, repeating — external never buried.
+      expect(res.models.map((c: any) => c.id)).toEqual(['f0', 'f1', 'e0', 'f2', 'f3', 'e1', 'f4', 'e2', 'e3', 'e4']);
+    });
+
+    it('500s when a query errors', async () => {
+      viewByKind = { first_party: { error: { message: 'boom' } }, external: { count: 0 } };
       await expect(listHandler({})).rejects.toMatchObject({ statusCode: 500 });
     });
   });

--- a/tests/unit/utils/browseInterleave.test.ts
+++ b/tests/unit/utils/browseInterleave.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { planInterleave } from '~~/server/utils/browseInterleave';
+
+describe('planInterleave — 2:1 lead with first-party', () => {
+  it('interleaves two first-party then one external on page 1', () => {
+    const p = planInterleave(100, 100, 0, 9);
+    expect(p.order).toEqual([
+      'first_party',
+      'first_party',
+      'external',
+      'first_party',
+      'first_party',
+      'external',
+      'first_party',
+      'first_party',
+      'external',
+    ]);
+    expect(p).toMatchObject({ fpStart: 0, fpCount: 6, extStart: 0, extCount: 3 });
+  });
+
+  it('continues cleanly onto page 2 (correct rank offsets)', () => {
+    const p = planInterleave(100, 100, 9, 9);
+    // positions 9..17 → fp ranks 6..11, ext ranks 3..5
+    expect(p).toMatchObject({ fpStart: 6, fpCount: 6, extStart: 3, extCount: 3 });
+    expect(p.order.filter((k) => k === 'first_party')).toHaveLength(6);
+    expect(p.order.filter((k) => k === 'external')).toHaveLength(3);
+  });
+
+  it('fills the rest with external once first-party run out (page stays full)', () => {
+    const p = planInterleave(3, 100, 0, 10);
+    expect(p.order).toEqual([
+      'first_party',
+      'first_party',
+      'external',
+      'first_party',
+      'external',
+      'external',
+      'external',
+      'external',
+      'external',
+      'external',
+    ]);
+    expect(p).toMatchObject({ fpStart: 0, fpCount: 3, extStart: 0, extCount: 7 });
+  });
+
+  it('fills with first-party once external run out', () => {
+    const p = planInterleave(100, 2, 0, 10);
+    // g0: fp fp ext | g1: fp fp ext | then ext gone → fp fp fp fp
+    expect(p.order).toEqual([
+      'first_party',
+      'first_party',
+      'external',
+      'first_party',
+      'first_party',
+      'external',
+      'first_party',
+      'first_party',
+      'first_party',
+      'first_party',
+    ]);
+    expect(p).toMatchObject({ fpCount: 8, extCount: 2 });
+  });
+
+  it('returns only first-party when there are no external', () => {
+    const p = planInterleave(50, 0, 0, 5);
+    expect(p.order).toEqual(Array(5).fill('first_party'));
+    expect(p).toMatchObject({ fpStart: 0, fpCount: 5, extCount: 0 });
+  });
+
+  it('returns only external when there are no first-party', () => {
+    const p = planInterleave(0, 50, 0, 5);
+    expect(p.order).toEqual(Array(5).fill('external'));
+    expect(p).toMatchObject({ extStart: 0, extCount: 5, fpCount: 0 });
+  });
+
+  it('handles a final partial page', () => {
+    const p = planInterleave(5, 2, 0, 24);
+    // total 7: fp fp ext fp fp ext fp
+    expect(p.order).toEqual([
+      'first_party',
+      'first_party',
+      'external',
+      'first_party',
+      'first_party',
+      'external',
+      'first_party',
+    ]);
+    expect(p).toMatchObject({ fpCount: 5, extCount: 2 });
+  });
+
+  it('returns an empty plan when the offset is past the end', () => {
+    const p = planInterleave(3, 1, 100, 24);
+    expect(p.order).toEqual([]);
+    expect(p).toMatchObject({ fpCount: 0, extCount: 0 });
+  });
+});
+
+describe('planInterleave — pagination integrity (nothing buried or duplicated)', () => {
+  const cases: Array<[number, number, number]> = [
+    [100, 100, 24],
+    [50, 7, 24],
+    [7, 50, 24],
+    [0, 30, 24],
+    [30, 0, 24],
+    [1, 1, 24],
+    [25, 25, 10],
+    [200, 3, 24],
+    [3, 200, 24],
+  ];
+
+  it.each(cases)('fp=%i ext=%i limit=%i: every item appears exactly once, no early short page', (fpTotal, extTotal, limit) => {
+    const total = fpTotal + extTotal;
+    const fpSeen = new Set<number>();
+    const extSeen = new Set<number>();
+    let collected = 0;
+
+    for (let offset = 0; offset < total; offset += limit) {
+      const p = planInterleave(fpTotal, extTotal, offset, limit);
+      // Reconstruct the absolute ranks placed on this page, in order.
+      let fi = p.fpStart;
+      let ei = p.extStart;
+      for (const kind of p.order) {
+        if (kind === 'first_party') {
+          expect(fpSeen.has(fi)).toBe(false);
+          fpSeen.add(fi++);
+        } else {
+          expect(extSeen.has(ei)).toBe(false);
+          extSeen.add(ei++);
+        }
+      }
+      collected += p.order.length;
+      const isLastPage = offset + limit >= total;
+      if (!isLastPage) expect(p.order.length).toBe(limit); // full pages until the end
+    }
+
+    expect(collected).toBe(total);
+    expect(fpSeen.size).toBe(fpTotal);
+    expect(extSeen.size).toBe(extTotal);
+    // ranks are exactly 0..total-1 with none missing
+    for (let i = 0; i < fpTotal; i++) expect(fpSeen.has(i)).toBe(true);
+    for (let i = 0; i < extTotal; i++) expect(extSeen.has(i)).toBe(true);
+  });
+});


### PR DESCRIPTION
The proper follow-up to the reverted #622. First-party models now **lead** every browse page, with external ("Around the Web") listings **interspersed 2:1** — so first-party are prioritized but external are never buried off the end (the bug that hit prod).

## Why the previous approach failed
#622 ordered ALL first-party before ALL external. With pagination, once first-party exceeded the page size, page 1 became 100% first-party and external fell off entirely. Reverted in `f760bd07`.

## This approach
A stateless, **exhaustion-aware** interleave: the page repeats `[first-party ×2, external ×1]`, each kind in its own sorted order; when one kind runs out, the other fills the rest so pages stay full and pagination stays correct.

- `server/utils/browseInterleave.ts` — `planInterleave(fpTotal, extTotal, offset, limit)`: pure page planner returning the per-kind rank ranges to fetch + the placement order.
- `index.get` — counts each kind, plans the page, fetches the two ranges, assembles in order. Single-kind filters (`source` / `pricing`) keep the original straight query (no interleave needed).
- Applies to **all** sorts (newest / popular / likes / featured) — each kind is ordered by the chosen sort, then interleaved.

## Tests / verification
- **+17** interleave unit tests including a pagination-integrity property test across 9 size scenarios: every item appears exactly once, no early short page, ranks are contiguous 0..N.
- Browse handler tests reworked for the per-kind query pattern; a new case locks the 2:1 order (`f0 f1 e0 f2 f3 e1 …`).
- 1690 tests pass, build clean.
- **Verified against prod data**: total 59 (7 first-party + 52 external) → page 1 = `F F X F F X F F X F` then external fill the rest. External clearly visible from slot 3.

Cost: the mixed view now runs 2 count + 2 range queries (2 round trips) instead of 1 — acceptable for browse; can be optimized later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)