### PR TITLE
fix(models): unblock checkout (BotID static path) + wrap long license name

### DIFF
--- a/app/components/models/LicenseBadge.vue
+++ b/app/components/models/LicenseBadge.vue
@@ -50,26 +50,17 @@
 
 <template>
   <div class="flex flex-wrap items-start gap-2">
-    <a
-      v-if="license.url"
-      :href="license.url"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="badge badge-lg h-auto min-h-8 items-start gap-1.5 whitespace-normal py-1.5 text-left leading-snug"
-      :class="license.isPaid ? 'badge-primary' : 'badge-outline'"
-      :title="viewFullLicense"
-    >
-      <i class="fas mt-0.5 shrink-0" :class="license.isPaid ? 'fa-tag' : 'fa-scale-balanced'"></i>
-      {{ license.name }}
-    </a>
-    <span
-      v-else
+    <component
+      :is="license.url ? 'a' : 'span'"
+      v-bind="
+        license.url ? { href: license.url, target: '_blank', rel: 'noopener noreferrer', title: viewFullLicense } : {}
+      "
       class="badge badge-lg h-auto min-h-8 items-start gap-1.5 whitespace-normal py-1.5 text-left leading-snug"
       :class="license.isPaid ? 'badge-primary' : 'badge-outline'"
     >
       <i class="fas mt-0.5 shrink-0" :class="license.isPaid ? 'fa-tag' : 'fa-scale-balanced'"></i>
       {{ license.name }}
-    </span>
+    </component>
 
     <template v-if="!compact">
       <span v-for="chip in chips" :key="chip.label" class="badge badge-sm gap-1" :class="toneClass[chip.tone]">

--- a/app/components/models/LicenseBadge.vue
+++ b/app/components/models/LicenseBadge.vue
@@ -49,21 +49,25 @@
 </script>
 
 <template>
-  <div class="flex flex-wrap items-center gap-2">
+  <div class="flex flex-wrap items-start gap-2">
     <a
       v-if="license.url"
       :href="license.url"
       target="_blank"
       rel="noopener noreferrer"
-      class="badge badge-lg gap-1.5"
+      class="badge badge-lg h-auto min-h-8 items-start gap-1.5 whitespace-normal py-1.5 text-left leading-snug"
       :class="license.isPaid ? 'badge-primary' : 'badge-outline'"
       :title="viewFullLicense"
     >
-      <i class="fas" :class="license.isPaid ? 'fa-tag' : 'fa-scale-balanced'"></i>
+      <i class="fas mt-0.5 shrink-0" :class="license.isPaid ? 'fa-tag' : 'fa-scale-balanced'"></i>
       {{ license.name }}
     </a>
-    <span v-else class="badge badge-lg gap-1.5" :class="license.isPaid ? 'badge-primary' : 'badge-outline'">
-      <i class="fas" :class="license.isPaid ? 'fa-tag' : 'fa-scale-balanced'"></i>
+    <span
+      v-else
+      class="badge badge-lg h-auto min-h-8 items-start gap-1.5 whitespace-normal py-1.5 text-left leading-snug"
+      :class="license.isPaid ? 'badge-primary' : 'badge-outline'"
+    >
+      <i class="fas mt-0.5 shrink-0" :class="license.isPaid ? 'fa-tag' : 'fa-scale-balanced'"></i>
       {{ license.name }}
     </span>
 

