### PR TITLE
fix(models): external-listing submitter info + GrabCAD/SPA scraping

### DIFF
--- a/app/pages/admin/models.vue
+++ b/app/pages/admin/models.vue
@@ -416,7 +416,7 @@
   }
   async function confirmRejectExternal() {
     const row = externalRejectTarget.value;
-    if (!row || externalRejectReason.value.trim().length < 3) return;
+    if (!row || externalBusy.value || externalRejectReason.value.trim().length < 3) return;
     externalBusy.value = row.id;
     externalError.value = null;
     const { error } = await supabase.rpc('moderate_external_model', {

--- a/app/pages/admin/models.vue
+++ b/app/pages/admin/models.vue
@@ -326,7 +326,10 @@
     try {
       await $adminFetch('/api/admin/models/set-status', { method: 'POST', body: { modelId: m.id, status } });
       m.status = status;
-      flash('success', status === 'published' ? 'Model shown' : status === 'archived' ? 'Model hidden' : 'Model removed');
+      flash(
+        'success',
+        status === 'published' ? 'Model shown' : status === 'archived' ? 'Model hidden' : 'Model removed'
+      );
     } catch (e: any) {
       flash('error', e?.data?.statusMessage || e?.statusMessage || 'Failed to update model');
     }
@@ -362,12 +365,24 @@
     const { data, error } = await supabase
       .from('external_models')
       .select(
-        'id, slug, title, summary, source_site, source_url, source_author_name, source_license, category_slug, created_at'
+        'id, slug, title, summary, source_site, source_url, source_author_name, source_author_url, source_license, category_slug, submitted_by, created_at'
       )
       .eq('status', 'pending')
       .order('created_at', { ascending: true });
     if (error) externalError.value = error.message;
-    external.value = (data ?? []) as any[];
+    const rows = (data ?? []) as any[];
+    // Join the CMDIY member who submitted the link (distinct from the original
+    // designer in `source_author_name`).
+    const submitterIds = [...new Set(rows.map((r) => r.submitted_by).filter(Boolean))];
+    const profiles: Record<string, any> = {};
+    if (submitterIds.length) {
+      const { data: profs } = await supabase
+        .from('profiles')
+        .select('id, username, display_name, trust_level')
+        .in('id', submitterIds);
+      for (const p of (profs ?? []) as any[]) profiles[p.id] = p;
+    }
+    external.value = rows.map((r) => ({ ...r, submitter: profiles[r.submitted_by] || null }));
     externalCount.value = external.value.length;
     externalLoading.value = false;
   }
@@ -391,15 +406,23 @@
     externalCount.value = external.value.length;
   }
 
-  async function rejectExternal(row: any) {
-    const reason = window.prompt(`Reject "${row.title}"\n\nRejection reason (shown to submitter):`);
-    if (reason === null) return; // cancelled
+  // Reject flow: a proper reason modal (the reason is stored on the listing,
+  // shown to the submitter in their dashboard, and emailed to them).
+  const externalRejectTarget = ref<any | null>(null);
+  const externalRejectReason = ref('');
+  function openRejectExternal(row: any) {
+    externalRejectTarget.value = row;
+    externalRejectReason.value = '';
+  }
+  async function confirmRejectExternal() {
+    const row = externalRejectTarget.value;
+    if (!row || externalRejectReason.value.trim().length < 3) return;
     externalBusy.value = row.id;
     externalError.value = null;
     const { error } = await supabase.rpc('moderate_external_model', {
       p_id: row.id,
       p_status: 'rejected',
-      p_notes: reason.trim() || undefined,
+      p_notes: externalRejectReason.value.trim(),
     });
     externalBusy.value = null;
     if (error) {
@@ -409,6 +432,8 @@
     flash('success', `Rejected "${row.title}"`);
     external.value = external.value.filter((r) => r.id !== row.id);
     externalCount.value = external.value.length;
+    externalRejectTarget.value = null;
+    externalRejectReason.value = '';
   }
 
   // ----- lazy per-tab load -----
@@ -454,7 +479,9 @@
     <div class="container mx-auto px-4 py-8">
       <div class="breadcrumbs text-sm mb-4">
         <ul>
-          <li><NuxtLink to="/admin" class="link link-primary"><i class="fas fa-gauge mr-1"></i> Admin</NuxtLink></li>
+          <li>
+            <NuxtLink to="/admin" class="link link-primary"><i class="fas fa-gauge mr-1"></i> Admin</NuxtLink>
+          </li>
           <li><span>3D Models</span></li>
         </ul>
       </div>
@@ -515,16 +542,18 @@
                   <span class="text-sm opacity-70">
                     {{ v.owner?.display_name || v.owner?.username || 'Unknown' }}
                   </span>
-                  <span v-if="v.owner" class="badge badge-sm capitalize" :class="trustTone[v.owner.trust_level] || 'badge-ghost'">
+                  <span
+                    v-if="v.owner"
+                    class="badge badge-sm capitalize"
+                    :class="trustTone[v.owner.trust_level] || 'badge-ghost'"
+                  >
                     {{ v.owner.trust_level }}
                   </span>
                 </div>
               </div>
 
               <p v-if="v.model?.summary" class="text-sm opacity-80">{{ v.model.summary }}</p>
-              <p v-if="v.changelog" class="text-sm">
-                <span class="opacity-50">Changelog:</span> {{ v.changelog }}
-              </p>
+              <p v-if="v.changelog" class="text-sm"><span class="opacity-50">Changelog:</span> {{ v.changelog }}</p>
 
               <!-- Images -->
               <div v-if="v.images.length" class="flex gap-2 flex-wrap">
@@ -624,11 +653,17 @@
                 <td class="text-sm whitespace-nowrap">
                   {{ m.owner?.display_name || m.owner?.username || m.owner_id.slice(0, 8) }}
                 </td>
-                <td><span class="badge badge-ghost badge-sm capitalize">{{ m.pricing_mode }}</span></td>
                 <td>
-                  <span class="badge badge-sm capitalize" :class="modelStatusTone[m.status] || 'badge-ghost'">{{ m.status }}</span>
+                  <span class="badge badge-ghost badge-sm capitalize">{{ m.pricing_mode }}</span>
                 </td>
-                <td class="text-right text-xs opacity-70 whitespace-nowrap">{{ m.download_count }} / {{ m.like_count }}</td>
+                <td>
+                  <span class="badge badge-sm capitalize" :class="modelStatusTone[m.status] || 'badge-ghost'">{{
+                    m.status
+                  }}</span>
+                </td>
+                <td class="text-right text-xs opacity-70 whitespace-nowrap">
+                  {{ m.download_count }} / {{ m.like_count }}
+                </td>
                 <td class="text-right">
                   <div class="flex justify-end items-center gap-1.5">
                     <button
@@ -697,7 +732,9 @@
             <div class="card-body gap-2">
               <div class="flex flex-wrap items-start justify-between gap-2">
                 <div class="flex items-center gap-2 flex-wrap">
-                  <span class="badge badge-sm capitalize" :class="reasonTone[r.reason] || 'badge-ghost'">{{ r.reason }}</span>
+                  <span class="badge badge-sm capitalize" :class="reasonTone[r.reason] || 'badge-ghost'">{{
+                    r.reason
+                  }}</span>
                   <NuxtLink
                     v-if="r.model"
                     :to="`/models/${r.model.slug}`"
@@ -748,7 +785,9 @@
             <tbody>
               <tr v-for="s in sellers" :key="s.user_id" :class="{ 'opacity-50': s.selling_disabled }">
                 <td>
-                  <div class="font-medium">{{ s.profile?.display_name || s.profile?.username || s.user_id.slice(0, 8) }}</div>
+                  <div class="font-medium">
+                    {{ s.profile?.display_name || s.profile?.username || s.user_id.slice(0, 8) }}
+                  </div>
                   <div class="text-xs opacity-50 font-mono">{{ s.stripe_account_id }}</div>
                 </td>
                 <td>
@@ -757,13 +796,23 @@
                   </span>
                 </td>
                 <td>
-                  <i :class="s.charges_enabled ? 'fas fa-circle-check text-success' : 'fas fa-circle-xmark text-error/60'"></i>
+                  <i
+                    :class="
+                      s.charges_enabled ? 'fas fa-circle-check text-success' : 'fas fa-circle-xmark text-error/60'
+                    "
+                  ></i>
                 </td>
                 <td>
-                  <i :class="s.payouts_enabled ? 'fas fa-circle-check text-success' : 'fas fa-circle-xmark text-error/60'"></i>
+                  <i
+                    :class="
+                      s.payouts_enabled ? 'fas fa-circle-check text-success' : 'fas fa-circle-xmark text-error/60'
+                    "
+                  ></i>
                 </td>
                 <td class="text-center">
-                  <span :class="s.strikes >= 3 ? 'text-error font-bold' : s.strikes > 0 ? 'text-warning' : 'opacity-40'">
+                  <span
+                    :class="s.strikes >= 3 ? 'text-error font-bold' : s.strikes > 0 ? 'text-warning' : 'opacity-40'"
+                  >
                     {{ s.strikes }}
                   </span>
                 </td>
@@ -843,7 +892,9 @@
                   <td class="text-right whitespace-nowrap">{{ fmt(p.amount_cents) }}</td>
                   <td class="text-right whitespace-nowrap opacity-70">{{ fmt(p.application_fee_cents) }}</td>
                   <td>
-                    <span class="badge badge-xs capitalize" :class="statusTone[p.status] || 'badge-ghost'">{{ p.status }}</span>
+                    <span class="badge badge-xs capitalize" :class="statusTone[p.status] || 'badge-ghost'">{{
+                      p.status
+                    }}</span>
                   </td>
                   <td class="text-right whitespace-nowrap text-xs opacity-60">{{ fmtDate(p.created_at) }}</td>
                 </tr>
@@ -880,8 +931,20 @@
                   </div>
                   <p class="text-xs opacity-60 mt-1">Submitted {{ fmtDate(row.created_at) }}</p>
                 </div>
-                <div class="text-sm opacity-70 shrink-0">
-                  {{ row.source_author_name || '—' }}
+                <div class="flex items-center gap-2 shrink-0">
+                  <div class="text-right">
+                    <p class="text-xs opacity-50 leading-tight">Submitted by</p>
+                    <p class="text-sm font-medium leading-tight">
+                      {{ row.submitter?.display_name || row.submitter?.username || 'Unknown' }}
+                    </p>
+                  </div>
+                  <span
+                    v-if="row.submitter"
+                    class="badge badge-sm capitalize"
+                    :class="trustTone[row.submitter.trust_level] || 'badge-ghost'"
+                  >
+                    {{ row.submitter.trust_level }}
+                  </span>
                 </div>
               </div>
 
@@ -900,13 +963,25 @@
                 <span v-if="row.source_license" class="badge badge-neutral badge-sm">
                   {{ row.source_license }}
                 </span>
+                <span v-if="row.source_author_name" class="text-xs opacity-60">
+                  Designer:
+                  <a
+                    v-if="row.source_author_url"
+                    :href="row.source_author_url"
+                    target="_blank"
+                    rel="nofollow noopener"
+                    class="link link-hover"
+                    >{{ row.source_author_name }}</a
+                  >
+                  <template v-else>{{ row.source_author_name }}</template>
+                </span>
               </div>
 
               <div class="card-actions justify-end pt-2 border-t border-base-300">
                 <button
                   class="btn btn-sm btn-error btn-outline"
                   :disabled="externalBusy === row.id"
-                  @click="rejectExternal(row)"
+                  @click="openRejectExternal(row)"
                 >
                   <span v-if="externalBusy === row.id" class="loading loading-spinner loading-xs"></span>
                   <i v-else class="fas fa-xmark mr-1"></i> Reject
@@ -1019,6 +1094,39 @@
         </div>
       </div>
       <form method="dialog" class="modal-backdrop" @click="confirmRemove = null"><button>close</button></form>
+    </dialog>
+
+    <!-- Reject external listing modal -->
+    <dialog class="modal" :class="{ 'modal-open': !!externalRejectTarget }">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">Reject "{{ externalRejectTarget?.title }}"</h3>
+        <p class="text-sm opacity-70 py-2">
+          The submitter is emailed this reason and sees it on their dashboard. Be specific — e.g. the page couldn't be
+          read, it isn't a Classic Mini part, or it links to a profile instead of a model.
+        </p>
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend">Reason</legend>
+          <textarea
+            v-model="externalRejectReason"
+            class="textarea w-full"
+            rows="3"
+            placeholder="e.g. We couldn't read model details from this GrabCAD link — please submit a Thingiverse, Printables, or MakerWorld link instead."
+          ></textarea>
+        </fieldset>
+        <div class="modal-action">
+          <button type="button" class="btn btn-ghost" @click="externalRejectTarget = null">Cancel</button>
+          <button
+            type="button"
+            class="btn btn-error"
+            :disabled="externalRejectReason.trim().length < 3 || externalBusy === externalRejectTarget?.id"
+            @click="confirmRejectExternal"
+          >
+            <span v-if="externalBusy === externalRejectTarget?.id" class="loading loading-spinner loading-sm"></span>
+            Reject listing
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop" @click="externalRejectTarget = null"><button>close</button></form>
     </dialog>
 
     <!-- Toast -->

--- a/data/models/external-sources.ts
+++ b/data/models/external-sources.ts
@@ -19,6 +19,7 @@ export type ExternalSourceSite =
   | 'cults3d'
   | 'thangs'
   | 'myminifactory'
+  | 'grabcad'
   | 'other';
 
 export interface ExternalSourceConfig {
@@ -37,6 +38,14 @@ export interface ExternalSourceConfig {
   defaultLicense: string | null;
   /** Whether the default license permits commercial use. */
   commercialUseAllowed: boolean | null;
+  /**
+   * Skip the self-hosted direct fetch and go straight to the render service.
+   * For client-rendered SPAs (e.g. GrabCAD's AngularJS pages) the static HTML
+   * carries no usable OG/JSON-LD — only an unrendered template shell — so the
+   * direct parse would otherwise "succeed" with generic junk and never fall
+   * back. See `server/utils/external-models/index.ts`.
+   */
+  requiresRender?: boolean;
   /** Optional brand logo at `/public/brands/{id}.svg`. */
   logo?: string;
 }
@@ -106,6 +115,23 @@ export const EXTERNAL_SOURCES: Record<ExternalSourceSite, ExternalSourceConfig> 
     defaultLicense: null,
     commercialUseAllowed: null,
   },
+  grabcad: {
+    id: 'grabcad',
+    label: 'GrabCAD',
+    // GrabCAD (a Stratasys brand) teal. Verify against current brand guidelines.
+    brandColor: '#00B2A9',
+    textColor: '#FFFFFF',
+    hostnames: ['grabcad.com', 'www.grabcad.com'],
+    // Model pages are /library/{slug}; capture the slug. Profile pages
+    // (/{user}/models) intentionally don't match → no external id.
+    urlPattern: /grabcad\.com\/library\/([\w-]+)/i,
+    // GrabCAD models carry the GrabCAD Terms, not a standard CC license; leave
+    // unknown rather than asserting a permissive default.
+    defaultLicense: null,
+    commercialUseAllowed: null,
+    // AngularJS SPA — static HTML has no real OG/JSON-LD. Force the render path.
+    requiresRender: true,
+  },
   other: {
     id: 'other',
     label: 'External',
@@ -126,6 +152,7 @@ export const SUPPORTED_SOURCE_SITES: ExternalSourceSite[] = [
   'cults3d',
   'thangs',
   'myminifactory',
+  'grabcad',
 ];
 
 export function sourceConfig(site: ExternalSourceSite | string | null | undefined): ExternalSourceConfig {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import { ArchiveItems, ToolboxItems } from './data/models/generic';
 import { AI_ANSWER_BOTS, AI_TRAINING_BOTS, PRIVATE_DISALLOW } from './server/utils/aiBots';
@@ -545,13 +546,7 @@ export default defineNuxtConfig({
       // build). nitro matches ignore patterns with String.startsWith, so these
       // are PREFIXES (trailing slash) — they catch `/archive/colors/<id>` but not
       // the prerendered index `/archive/colors` itself.
-      ignore: [
-        '/admin',
-        '/raw',
-        '/archive/colors/',
-        '/archive/wheels/',
-        '/archive/documents/',
-      ],
+      ignore: ['/admin', '/raw', '/archive/colors/', '/archive/wheels/', '/archive/documents/'],
       routes: [
         '/',
         '/privacy',
@@ -575,6 +570,16 @@ export default defineNuxtConfig({
     },
     // Minify responses
     minify: true,
+    // botid/server does a guarded `await import("next/headers")` for its Next.js
+    // code path. This is a Nuxt app, so that bare specifier never resolves and
+    // Rollup logs a noisy UNRESOLVED_IMPORT warning on every server build. Alias
+    // it to a local stub so the import resolves cleanly; botid's try/catch around
+    // it still falls back to null (the Next path is never taken here). Done via an
+    // alias rather than a custom onwarn so Nitro's default warning filtering
+    // (circular-dep noise, etc.) stays intact.
+    alias: {
+      'next/headers': fileURLToPath(new URL('./server/stubs/next-headers-stub.mjs', import.meta.url)),
+    },
   },
 
   vite: {

--- a/server/stubs/next-headers-stub.mjs
+++ b/server/stubs/next-headers-stub.mjs
@@ -1,0 +1,21 @@
+// Stub for `next/headers`, aliased in nuxt.config.ts (nitro.alias).
+//
+// botid/server does a guarded `await import("next/headers")` to read request
+// headers when running inside Next.js. This is a Nuxt app — that module doesn't
+// exist, and the import sits inside a try/catch that falls back to null, so the
+// only effect of the missing module was a noisy Rollup UNRESOLVED_IMPORT warning
+// on every server build. Aliasing the bare specifier here makes it resolve.
+//
+// `headers()` throws so botid's try/catch takes its existing null fallback; it is
+// never actually invoked in production (botid reads headers from the Vercel
+// request context first and only probes next/headers in dev).
+//
+// Kept in server/stubs (NOT server/utils) so Nitro doesn't auto-import these
+// generic names into server code.
+export function headers() {
+  throw new Error('next/headers is not available outside Next.js');
+}
+
+export function cookies() {
+  throw new Error('next/cookies is not available outside Next.js');
+}

--- a/server/utils/external-models/enrichers.ts
+++ b/server/utils/external-models/enrichers.ts
@@ -79,9 +79,8 @@ const makerworld: Enricher = (base, ctx) => {
   // Author: "designed by X" in the description, else OG author.
   const m = base.description?.match(/designed by\s+([^.]+)/i);
   if (m) f.authorName = m[1].trim();
-  f.description = (base.description ?? '')
-    .replace(/^Download this free 3D print file designed by [^.]+\.\s*/i, '')
-    .trim() || f.title;
+  f.description =
+    (base.description ?? '').replace(/^Download this free 3D print file designed by [^.]+\.\s*/i, '').trim() || f.title;
   f.summary = f.description ? truncate(f.description, 280) : null;
   if (f.authorName) f.authorUrl = `https://makerworld.com/en/@${f.authorName.replace(/\s+/g, '')}`;
   return f;
@@ -132,6 +131,20 @@ const myminifactory: Enricher = (base, ctx) => {
   return f;
 };
 
+const grabcad: Enricher = (base, ctx) => {
+  const f = baseFields(base, ctx);
+  // Strip GrabCAD title suffixes (rendered metadata only — static pages are an
+  // unrendered shell, so `requiresRender` routes GrabCAD through the render
+  // service): "… | The GrabCAD Community Library", "… | CAD Models | GrabCAD",
+  // and the bare "… | GrabCAD" / "… - GrabCAD".
+  f.title = f.title
+    .replace(/\s*[|\-–]\s*The GrabCAD Community Library\s*$/i, '')
+    .replace(/\s*[|\-–]\s*CAD Models\s*[|\-–]\s*GrabCAD\s*$/i, '')
+    .replace(/\s*[|\-–]\s*GrabCAD\s*$/i, '')
+    .trim();
+  return f;
+};
+
 /** Generic OG-only fallback for `source_site: 'other'`. */
 const generic: Enricher = (base, ctx) => baseFields(base, ctx);
 
@@ -142,6 +155,7 @@ export const ENRICHERS: Record<ExternalSourceSite, Enricher> = {
   cults3d,
   thangs,
   myminifactory,
+  grabcad,
   other: generic,
 };
 

--- a/server/utils/external-models/index.ts
+++ b/server/utils/external-models/index.ts
@@ -16,6 +16,7 @@ import {
   extractExternalId,
   isValidExternalUrl,
   normalizeExternalUrl,
+  sourceConfig,
 } from '../../../data/models/external-sources';
 import { fetchExternalPage, parseOpenGraph, type OgMetadata } from './ogParser';
 import { renderExternalPage } from './render';
@@ -65,22 +66,28 @@ export async function fetchExternalMetadata(rawUrl: string, deps: ScrapeDeps = {
 
   const sourceUrl = normalizeExternalUrl(rawUrl);
   const site = detectSourceSite(sourceUrl) ?? 'other';
+  const forceRender = sourceConfig(site).requiresRender === true;
 
-  // 1) Self-hosted direct fetch + OG/JSON-LD parse. `og` stays null when the
-  //    page is blocked (4xx), JS-only (200 with no usable metadata), or the
-  //    fetch errored — those fall through to the render service below.
+  // 1) Self-hosted direct fetch + OG/JSON-LD parse. Skipped entirely for sites
+  //    flagged `requiresRender` (client-rendered SPAs whose static HTML is only
+  //    an unrendered template shell — parsing it yields generic junk that would
+  //    masquerade as success). `og` stays null when the page is blocked (4xx),
+  //    JS-only (200 with no usable metadata), or the fetch errored — those fall
+  //    through to the render service below.
   let og: OgMetadata | null = null;
   let directStatus = 0;
-  try {
-    const page = await fetchExternalPage(sourceUrl, deps.fetchImpl);
-    directStatus = page.status;
-    if (page.status < 400) {
-      const parsed = parseOpenGraph(page.html);
-      if (parsed.title || parsed.image) og = parsed;
+  if (!forceRender) {
+    try {
+      const page = await fetchExternalPage(sourceUrl, deps.fetchImpl);
+      directStatus = page.status;
+      if (page.status < 400) {
+        const parsed = parseOpenGraph(page.html);
+        if (parsed.title || parsed.image) og = parsed;
+      }
+    } catch (e) {
+      // SSRF (private address) and too-large are terminal — never send those on.
+      if (e instanceof ScrapeError && (e.statusCode === 400 || e.statusCode === 413)) throw e;
     }
-  } catch (e) {
-    // SSRF (private address) and too-large are terminal — never send those on.
-    if (e instanceof ScrapeError && (e.statusCode === 400 || e.statusCode === 413)) throw e;
   }
 
   // 2) Render-service fallback for blocked / JS-only / empty pages. Runs in

--- a/server/utils/external-models/index.ts
+++ b/server/utils/external-models/index.ts
@@ -75,18 +75,22 @@ export async function fetchExternalMetadata(rawUrl: string, deps: ScrapeDeps = {
   //    JS-only (200 with no usable metadata), or the fetch errored — those fall
   //    through to the render service below.
   let og: OgMetadata | null = null;
-  let directStatus = 0;
   if (!forceRender) {
     try {
       const page = await fetchExternalPage(sourceUrl, deps.fetchImpl);
-      directStatus = page.status;
+      // A real 404 won't be fixed by rendering — fail now with a precise message
+      // rather than wasting a render call and returning a generic "blocked" error.
+      if (page.status === 404) {
+        throw new ScrapeError('That model page couldn’t be found (404). It may have been removed.', 404, site);
+      }
       if (page.status < 400) {
         const parsed = parseOpenGraph(page.html);
         if (parsed.title || parsed.image) og = parsed;
       }
     } catch (e) {
-      // SSRF (private address) and too-large are terminal — never send those on.
-      if (e instanceof ScrapeError && (e.statusCode === 400 || e.statusCode === 413)) throw e;
+      // ScrapeErrors (SSRF, too-large, non-HTML, or the 404 above) are terminal —
+      // never fall through to the render service for those.
+      if (e instanceof ScrapeError) throw e;
     }
   }
 
@@ -96,10 +100,9 @@ export async function fetchExternalMetadata(rawUrl: string, deps: ScrapeDeps = {
     og = await renderExternalPage(sourceUrl, deps.renderImpl, deps.microlinkApiKey); // throws ScrapeError if it also fails
   }
 
+  // A 404 already threw above; reaching here means the page (or render) yielded
+  // no usable metadata — login-walled, JS-only, or preview-blocked.
   if (!og) {
-    if (directStatus === 404) {
-      throw new ScrapeError('That model page couldn’t be found (404). It may have been removed.', 404, site);
-    }
     throw new ScrapeError(
       'We couldn’t read any model details from that page. It may require a login or block previews.',
       422,

--- a/server/utils/external-models/ogParser.ts
+++ b/server/utils/external-models/ogParser.ts
@@ -64,8 +64,12 @@ export function decodeHtmlEntities(input: string): string {
 }
 
 function getAttr(tag: string, attr: string): string | null {
-  // attr="value" | attr='value' (attribute order within the tag is irrelevant)
-  const re = new RegExp(`${attr}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i');
+  // attr="value" | attr='value' (attribute order within the tag is irrelevant).
+  // The negative lookbehind keeps `content` from matching inside `ng-attr-content`
+  // / `data-content` — SPA shells (e.g. GrabCAD's AngularJS pages) expose those
+  // carrying an unrendered `{{…}}` template literal that we must NOT read as the
+  // real attribute value.
+  const re = new RegExp(`(?<![-\\w:])${attr}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i');
   const m = tag.match(re);
   if (!m) return null;
   return decodeHtmlEntities(m[2] ?? m[3] ?? '').trim();
@@ -104,7 +108,14 @@ export function parseJsonLd(html: string): unknown[] {
 }
 
 function firstString(...vals: (string | null | undefined)[]): string | null {
-  for (const v of vals) if (v && v.trim()) return v.trim();
+  for (const v of vals) {
+    if (!v) continue;
+    // Drop unrendered client-side template tokens (`{{ … }}`) before considering
+    // a candidate — an SPA shell with no static fallback otherwise yields a
+    // literal "{{meta.title}}" as the title/description.
+    const cleaned = v.replace(/\{\{[^}]*\}\}/g, '').trim();
+    if (cleaned) return cleaned;
+  }
   return null;
 }
 
@@ -117,7 +128,14 @@ function harvestJsonLd(blocks: unknown[]): {
   keywords: string[];
   license: string | null;
 } {
-  const out = { name: null as string | null, description: null as string | null, image: [] as string[], author: null as string | null, keywords: [] as string[], license: null as string | null };
+  const out = {
+    name: null as string | null,
+    description: null as string | null,
+    image: [] as string[],
+    author: null as string | null,
+    keywords: [] as string[],
+    license: null as string | null,
+  };
   const visit = (node: unknown): void => {
     if (!node || typeof node !== 'object') return;
     if (Array.isArray(node)) {
@@ -133,19 +151,36 @@ function harvestJsonLd(blocks: unknown[]): {
     // image: string | {url} | array
     const img = obj.image;
     if (typeof img === 'string') out.image.push(img);
-    else if (img && typeof img === 'object' && typeof (img as Record<string, unknown>).url === 'string') out.image.push((img as Record<string, string>).url);
-    else if (Array.isArray(img)) for (const i of img) {
-      if (typeof i === 'string') out.image.push(i);
-      else if (i && typeof i === 'object' && typeof (i as Record<string, unknown>).url === 'string') out.image.push((i as Record<string, string>).url);
-    }
+    else if (img && typeof img === 'object' && typeof (img as Record<string, unknown>).url === 'string')
+      out.image.push((img as Record<string, string>).url);
+    else if (Array.isArray(img))
+      for (const i of img) {
+        if (typeof i === 'string') out.image.push(i);
+        else if (i && typeof i === 'object' && typeof (i as Record<string, unknown>).url === 'string')
+          out.image.push((i as Record<string, string>).url);
+      }
     // author: string | {name} | array
     const author = obj.author;
     if (typeof author === 'string') out.author ??= author;
-    else if (author && typeof author === 'object' && typeof (author as Record<string, unknown>).name === 'string') out.author ??= (author as Record<string, string>).name;
-    else if (Array.isArray(author) && author[0] && typeof author[0] === 'object' && typeof (author[0] as Record<string, unknown>).name === 'string') out.author ??= (author[0] as Record<string, string>).name;
+    else if (author && typeof author === 'object' && typeof (author as Record<string, unknown>).name === 'string')
+      out.author ??= (author as Record<string, string>).name;
+    else if (
+      Array.isArray(author) &&
+      author[0] &&
+      typeof author[0] === 'object' &&
+      typeof (author[0] as Record<string, unknown>).name === 'string'
+    )
+      out.author ??= (author[0] as Record<string, string>).name;
     // keywords: string (comma) | array
-    if (typeof obj.keywords === 'string') out.keywords.push(...obj.keywords.split(',').map((k) => k.trim()).filter(Boolean));
-    else if (Array.isArray(obj.keywords)) out.keywords.push(...(obj.keywords as unknown[]).filter((k): k is string => typeof k === 'string'));
+    if (typeof obj.keywords === 'string')
+      out.keywords.push(
+        ...obj.keywords
+          .split(',')
+          .map((k) => k.trim())
+          .filter(Boolean)
+      );
+    else if (Array.isArray(obj.keywords))
+      out.keywords.push(...(obj.keywords as unknown[]).filter((k): k is string => typeof k === 'string'));
   };
   blocks.forEach(visit);
   return out;
@@ -174,7 +209,13 @@ export function parseOpenGraph(html: string): OgMetadata {
 
   const keywords = Array.from(
     new Set(
-      [...(get('keywords')?.split(',').map((k) => k.trim()) ?? []), ...getAll('article:tag'), ...ld.keywords]
+      [
+        ...(get('keywords')
+          ?.split(',')
+          .map((k) => k.trim()) ?? []),
+        ...getAll('article:tag'),
+        ...ld.keywords,
+      ]
         .map((k) => k.trim())
         .filter(Boolean)
     )

--- a/server/utils/external-models/render.ts
+++ b/server/utils/external-models/render.ts
@@ -16,6 +16,8 @@ import { ScrapeError } from './errors';
 
 interface MicrolinkResponse {
   status?: string;
+  /** Upstream HTTP status of the rendered page (Microlink reports it here). */
+  statusCode?: number;
   data?: {
     title?: string;
     description?: string;
@@ -34,11 +36,7 @@ const DEFAULT_ENDPOINT = 'https://api.microlink.io';
  * back to MICROLINK_API_KEY in the environment so the function stays usable in
  * isolation (e.g. unit tests).
  */
-export async function renderExternalPage(
-  url: string,
-  fetchImpl?: typeof fetch,
-  apiKey?: string
-): Promise<OgMetadata> {
+export async function renderExternalPage(url: string, fetchImpl?: typeof fetch, apiKey?: string): Promise<OgMetadata> {
   // Strict undefined check: a forwarded '' (runtimeConfig default when unset)
   // means "no key" and must NOT fall through to process.env. Only an omitted
   // arg (e.g. a direct unit-test call) falls back.
@@ -68,6 +66,14 @@ export async function renderExternalPage(
   }
 
   if (body.status !== 'success' || !body.data) {
+    throw new ScrapeError('That site blocks automated previews and we couldn’t render it.', 422);
+  }
+
+  // Microlink wraps the render in `status:"success"` even when the upstream page
+  // returned an error (e.g. GrabCAD behind CloudFront answers 403 with an
+  // "ERROR: The request could not be satisfied" body). Treat any 4xx/5xx upstream
+  // status as blocked rather than storing the error page as model metadata.
+  if (typeof body.statusCode === 'number' && body.statusCode >= 400) {
     throw new ScrapeError('That site blocks automated previews and we couldn’t render it.', 422);
   }
 

--- a/tests/unit/external-models/scraper.test.ts
+++ b/tests/unit/external-models/scraper.test.ts
@@ -26,6 +26,7 @@ describe('detectSourceSite', () => {
     expect(detectSourceSite('https://cults3d.com/en/3d-model/tool/foo')).toBe('cults3d');
     expect(detectSourceSite('https://thangs.com/designer/x/3d-model/foo-123')).toBe('thangs');
     expect(detectSourceSite('https://www.myminifactory.com/object/3d-print-foo-123')).toBe('myminifactory');
+    expect(detectSourceSite('https://grabcad.com/library/austin-mini-1')).toBe('grabcad');
   });
   it('falls back to other for unknown hosts and null for non-URLs', () => {
     expect(detectSourceSite('https://example.com/cool-model')).toBe('other');
@@ -39,9 +40,14 @@ describe('extractExternalId', () => {
     expect(extractExternalId('https://www.printables.com/model/98765-foo')).toBe('98765');
     expect(extractExternalId('https://makerworld.com/en/models/555')).toBe('555');
     expect(extractExternalId('https://cults3d.com/en/3d-model/various/mini-knob')).toBe('mini-knob');
+    expect(extractExternalId('https://grabcad.com/library/classic-mini-rear-trailing-arm-1')).toBe(
+      'classic-mini-rear-trailing-arm-1'
+    );
   });
   it('returns null when there is no id pattern', () => {
     expect(extractExternalId('https://example.com/foo')).toBeNull();
+    // GrabCAD profile pages aren't model pages — no id
+    expect(extractExternalId('https://grabcad.com/mike--223/models')).toBeNull();
   });
 });
 
@@ -117,6 +123,18 @@ describe('parseMetaTags / parseOpenGraph', () => {
     const blocks = parseJsonLd('<script type="application/ld+json">{bad json}</script>');
     expect(blocks).toEqual([]);
   });
+
+  it('ignores ng-attr-content and drops {{ }} template placeholders (SPA shell)', () => {
+    // GrabCAD-style AngularJS shell: the real `content` must win over the
+    // adjacent `ng-attr-content`, and a pure-placeholder og:title is skipped.
+    const html = `
+      <title ng-bind="title">Free CAD Designs, Files &amp; 3D Models | The GrabCAD Community Library</title>
+      <meta name="description" ng-attr-content="{{meta.description}}" content="Static fallback blurb">
+      <meta property="og:title" content="{{model.title}}">`;
+    const og = parseOpenGraph(html);
+    expect(og.description).toBe('Static fallback blurb');
+    expect(og.title).toBe('Free CAD Designs, Files & 3D Models | The GrabCAD Community Library');
+  });
 });
 
 // --- enrichers --------------------------------------------------------------
@@ -160,12 +178,23 @@ describe('enrichers', () => {
 
   it('makerworld strips suffix + reads "designed by"', () => {
     const f = enrich(
-      base({ title: 'Cool Part - Free 3D Print Model - MakerWorld', description: 'Download this free 3D print file designed by Carol. Extra.' }),
+      base({
+        title: 'Cool Part - Free 3D Print Model - MakerWorld',
+        description: 'Download this free 3D print file designed by Carol. Extra.',
+      }),
       { url: 'https://makerworld.com/en/models/3', site: 'makerworld', externalId: '3' }
     );
     expect(f.title).toBe('Cool Part');
     expect(f.authorName).toBe('Carol');
     expect(f.description).toBe('Extra.');
+  });
+
+  it('grabcad strips its title suffixes', () => {
+    const e = (title: string, externalId: string | null = 'x') =>
+      enrich(base({ title }), { url: 'https://grabcad.com/library/x', site: 'grabcad', externalId }).title;
+    expect(e('Classic Mini Trailing Arm | The GrabCAD Community Library')).toBe('Classic Mini Trailing Arm');
+    expect(e('Mike | CAD Models | GrabCAD', null)).toBe('Mike');
+    expect(e('Widget - GrabCAD')).toBe('Widget');
   });
 
   it('generic (other) passes the OG title through', () => {
@@ -182,8 +211,7 @@ describe('enrichers', () => {
 // --- fetchExternalMetadata (injected fetch) ---------------------------------
 
 function fakeFetch(html: string, status = 200) {
-  return async (url: string) =>
-    ({ text: async () => html, url, status }) as unknown as Response;
+  return async (url: string) => ({ text: async () => html, url, status }) as unknown as Response;
 }
 
 describe('fetchExternalMetadata', () => {
@@ -248,11 +276,27 @@ describe('renderExternalPage (fallback)', () => {
   });
 
   it('throws ScrapeError when the service cannot render', async () => {
-    await expect(renderExternalPage('https://x/y', fakeJsonFetch({ status: 'fail' }))).rejects.toBeInstanceOf(ScrapeError);
+    await expect(renderExternalPage('https://x/y', fakeJsonFetch({ status: 'fail' }))).rejects.toBeInstanceOf(
+      ScrapeError
+    );
   });
 
   it('throws ScrapeError when rate-limited', async () => {
     await expect(renderExternalPage('https://x/y', fakeJsonFetch({}, 429))).rejects.toBeInstanceOf(ScrapeError);
+  });
+
+  it('throws ScrapeError when the rendered page errored upstream (statusCode >= 400)', async () => {
+    // Microlink reports success but the upstream page was a CloudFront 403 error.
+    await expect(
+      renderExternalPage(
+        'https://grabcad.com/library/x',
+        fakeJsonFetch({
+          status: 'success',
+          statusCode: 403,
+          data: { title: 'ERROR: The request could not be satisfied', logo: { url: 'https://t3.gstatic.com/favicon' } },
+        })
+      )
+    ).rejects.toBeInstanceOf(ScrapeError);
   });
 });
 
@@ -285,5 +329,43 @@ describe('fetchExternalMetadata — render fallback wiring', () => {
     });
     expect(rendered).toBe(false);
     expect(result.title).toBe('Sump Guard');
+  });
+});
+
+describe('fetchExternalMetadata — requiresRender (GrabCAD SPA)', () => {
+  it('skips the direct fetch entirely and renders', async () => {
+    let directHit = false;
+    const result = await fetchExternalMetadata('https://grabcad.com/library/classic-mini-boot-rough-1', {
+      fetchImpl: (async (url: string) => {
+        directHit = true; // must NOT be called for a requiresRender site
+        return {
+          text: async () => '<title>Free CAD Designs, Files & 3D Models | The GrabCAD Community Library</title>',
+          url,
+          status: 200,
+        } as unknown as Response;
+      }) as unknown as typeof fetch,
+      renderImpl: fakeJsonFetch({
+        status: 'success',
+        statusCode: 200,
+        data: { title: 'Classic Mini Boot | GrabCAD', author: 'Bob', image: { url: 'https://cdn.test/boot.jpg' } },
+      }) as unknown as typeof fetch,
+    });
+    expect(directHit).toBe(false);
+    expect(result.sourceSite).toBe('grabcad');
+    expect(result.title).toBe('Classic Mini Boot'); // enricher stripped the GrabCAD suffix
+    expect(result.images[0]).toEqual({ url: 'https://cdn.test/boot.jpg', isPrimary: true });
+  });
+
+  it('fails cleanly (no junk stored) when GrabCAD is blocked upstream', async () => {
+    await expect(
+      fetchExternalMetadata('https://grabcad.com/library/classic-mini-rear-trailing-arm-1', {
+        fetchImpl: fakeFetch('', 200),
+        renderImpl: fakeJsonFetch({
+          status: 'success',
+          statusCode: 403,
+          data: { title: 'ERROR: The request could not be satisfied', logo: { url: 'https://t3.gstatic.com/fav' } },
+        }) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(ScrapeError);
   });
 });

--- a/tests/unit/external-models/scraper.test.ts
+++ b/tests/unit/external-models/scraper.test.ts
@@ -330,6 +330,20 @@ describe('fetchExternalMetadata — render fallback wiring', () => {
     expect(rendered).toBe(false);
     expect(result.title).toBe('Sump Guard');
   });
+
+  it('does NOT render on a real 404 (terminal — saves render quota)', async () => {
+    let rendered = false;
+    await expect(
+      fetchExternalMetadata('https://www.thingiverse.com/thing:404', {
+        fetchImpl: fakeFetch('', 404),
+        renderImpl: (async () => {
+          rendered = true;
+          return fakeJsonFetch({})();
+        }) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(ScrapeError);
+    expect(rendered).toBe(false);
+  });
 });
 
 describe('fetchExternalMetadata — requiresRender (GrabCAD SPA)', () => {


### PR DESCRIPTION
## What
Two fixes for the External 3D Model Listings ("Around the Web") admin/submission flow.

### 1. Admin: who submitted the external link
The External review tab showed `source_author_name` — the **original designer** on the source site — not the CMDIY member who submitted the link. Now joins `submitted_by → profiles` and shows **Submitted by {member} + trust badge**, with the source designer labeled separately near the outbound link.

Also: the reject action moved from a `window.prompt` to a proper reason **modal** (mirrors the first-party version). The reason is stored, shown on the submitter's dashboard, and — with the companion supabase PR — emailed to them.

### 2. GrabCAD links were storing generic junk
GrabCAD serves an **AngularJS shell**: the static HTML has no `og:`/`twitter:`/JSON-LD, just a generic `<title>` and unrendered `{{…}}` templates. Submissions stored titles like *"Free CAD Designs, Files & 3D Models | The GrabCAD Community Library"* and a literal `{{meta.description}}`. Root causes + fixes:

- **`getAttr` word-boundary bug** — it matched `ng-attr-content="{{…}}"` as `content`, reading the template literal. Fixed with a negative lookbehind.
- **`{{…}}` template tokens** are now stripped from parsed values.
- **GrabCAD registered** in the source registry (badge, `/library/{slug}` id) with a new `requiresRender` flag → SPA sites skip the useless direct parse and go straight to the render service.
- **`render.ts`** now treats microlink's upstream `statusCode ≥ 400` (GrabCAD sits behind CloudFront, which 403s the render) as blocked, instead of saving "ERROR: The request could not be satisfied" as the title.

Net: GrabCAD now works **iff** the paid microlink key can render it; otherwise the submission fails cleanly (no junk stored) and the submitter gets an actionable reason.

## Tests
`tests/unit/external-models/scraper.test.ts` extended — GrabCAD detection/id, SPA-shell parsing (`ng-attr-content` + `{{…}}`), `requiresRender` wiring, render `statusCode≥400` rejection, GrabCAD enricher. 67/67 pass.

## Companion
Backend (submitter rejection email) is in a separate `classicminidiy-supabase` PR. This PR works without it — the reason is still stored + shown on the submitter dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)