### PR TITLE
fix(models): pin FK on admin review-queue embed so pending models appear

### DIFF
--- a/app/pages/admin/models.vue
+++ b/app/pages/admin/models.vue
@@ -52,13 +52,18 @@
   const queueLoading = ref(false);
   async function loadQueue() {
     queueLoading.value = true;
-    const { data: versions } = await supabase
+    // Pin the FK on the models embed: models<->model_versions has TWO
+    // relationships (model_versions.model_id and models.current_version_id), so a
+    // bare `models(...)` embed is ambiguous and PostgREST fails it (PGRST201),
+    // which previously left the queue silently empty.
+    const { data: versions, error } = await supabase
       .from('model_versions')
       .select(
-        'id, version_number, label, changelog, created_at, status, models(id, title, slug, status, owner_id, pricing_mode, price_cents, suggested_price_cents, min_price_cents, currency, safety_critical, license_code, summary)'
+        'id, version_number, label, changelog, created_at, status, models!model_versions_model_id_fkey(id, title, slug, status, owner_id, pricing_mode, price_cents, suggested_price_cents, min_price_cents, currency, safety_critical, license_code, summary)'
       )
       .eq('status', 'pending')
       .order('created_at', { ascending: true });
+    if (error) flash('error', `Failed to load review queue: ${error.message}`);
     const rows = (versions ?? []) as any[];
     const versionIds = rows.map((r) => r.id);
     const modelIds = rows.map((r) => r.models?.id).filter(Boolean);


### PR DESCRIPTION
## Bug
The `/admin/models` **Queue** tab was empty even with models awaiting review (they showed in **All Models**), and there were no approve/reject buttons for first-party submissions.

## Root cause
`loadQueue()` fetched `model_versions` with a bare `models(...)` embed. `models` ↔ `model_versions` has **two** FK relationships:
- `model_versions.model_id → models.id`
- `models.current_version_id → model_versions.id`

So PostgREST can't resolve the embed and returns **PGRST201 / HTTP 300**. The code ignored the error (`const { data } = ...`), leaving the queue silently empty. The approve/reject buttons render inside `v-for="v in queue"`, so an empty queue also meant no moderation controls. It only surfaced now because trusted-owner uploads auto-publish — these are the first real *pending* submissions to hit the query.

## Fix
- Pin the relationship: `models!model_versions_model_id_fkey(...)`.
- Surface load errors via `flash('error', ...)` instead of swallowing them.

## Verification
Against PostgREST (`/rest/v1/model_versions?select=id,models(...)&status=eq.pending`):
- bare embed → `HTTP 300` `PGRST201` (ambiguous)
- `models!model_versions_model_id_fkey(...)` → `HTTP 200`

Under an admin session, RLS (`is_admin()`) returns the pending rows, so the queue populates and the approve/reject buttons appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)