--- a/app/composables/useModelCheckout.ts
+++ b/app/composables/useModelCheckout.ts
@@ -70,8 +70,12 @@ export function useModelCheckout() {
 
     const base = `${window.location.origin}${window.location.pathname}`;
     try {
-      // Native fetch (not $fetch) so Vercel BotID's challenge header attaches — see postProtected.
-      const res = await postProtected<{ url?: string }>(`/api/models/${modelId}/checkout`, headers, {
+      // STATIC path with modelId in the body — Vercel BotID matches the request
+      // path to attach its challenge, and a dynamic mid-path segment
+      // (/api/models/[id]/checkout) did not register, so checkBotId() 403'd every
+      // real buyer. See server/api/models/checkout.post.ts + botid.client.ts.
+      const res = await postProtected<{ url?: string }>(`/api/models/checkout`, headers, {
+        modelId,
         kind,
         ...(amountCents != null ? { amountCents } : {}),
         successUrl: `${base}?purchase=success`,

--- a/app/plugins/botid.client.ts
+++ b/app/plugins/botid.client.ts
@@ -24,8 +24,12 @@ export default defineNuxtPlugin({
         // Unauthenticated, expensive AI chat proxy — thread creation + run streaming
         // (POST). GET reads (thread state/history) are intentionally not protected.
         { path: '/api/langgraph/*', method: 'POST' },
-        // Stripe Connect money paths (web model marketplace).
-        { path: '/api/models/*/checkout', method: 'POST' },
+        // Stripe Connect money paths (web model marketplace). BOTH are STATIC
+        // paths on purpose: BotID matches the outgoing request path to attach the
+        // x-is-human challenge, and a dynamic mid-path segment
+        // (the old /api/models/*/checkout) did not register the challenge — so
+        // checkBotId() 403'd every real buyer. checkout takes modelId in the body.
+        { path: '/api/models/checkout', method: 'POST' },
         { path: '/api/models/seller/onboard', method: 'POST' },
       ],
     });

--- a/server/api/models/checkout.post.ts
+++ b/server/api/models/checkout.post.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/models/[modelId]/checkout  (keystone §6)
+ * POST /api/models/checkout  (keystone §6)
  *
  * Thin web proxy for model purchases and tips. Forwards the caller's Supabase
  * access token to the `create-model-checkout` Edge Function, which validates the
@@ -8,7 +8,18 @@
  * Stripe here — the web only mints the session via the edge function and the
  * client redirects to the returned URL.
  *
- *   body: { kind: 'purchase'|'tip', amountCents?, successUrl?, cancelUrl? }
+ *   body: { modelId, kind: 'purchase'|'tip', amountCents?, successUrl?, cancelUrl? }
+ *
+ * STATIC path — modelId rides in the BODY, not the URL — on purpose. Vercel
+ * BotID's client protection (app/plugins/botid.client.ts) attaches the
+ * x-is-human challenge by matching the OUTGOING request path. The old route,
+ * /api/models/[modelId]/checkout, needed a mid-path wildcard
+ * (`/api/models/*/checkout`) to register, and that did NOT carry the challenge
+ * the way a trailing-wildcard / static path does — so checkBotId() fail-closed
+ * to 403 'Bot detected' for every real buyer (zero sales since launch). The
+ * chat proxy was never affected because /api/langgraph/* is a trailing-wildcard
+ * match. Keep this path static and listed verbatim in botid.client.ts; any new
+ * BotID-protected route should avoid a dynamic segment before the matched path.
  *
  * The edge function owns amount/seller/entitlement validation and surfaces
  * actionable error codes (ALREADY_OWNED, SELLER_UNAVAILABLE, AMOUNT_BELOW_MINIMUM
@@ -19,8 +30,14 @@ import { checkBotId } from 'botid/server';
 export default defineEventHandler(async (event) => {
   // Vercel BotID — block bots before minting a Stripe Checkout session.
   // Protected in app/plugins/botid.client.ts. No-op (always human) in local dev.
-  const { isBot } = await checkBotId();
-  if (isBot) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    // Surface the classification so this isn't a silent black box again — the
+    // last regression hid for a week because the 403 carried no reason.
+    console.warn('[models/checkout] BotID blocked request', {
+      classificationReason: verification.classificationReason,
+      isVerifiedBot: verification.isVerifiedBot,
+    });
     throw createError({ statusCode: 403, statusMessage: 'Bot detected' });
   }
 
@@ -31,16 +48,23 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, statusMessage: 'Sign in required to start checkout' });
   }
 
-  const modelId = getRouterParam(event, 'modelId');
-  if (!modelId) throw createError({ statusCode: 400, statusMessage: 'Missing model id' });
-
   const supabaseUrl = (config.public.supabaseUrl as string)?.replace(/\/$/, '');
   const supabaseKey = config.public.supabaseKey as string;
   if (!supabaseUrl) {
     throw createError({ statusCode: 500, statusMessage: 'Supabase URL not configured' });
   }
 
-  const body = await readBody<{ kind?: string; amountCents?: number; successUrl?: string; cancelUrl?: string }>(event);
+  const body = await readBody<{
+    modelId?: string;
+    kind?: string;
+    amountCents?: number;
+    successUrl?: string;
+    cancelUrl?: string;
+  }>(event);
+
+  const modelId = body?.modelId;
+  if (!modelId) throw createError({ statusCode: 400, statusMessage: 'Missing model id' });
+
   const kind = body?.kind === 'tip' ? 'tip' : body?.kind === 'purchase' ? 'purchase' : null;
   if (!kind) {
     throw createError({ statusCode: 400, statusMessage: 'kind must be "purchase" or "tip"' });

--- a/server/api/models/checkout.post.ts
+++ b/server/api/models/checkout.post.ts
@@ -31,12 +31,15 @@ export default defineEventHandler(async (event) => {
   // Vercel BotID — block bots before minting a Stripe Checkout session.
   // Protected in app/plugins/botid.client.ts. No-op (always human) in local dev.
   const verification = await checkBotId();
-  if (verification.isBot) {
+  // Fail CLOSED: treat a missing/odd verification as a block. (Optional chaining
+  // on `verification?.isBot` alone would fail OPEN on a nullish result, which is
+  // the wrong default for a security gate — checkBotId() returns an object or throws.)
+  if (!verification || verification.isBot) {
     // Surface the classification so this isn't a silent black box again — the
     // last regression hid for a week because the 403 carried no reason.
     console.warn('[models/checkout] BotID blocked request', {
-      classificationReason: verification.classificationReason,
-      isVerifiedBot: verification.isVerifiedBot,
+      classificationReason: verification?.classificationReason,
+      isVerifiedBot: verification?.isVerifiedBot,
     });
     throw createError({ statusCode: 403, statusMessage: 'Bot detected' });
   }
@@ -63,11 +66,27 @@ export default defineEventHandler(async (event) => {
   }>(event);
 
   const modelId = body?.modelId;
-  if (!modelId) throw createError({ statusCode: 400, statusMessage: 'Missing model id' });
+  if (!modelId || typeof modelId !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'Missing or invalid model id' });
+  }
 
   const kind = body?.kind === 'tip' ? 'tip' : body?.kind === 'purchase' ? 'purchase' : null;
   if (!kind) {
     throw createError({ statusCode: 400, statusMessage: 'kind must be "purchase" or "tip"' });
+  }
+
+  // Defense-in-depth on the optional fields before they reach the edge function.
+  if (
+    body?.amountCents != null &&
+    (typeof body.amountCents !== 'number' || !Number.isSafeInteger(body.amountCents) || body.amountCents < 0)
+  ) {
+    throw createError({ statusCode: 400, statusMessage: 'amountCents must be a non-negative integer' });
+  }
+  if (body?.successUrl != null && typeof body.successUrl !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'successUrl must be a string' });
+  }
+  if (body?.cancelUrl != null && typeof body.cancelUrl !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'cancelUrl must be a string' });
   }
 
   try {


### PR DESCRIPTION
Two model-library fixes.

## 1. Checkout still 403'd every real buyer (the real fix)

The earlier "call BotID routes via native fetch" change (`f0d3cfd6`) was a **no-op** — checkout kept returning `403 Bot detected` in production (confirmed in Vercel runtime logs on the live deploy of that commit). ofetch 1.5.1 defines its fetch as `(...args) => globalThis.fetch(...args)` and `createFetch` invokes that wrapper per request, so `$fetch` already routed through the BotID-patched `window.fetch` — swapping to native `fetch` changed nothing.

Real cause: the BotID `protect` path used a **dynamic mid-path segment** (`/api/models/*/checkout`), which never carried the `x-is-human` challenge, so `checkBotId()` fail-closed to 403. The chat proxy was never affected because `/api/langgraph/*` is a trailing-wildcard match (returns 200 throughout). Same client patch, same `checkBotId()`, only the path shape differed.

Fix: move checkout to a **static** path `POST /api/models/checkout` with `modelId` in the body — the exact shape Vercel's BotID docs use (`path: '/api/checkout'`). `seller/onboard` was already static, so it was fine. The handler now logs `classificationReason` on a block so the next regression isn't a silent black box.

- `server/api/models/checkout.post.ts` (moved from `[modelId]/checkout.post.ts`; reads `modelId` from body)
- `app/composables/useModelCheckout.ts` — POSTs `/api/models/checkout` with `modelId` in body
- `app/plugins/botid.client.ts` — protect `/api/models/checkout` (static)

## 2. License badge overflow

The license-name daisyUI `badge badge-lg` has a fixed height + `nowrap`, so a long paid-license name ("CMDIY Paid File License — Personal Use") wrapped but spilled over the pill edges. Let it grow (`h-auto min-h-8 whitespace-normal py-1.5 leading-snug`, icon pinned to the first line, row top-aligned).

- `app/components/models/LicenseBadge.vue`

## Verification

⚠️ The checkout fix **cannot be tested locally** — BotID is a no-op (always "human") in dev. Verify on the Vercel **Preview** for this PR: a signed-in browser checkout should return a Stripe URL (200), not 403, *before* any payment. The license fix is in the included before/after mockup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)