### PR TITLE
feat(models): email model owners on admin takedown, hide + seller kill-switch

### DIFF
--- a/server/api/admin/models/resolve-report.post.ts
+++ b/server/api/admin/models/resolve-report.post.ts
@@ -53,7 +53,7 @@ export default defineEventHandler(async (event) => {
       .update({ status: 'removed' })
       .eq('id', report.model_id)
       .select('owner_id, title')
-      .single();
+      .maybeSingle();
     if (mErr) throw createError({ statusCode: 500, statusMessage: mErr.message });
     modelRemoved = true;
 

--- a/server/api/admin/models/resolve-report.post.ts
+++ b/server/api/admin/models/resolve-report.post.ts
@@ -48,9 +48,25 @@ export default defineEventHandler(async (event) => {
 
   let modelRemoved = false;
   if (action === 'takedown') {
-    const { error: mErr } = await db.from('models').update({ status: 'removed' }).eq('id', report.model_id);
+    const { data: model, error: mErr } = await db
+      .from('models')
+      .update({ status: 'removed' })
+      .eq('id', report.model_id)
+      .select('owner_id, title')
+      .single();
     if (mErr) throw createError({ statusCode: 500, statusMessage: mErr.message });
     modelRemoved = true;
+
+    // Notify the model owner of the takedown (skip if the owner filed the report).
+    if (model?.owner_id && model.owner_id !== report.reporter_id) {
+      await db.from('notification_queue').insert({
+        user_id: model.owner_id,
+        event_type: 'model_removed',
+        payload: { model_id: report.model_id, title: model.title, reason: 'report_takedown' },
+        channel: 'email',
+        batch_key: `model_admin_action:${report.model_id}`,
+      });
+    }
   }
 
   // Registered reporters get a notification; DMCA email intake has no user row.

--- a/server/api/admin/models/set-status.post.ts
+++ b/server/api/admin/models/set-status.post.ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
   const db = getServiceClient();
   const { data: model, error: mErr } = await db
     .from('models')
-    .select('id, status, current_version_id, title')
+    .select('id, status, current_version_id, title, owner_id')
     .eq('id', modelId)
     .single();
   if (mErr || !model) throw createError({ statusCode: 404, statusMessage: 'Model not found' });
@@ -54,6 +54,19 @@ export default defineEventHandler(async (event) => {
     target_id: modelId,
     details: { from: model.status, to: status, title: model.title },
   });
+
+  // Notify the owner when their model is hidden or removed (enforcement notice;
+  // re-publishing/"show" is intentionally silent). Rendered + sent by the
+  // process-notifications edge function.
+  if ((status === 'archived' || status === 'removed') && model.owner_id) {
+    await db.from('notification_queue').insert({
+      user_id: model.owner_id,
+      event_type: status === 'removed' ? 'model_removed' : 'model_hidden',
+      payload: { model_id: modelId, title: model.title, reason: status === 'removed' ? 'admin_removed' : null },
+      channel: 'email',
+      batch_key: `model_admin_action:${modelId}`,
+    });
+  }
 
   return { ok: true };
 });

--- a/server/api/admin/models/toggle-seller.post.ts
+++ b/server/api/admin/models/toggle-seller.post.ts
@@ -37,5 +37,16 @@ export default defineEventHandler(async (event) => {
     details: { selling_disabled: sellingDisabled },
   });
 
+  // Notify the seller when the kill switch is engaged (re-enabling is silent).
+  if (sellingDisabled) {
+    await db.from('notification_queue').insert({
+      user_id: userId,
+      event_type: 'model_seller_disabled',
+      payload: { user_id: userId },
+      channel: 'email',
+      batch_key: `seller_disabled:${userId}`,
+    });
+  }
+
   return { ok: true };
 });


### PR DESCRIPTION
## What & why

Admin enforcement actions on the 3D model library changed an owner's world silently — only the *reporter* was ever notified. Enqueue `notification_queue` entries (rendered + sent by the shared `process-notifications` SES engine) so the owner/seller is told:

- **set-status** → `model_removed` (status `removed`) / `model_hidden` (status `archived`) to `owner_id`
- **toggle-seller** → `model_seller_disabled` to the seller on disable
- **resolve-report** → `model_removed` to the owner on takedown (skipped when the owner filed the report)

Re-publish / seller-enable stay silent (avoid notifying on positive reversals). Mirrors the existing `resolve-report` reporter-notification enqueue pattern.

## Depends on
The event types, templates, and branded sender land in **ClassicMiniDIY/classicminidiy-supabase#43**. Merge/deploy that first (and run `bun run gen:types` to refresh `types/database.ts`).

## Changes
- `server/api/admin/models/set-status.post.ts` (adds `owner_id` to the select + enqueue)
- `server/api/admin/models/toggle-seller.post.ts`
- `server/api/admin/models/resolve-report.post.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)