### PR TITLE
fix(models): remove BotID from checkout — it false-positive-blocked every real buyer

### DIFF
--- a/app/plugins/botid.client.ts
+++ b/app/plugins/botid.client.ts
@@ -24,12 +24,14 @@ export default defineNuxtPlugin({
         // Unauthenticated, expensive AI chat proxy — thread creation + run streaming
         // (POST). GET reads (thread state/history) are intentionally not protected.
         { path: '/api/langgraph/*', method: 'POST' },
-        // Stripe Connect money paths (web model marketplace). BOTH are STATIC
-        // paths on purpose: BotID matches the outgoing request path to attach the
-        // x-is-human challenge, and a dynamic mid-path segment
-        // (the old /api/models/*/checkout) did not register the challenge — so
-        // checkBotId() 403'd every real buyer. checkout takes modelId in the body.
-        { path: '/api/models/checkout', method: 'POST' },
+        // Stripe Connect seller onboarding (web model marketplace).
+        //
+        // NOTE: /api/models/checkout was deliberately removed from BotID. It
+        // false-positive-blocked ~100% of real buyers (403 'Bot detected') while
+        // the identical setup passed here and on langgraph; checkout is gated by
+        // auth + the edge function + Stripe + rate limiting instead. seller/onboard
+        // (low-traffic, also auth'd) keeps BotID for now — revisit if it shows the
+        // same false positives.
         { path: '/api/models/seller/onboard', method: 'POST' },
       ],
     });

--- a/server/api/models/checkout.post.ts
+++ b/server/api/models/checkout.post.ts
@@ -10,41 +10,21 @@
  *
  *   body: { modelId, kind: 'purchase'|'tip', amountCents?, successUrl?, cancelUrl? }
  *
- * STATIC path — modelId rides in the BODY, not the URL — on purpose. Vercel
- * BotID's client protection (app/plugins/botid.client.ts) attaches the
- * x-is-human challenge by matching the OUTGOING request path. The old route,
- * /api/models/[modelId]/checkout, put the model id as a dynamic segment in the
- * MIDDLE of the path, which forced a mid-path wildcard in the BotID protect
- * list; that pattern never carried the challenge, so checkBotId() fail-closed
- * to 403 'Bot detected' for every real buyer (zero sales since launch). The
- * langgraph chat proxy was never affected because its protect entry is a
- * trailing wildcard. Keep this path static and listed verbatim in
- * botid.client.ts; any new BotID-protected route should avoid a dynamic
- * segment before the matched path.
+ * NOTE: Vercel BotID was intentionally REMOVED from this route. It
+ * false-positive-blocked legitimate buyers (403 'Bot detected') at ~100% —
+ * zero sales from launch until this was removed — while the identical setup
+ * passed on the langgraph chat proxy. Checkout is already gated by auth
+ * (Bearer, below), the edge function's model/seller/amount validation,
+ * Stripe-hosted payment, and per-IP rate limiting, so BotID here was
+ * defense-in-depth, not the primary gate. Do NOT re-add checkBotId() without
+ * first confirming (in a real browser, not just curl) that it no longer
+ * rejects legitimate traffic.
  *
  * The edge function owns amount/seller/entitlement validation and surfaces
  * actionable error codes (ALREADY_OWNED, SELLER_UNAVAILABLE, AMOUNT_BELOW_MINIMUM
  * …); we preserve its status + message for the UI.
  */
-import { checkBotId } from 'botid/server';
-
 export default defineEventHandler(async (event) => {
-  // Vercel BotID — block bots before minting a Stripe Checkout session.
-  // Protected in app/plugins/botid.client.ts. No-op (always human) in local dev.
-  const verification = await checkBotId();
-  // Fail CLOSED: treat a missing/odd verification as a block. (Optional chaining
-  // on `verification?.isBot` alone would fail OPEN on a nullish result, which is
-  // the wrong default for a security gate — checkBotId() returns an object or throws.)
-  if (!verification || verification.isBot) {
-    // Surface the classification so this isn't a silent black box again — the
-    // last regression hid for a week because the 403 carried no reason.
-    console.warn('[models/checkout] BotID blocked request', {
-      classificationReason: verification?.classificationReason,
-      isVerifiedBot: verification?.isVerifiedBot,
-    });
-    throw createError({ statusCode: 403, statusMessage: 'Bot detected' });
-  }
-
   const config = useRuntimeConfig();
 
   const authorization = getHeader(event, 'authorization');


### PR DESCRIPTION
## What

Removes Vercel BotID from `POST /api/models/checkout` (server `checkBotId()` call + client `protect` entry).

## Why

BotID was 403'ing ~100% of **real** buyers at checkout ("Bot detected") from launch onward — zero model sales. Two earlier fixes were ruled out **in production**:

1. **`$fetch` → native `fetch`** (f0d3cfd6): a no-op — ofetch already routes through the BotID-patched `window.fetch`. Still 403'd.
2. **Static path** `/api/models/checkout` (#629/#630): deployed READY, client confirmed calling the new path — **still 403'd** (logged via the new `classificationReason` warn).

The identical client patch + `checkBotId()` setup passes on `/api/langgraph/*` (chat returns 200 throughout), so BotID is **false-positive-classifying legitimate checkout traffic** — not a fetch or path-shape bug.

Checkout doesn't depend on BotID for safety: it requires an authenticated **Bearer token**, the `create-model-checkout` **edge function** re-validates model/seller/amount, payment happens on **Stripe-hosted** pages, and the route sits behind **per-IP rate limiting**. BotID here was defense-in-depth that became a 100% revenue kill-switch.

## Scope

- `seller/onboard` keeps BotID for now (low-traffic, also auth'd) — flagged to revisit if it shows the same false positives.
- The route's input validation (modelId/amountCents/url type checks) from #629 stays.

## Verification

Full `bun run build` in a clean worktree runs through client + server build + prerender-init + the checkout route transform with no errors (only stops at the env-dependent sitemap sources, same as any local build). BotID can't be exercised locally, so the real confirmation is a signed-in checkout on this PR's preview / prod returning a Stripe URL instead of 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)