### PR TITLE
fix(models): unblock checkout (BotID via native fetch) + add purchase funnel events

### DIFF
--- a/app/composables/useModelCheckout.ts
+++ b/app/composables/useModelCheckout.ts
@@ -18,6 +18,7 @@ export interface SellerStatus {
 
 export function useModelCheckout() {
   const supabase = useSupabase();
+  const { track } = useAnalytics();
 
   async function authHeader(): Promise<Record<string, string>> {
     const { data } = await supabase.auth.getSession();
@@ -26,6 +27,31 @@ export function useModelCheckout() {
 
   function errMessage(e: any, fallback: string): string {
     return e?.data?.statusMessage || e?.statusMessage || e?.data?.message || fallback;
+  }
+
+  /**
+   * POST a Vercel BotID-protected route using the NATIVE fetch — NOT $fetch.
+   *
+   * Vercel BotID's client plugin (app/plugins/botid.client.ts) patches
+   * window.fetch so calls to protected paths carry the x-is-human challenge
+   * header; the server's checkBotId() fail-closes (403 'Bot detected') without
+   * it. Nuxt's $fetch (ofetch) captures its fetch reference before that patch is
+   * applied, so $fetch calls SKIP the challenge and every real buyer was being
+   * 403'd. The chat works only because it uses native fetch (useStreamProvider).
+   * Keep checkout + seller-onboard on native fetch so the challenge attaches.
+   *
+   * Throws an ofetch-shaped error ({ statusCode, data }) so errMessage() can
+   * still surface the edge function's actionable message (ALREADY_OWNED, etc).
+   */
+  async function postProtected<T>(url: string, headers: Record<string, string>, body: unknown): Promise<T> {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw { statusCode: res.status, data };
+    return data as T;
   }
 
   /**
@@ -40,25 +66,27 @@ export function useModelCheckout() {
     const headers = await authHeader();
     if (!headers.Authorization) return 'Please sign in to continue.';
 
+    track('model_checkout_started', { model_id: modelId, kind, amount_cents: amountCents ?? null });
+
     const base = `${window.location.origin}${window.location.pathname}`;
     try {
-      const res = await $fetch<{ url?: string }>(`/api/models/${modelId}/checkout`, {
-        method: 'POST',
-        headers,
-        body: {
-          kind,
-          ...(amountCents != null ? { amountCents } : {}),
-          successUrl: `${base}?purchase=success`,
-          cancelUrl: `${base}?purchase=cancelled`,
-        },
+      // Native fetch (not $fetch) so Vercel BotID's challenge header attaches — see postProtected.
+      const res = await postProtected<{ url?: string }>(`/api/models/${modelId}/checkout`, headers, {
+        kind,
+        ...(amountCents != null ? { amountCents } : {}),
+        successUrl: `${base}?purchase=success`,
+        cancelUrl: `${base}?purchase=cancelled`,
       });
       if (res?.url) {
         window.location.href = res.url;
         return null;
       }
+      track('model_checkout_failed', { model_id: modelId, kind, reason: 'no_url' });
       return 'Could not start checkout. Please try again.';
     } catch (e: any) {
-      return errMessage(e, 'Could not start checkout. Please try again.');
+      const msg = errMessage(e, 'Could not start checkout. Please try again.');
+      track('model_checkout_failed', { model_id: modelId, kind, reason: msg, status: e?.statusCode ?? null });
+      return msg;
     }
   }
 
@@ -69,13 +97,10 @@ export function useModelCheckout() {
 
     const origin = window.location.origin;
     try {
-      const res = await $fetch<{ url?: string }>('/api/models/seller/onboard', {
-        method: 'POST',
-        headers,
-        body: {
-          returnUrl: `${origin}/dashboard/selling?onboarded=1`,
-          refreshUrl: `${origin}/dashboard/selling?refresh=1`,
-        },
+      // Native fetch (not $fetch) so Vercel BotID's challenge header attaches — see postProtected.
+      const res = await postProtected<{ url?: string }>('/api/models/seller/onboard', headers, {
+        returnUrl: `${origin}/dashboard/selling?onboarded=1`,
+        refreshUrl: `${origin}/dashboard/selling?refresh=1`,
       });
       if (res?.url) {
         window.location.href = res.url;

--- a/app/pages/models/[slug].vue
+++ b/app/pages/models/[slug].vue
@@ -9,6 +9,7 @@
   const { isAuthenticated, user } = useAuth();
   const supabase = useSupabase();
   const { verifyPurchase, downloadFile, downloadAll } = useModelCheckout();
+  const { track } = useAnalytics();
 
   const { data, error } = await useFetch<ModelDetail>(() => `/api/models/${slug.value}`);
   if (error.value) {
@@ -127,12 +128,17 @@
       if (sid && model.value) {
         const res = await verifyPurchase(model.value.id, sid);
         if (res.verified) {
+          track('model_purchase_completed', { model_id: model.value.id, kind: res.kind ?? 'purchase', session_id: sid });
           purchaseNotice.value = {
             type: 'success',
             text: res.kind === 'tip' ? t('notice.thankYouTip') : t('notice.purchaseComplete'),
           };
           await refreshEntitlement();
         } else {
+          // Stripe redirected to success but our webhook-lag verify hasn't seen
+          // the payment yet — track separately so the funnel distinguishes a true
+          // failure from normal webhook latency.
+          track('model_purchase_pending', { model_id: model.value.id, session_id: sid });
           purchaseNotice.value = {
             type: 'info',
             text: t('notice.paymentPending'),
@@ -143,6 +149,7 @@
       }
       router.replace({ query: {} });
     } else if (q.purchase === 'cancelled') {
+      if (model.value) track('model_checkout_cancelled', { model_id: model.value.id });
       purchaseNotice.value = { type: 'info', text: t('notice.checkoutCancelled') };
       router.replace({ query: {} });
     }


### PR DESCRIPTION
## Why
Every 3D-model checkout has returned **403 since launch** (zero sales ever). Vercel runtime logs show 100% of `POST /api/models/*/checkout` as 403 — including buyer Michal Rejchrt retrying 10× on the Synchro Hub. The only 403 in that handler is the **BotID gate**.

## Root cause
BotID protects routes by patching `window.fetch` to attach an `x-is-human` challenge; the server `checkBotId()` fail-closes to 403 without it. Nuxt's `$fetch` (ofetch) captured `fetch` before the BotID plugin patched `window.fetch`, so checkout + seller-onboard POSTs never carried the challenge. Chat works only because `useStreamProvider` uses **native `fetch`** (confirmed: chat 200s in the same minutes Michal got 403s).

## Fix
- `useModelCheckout.ts`: route the two BotID-protected money calls (`startCheckout`, `startSellerOnboarding`) through native `fetch` via a `postProtected()` helper. BotID stays fully enforced; real users now pass.
- Add the previously-missing PostHog funnel for the money path: `model_checkout_started` / `model_checkout_failed` / `model_purchase_completed` / `model_purchase_pending` / `model_checkout_cancelled`.

## Verification
Cannot be reproduced locally — BotID is a no-op in dev. **Verify on this PR's Vercel Preview:** log in, buy the Synchro Hub, expect `200` + Stripe redirect (and a `200`, not `403`, in runtime logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)