### PR TITLE
fix(models): repair main build — stray */ in checkout docstring broke esbuild

### DIFF
--- a/server/api/models/checkout.post.ts
+++ b/server/api/models/checkout.post.ts
@@ -13,13 +13,14 @@
  * STATIC path — modelId rides in the BODY, not the URL — on purpose. Vercel
  * BotID's client protection (app/plugins/botid.client.ts) attaches the
  * x-is-human challenge by matching the OUTGOING request path. The old route,
- * /api/models/[modelId]/checkout, needed a mid-path wildcard
- * (`/api/models/*/checkout`) to register, and that did NOT carry the challenge
- * the way a trailing-wildcard / static path does — so checkBotId() fail-closed
+ * /api/models/[modelId]/checkout, put the model id as a dynamic segment in the
+ * MIDDLE of the path, which forced a mid-path wildcard in the BotID protect
+ * list; that pattern never carried the challenge, so checkBotId() fail-closed
  * to 403 'Bot detected' for every real buyer (zero sales since launch). The
- * chat proxy was never affected because /api/langgraph/* is a trailing-wildcard
- * match. Keep this path static and listed verbatim in botid.client.ts; any new
- * BotID-protected route should avoid a dynamic segment before the matched path.
+ * langgraph chat proxy was never affected because its protect entry is a
+ * trailing wildcard. Keep this path static and listed verbatim in
+ * botid.client.ts; any new BotID-protected route should avoid a dynamic
+ * segment before the matched path.
  *
  * The edge function owns amount/seller/entitlement validation and surfaces
  * actionable error codes (ALREADY_OWNED, SELLER_UNAVAILABLE, AMOUNT_BELOW_MINIMUM


### PR DESCRIPTION
## Hotfix — `main` build is currently failing

The merged PR #629 broke the production build (deploy `dpl_5ybRv1oSXwAvFfRM36ncreJ184kG`, state ERROR). Prod is still serving the prior good deploy, so the site is up — but **nothing from #629 has actually deployed**, including the static-path checkout fix.

### Root cause
The new `server/api/models/checkout.post.ts` JSDoc quoted the old path pattern, which contains a slash-star sequence. Inside a `/** … */` block comment that sequence **closes the comment early**, so esbuild parsed the rest of the comment prose as code:

```
checkout.post.ts:35:9: ERROR: Expected ";" but found "verification"
```

The server bundle never transformed → build failed at prerender init, on every deploy (prod and the #629 preview alike). A pure syntax break that no runtime/env could surface — it just needed a build.

### Fix
Reword the docstring to drop the literal wildcard path so the comment stays a comment. One-file, comment-only change.

### Verification
- `esbuild.transformSync` on the file: transforms clean (previously threw at 35:9).
- Full `bun run build` in a clean worktree now runs **past** the prerender-init step that previously failed; it only stops later at the `@nuxtjs/sitemap` sources returning 500, which is the known local-only limitation (no AWS/Supabase env at build time — same config deploys fine on Vercel where the env exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)