### PR TITLE
fix(models): broaden Paid pricing filter to cover pwyw + fixed

### DIFF
--- a/app/pages/models/index.vue
+++ b/app/pages/models/index.vue
@@ -62,12 +62,13 @@
     });
   });
 
+  // "Paid" is an umbrella covering pwyw (min $1) + fixed — every model that costs
+  // money to download. The server expands `paid` accordingly.
   const pricingOptions = computed(() => [
     { value: '', label: t('filters.pricing.all') },
     { value: 'free', label: t('filters.pricing.free') },
     { value: 'tips', label: t('filters.pricing.tips') },
-    { value: 'pwyw', label: t('filters.pricing.pwyw') },
-    { value: 'fixed', label: t('filters.pricing.fixed') },
+    { value: 'paid', label: t('filters.pricing.paid') },
   ]);
   const sortOptions = computed(() => [
     { value: 'newest', label: t('filters.sort.newest') },
@@ -261,8 +262,7 @@
         "all": "All pricing",
         "free": "Free",
         "tips": "Free + tips",
-        "pwyw": "Pay what you want",
-        "fixed": "Paid"
+        "paid": "Paid"
       },
       "sort": {
         "newest": "Newest",
@@ -307,8 +307,7 @@
         "all": "Todos los precios",
         "free": "Gratis",
         "tips": "Gratis + propinas",
-        "pwyw": "Paga lo que quieras",
-        "fixed": "De pago"
+        "paid": "De pago"
       },
       "sort": {
         "newest": "Más recientes",
@@ -353,8 +352,7 @@
         "all": "Tous les tarifs",
         "free": "Gratuit",
         "tips": "Gratuit + pourboires",
-        "pwyw": "Prix libre",
-        "fixed": "Payant"
+        "paid": "Payant"
       },
       "sort": {
         "newest": "Les plus récents",
@@ -399,8 +397,7 @@
         "all": "Alle Preise",
         "free": "Kostenlos",
         "tips": "Kostenlos + Trinkgeld",
-        "pwyw": "Zahle was du willst",
-        "fixed": "Kostenpflichtig"
+        "paid": "Kostenpflichtig"
       },
       "sort": {
         "newest": "Neueste",
@@ -445,8 +442,7 @@
         "all": "Tutti i prezzi",
         "free": "Gratuito",
         "tips": "Gratuito + mance",
-        "pwyw": "Paghi quanto vuoi",
-        "fixed": "A pagamento"
+        "paid": "A pagamento"
       },
       "sort": {
         "newest": "Più recenti",
@@ -491,8 +487,7 @@
         "all": "Todos os preços",
         "free": "Grátis",
         "tips": "Grátis + gorjetas",
-        "pwyw": "Pague o que quiser",
-        "fixed": "Pago"
+        "paid": "Pago"
       },
       "sort": {
         "newest": "Mais recentes",
@@ -537,8 +532,7 @@
         "all": "Любая цена",
         "free": "Бесплатно",
         "tips": "Бесплатно + чаевые",
-        "pwyw": "Платите сколько хотите",
-        "fixed": "Платно"
+        "paid": "Платно"
       },
       "sort": {
         "newest": "Новые",
@@ -583,8 +577,7 @@
         "all": "すべての価格",
         "free": "無料",
         "tips": "無料＋チップ",
-        "pwyw": "自由価格",
-        "fixed": "有料"
+        "paid": "有料"
       },
       "sort": {
         "newest": "新着順",
@@ -629,8 +622,7 @@
         "all": "全部价格",
         "free": "免费",
         "tips": "免费 + 打赏",
-        "pwyw": "随心付",
-        "fixed": "付费"
+        "paid": "付费"
       },
       "sort": {
         "newest": "最新",
@@ -675,8 +667,7 @@
         "all": "모든 가격",
         "free": "무료",
         "tips": "무료 + 후원",
-        "pwyw": "자유 가격",
-        "fixed": "유료"
+        "paid": "유료"
       },
       "sort": {
         "newest": "최신순",

--- a/app/pages/models/index.vue
+++ b/app/pages/models/index.vue
@@ -10,7 +10,11 @@
   // Filters (seeded from the URL so a shared link reproduces the view).
   const q = ref(typeof route.query.q === 'string' ? route.query.q : '');
   const category = ref(typeof route.query.category === 'string' ? route.query.category : '');
-  const pricing = ref(typeof route.query.pricing === 'string' ? route.query.pricing : '');
+  // "Paid" is the umbrella for pwyw + fixed; migrate legacy deep-link values
+  // (?pricing=pwyw / ?pricing=fixed) at seed time so the dropdown shows a valid
+  // selection instead of a blank one.
+  const normalizePricing = (v: unknown) => (v === 'pwyw' || v === 'fixed' ? 'paid' : typeof v === 'string' ? v : '');
+  const pricing = ref(normalizePricing(route.query.pricing));
   const source = ref(typeof route.query.source === 'string' ? route.query.source : '');
   const sort = ref(typeof route.query.sort === 'string' ? route.query.sort : 'newest');
   const page = ref(Number(route.query.page) || 1);

--- a/server/api/models/index.get.ts
+++ b/server/api/models/index.get.ts
@@ -20,7 +20,12 @@ import type { ModelCard, PricingMode } from '../../../data/models/model-library'
 import type { BrowseCard, ExternalModelCard } from '../../../data/models/external-models';
 import { SUPPORTED_SOURCE_SITES, type ExternalSourceSite } from '../../../data/models/external-sources';
 
-const PRICING_MODES = ['free', 'tips', 'pwyw', 'fixed'];
+// Accepted `pricing` query values. `paid` is an umbrella (added for the browse
+// UI): it matches every model that costs money to download — `pwyw` (enforced
+// $1 minimum) and `fixed` (set price) — while `tips`/`free` download for $0.
+// The granular `pwyw`/`fixed` values stay accepted so older deep links keep working.
+const PRICING_MODES = ['free', 'tips', 'pwyw', 'fixed', 'paid'];
+const PAID_MODES = ['pwyw', 'fixed'];
 const SORTS = ['newest', 'popular', 'likes', 'featured'];
 const SOURCES = ['all', 'first_party', 'external', ...SUPPORTED_SOURCE_SITES];
 const DEFAULT_LIMIT = 24;
@@ -89,7 +94,7 @@ export default defineEventHandler(async (event) => {
   if (restrictKind) {
     let b = applySort(applyFilters(service.from('model_browse_cards').select(SELECT_COLS, { count: 'exact' }).eq('kind', restrictKind)));
     if (siteFilter) b = b.eq('source_site', siteFilter);
-    if (pricing) b = b.eq('pricing_mode', pricing);
+    if (pricing) b = pricing === 'paid' ? b.in('pricing_mode', PAID_MODES) : b.eq('pricing_mode', pricing);
     const { data, count, error } = await b.range(offset, offset + limit - 1);
     if (error) {
       console.error('[models/index] query failed:', error.message);


### PR DESCRIPTION
## Problem

Filtering the 3D Model Library by **Paid** showed no models. Root cause was data, not logic: the "Paid" option mapped to `pricing_mode = 'fixed'` only, and there are currently **zero fixed-price models** in the library (every monetized model is `tips` or `pwyw`). So "Paid" always returned empty and read as a broken filter. `free`/`tips`/`pwyw` all returned rows correctly.

## Change

"Paid" is now an umbrella over `pwyw` + `fixed` — every model that costs money to download. Since `pwyw` enforces a $1 minimum, it genuinely costs money and belongs there; `tips`/`free` download for $0 and stay separate. The standalone "Pay what you want" option is removed since it would show an identical subset under the umbrella.

New pricing options: **All pricing / Free / Free + tips / Paid**.

- `server/api/models/index.get.ts` — accept a new `paid` query value and expand it to `IN ('pwyw','fixed')`; granular `pwyw`/`fixed` values stay accepted so older deep links keep working.
- `app/pages/models/index.vue` — pricing options reduced to the 4 above; renamed the `fixed` i18n key → `paid` and dropped `pwyw` across all 10 locales.

## Verification

- DB query of the exact filter the server now runs (`first_party` + `pricing_mode IN ('pwyw','fixed')`) returns **1 model** where the old `fixed`-only filter returned **0**. `free` → 6, `tips` → 5.
- `<i18n>` block re-validated: parses cleanly, 10 locales × `{all, free, tips, paid}`.
- Live browser verification was blocked in the dev worktree (no Supabase env → `/api/models` 500s on every request); validation was done at the DB layer instead.

No Supabase migration or edge-function changes — web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)