### PR TITLE
feat(alignment): add wheel alignment tool — live diagram, presets, save-to-profile

### DIFF
--- a/app/components/Calculators/Alignment.vue
+++ b/app/components/Calculators/Alignment.vue
@@ -76,7 +76,9 @@
     const param = ALIGNMENT_PARAMETERS.find((p) => p.id === id)!;
     if (param.kind === 'toe') {
       if (Math.abs(v) < 0.05) return t('parallel');
-      return `${Math.abs(v).toFixed(2).replace(/\.?0+$/, '')} mm ${toeDir(v)} · ${toeFraction(v)}`;
+      const mmText = `${Math.abs(v).toFixed(2).replace(/\.?0+$/, '')} mm ${toeDir(v)}`;
+      const fraction = toeFraction(v);
+      return fraction === '0' ? mmText : `${mmText} · ${fraction}`;
     }
     return fmtDeg(v);
   }

--- a/app/components/Calculators/Alignment.vue
+++ b/app/components/Calculators/Alignment.vue
@@ -1,0 +1,1391 @@
+<script setup lang="ts">
+  import {
+    ALIGNMENT_PARAMETERS,
+    ALIGNMENT_PRESETS,
+    ALIGNMENT_WHEEL_SIZES,
+    ALIGNMENT_DEFAULT_WHEEL_SIZE,
+    defaultAlignmentValues,
+    getAlignmentPreset,
+    mmToInchFraction,
+    toeMmToDegrees,
+    getCamberGuidance,
+    type AlignmentValues,
+    type AlignmentParamId,
+    type AlignmentPresetId,
+    type AlignmentAxle,
+  } from '../../../data/models/alignment';
+  import {
+    useAlignmentConfigs,
+    alignmentValuesToColumns,
+    columnsToAlignmentValues,
+    type SavedAlignmentConfig,
+  } from '../../composables/useAlignmentConfigs';
+
+  const { t } = useI18n();
+  const { isAuthenticated } = useAuth();
+  const { track } = useAnalytics();
+  const { capture } = usePostHog();
+  const { saveConfig } = useAlignmentConfigs();
+
+  const values = reactive<AlignmentValues>(defaultAlignmentValues());
+  const wheelSize = ref<number>(ALIGNMENT_DEFAULT_WHEEL_SIZE);
+
+  const frontParams = ALIGNMENT_PARAMETERS.filter((p) => p.axle === 'front');
+  const rearParams = ALIGNMENT_PARAMETERS.filter((p) => p.axle === 'rear');
+
+  const EPS = 0.01;
+  const matchedPresetId = computed<AlignmentPresetId | null>(() => {
+    const match = ALIGNMENT_PRESETS.find((p) =>
+      (Object.keys(p.values) as (keyof AlignmentValues)[]).every((k) => Math.abs(p.values[k] - values[k]) < EPS)
+    );
+    return match ? match.id : null;
+  });
+  const activePreset = computed(() => (matchedPresetId.value ? getAlignmentPreset(matchedPresetId.value) : null));
+
+  function applyPreset(id: AlignmentPresetId) {
+    const preset = getAlignmentPreset(id);
+    if (!preset) return;
+    Object.assign(values, preset.values);
+    track('alignment_preset_selected', { preset: id });
+  }
+  function resetStock() {
+    applyPreset('stockRoad');
+  }
+
+  // ---- formatting / readouts ----
+  const fmtDeg = (v: number) => `${v > 0 ? '+' : ''}${v.toFixed(2).replace(/\.?0+$/, '')}°`;
+  const toeDir = (mm: number) => (Math.abs(mm) < 0.05 ? t('parallel') : mm < 0 ? t('toe_out') : t('toe_in'));
+  const toeFraction = (mm: number) => mmToInchFraction(mm);
+  const toeDegTotal = (mm: number) => toeMmToDegrees(mm, wheelSize.value);
+
+  // Wheel-size-aware camber guidance: the typical negative range for the selected rim, plus a
+  // gentle nudge when the chosen camber is more negative than that range.
+  function camberRangeText(axle: AlignmentAxle): string {
+    const g = getCamberGuidance(wheelSize.value, axle);
+    return `${fmtDeg(g.min)}…${fmtDeg(g.max)}`;
+  }
+  function isCamberAggressive(id: AlignmentParamId): boolean {
+    const param = ALIGNMENT_PARAMETERS.find((p) => p.id === id)!;
+    if (param.kind !== 'camber') return false;
+    const g = getCamberGuidance(wheelSize.value, param.axle);
+    return values[id] < g.min - 0.01;
+  }
+
+  function paramReadout(id: AlignmentParamId): string {
+    const v = values[id];
+    const param = ALIGNMENT_PARAMETERS.find((p) => p.id === id)!;
+    if (param.kind === 'toe') {
+      if (Math.abs(v) < 0.05) return t('parallel');
+      return `${Math.abs(v).toFixed(2).replace(/\.?0+$/, '')} mm ${toeDir(v)} · ${toeFraction(v)}`;
+    }
+    return fmtDeg(v);
+  }
+
+  const warnings = computed<string[]>(() => {
+    const w: string[] = [];
+    if (values.rearToe < -EPS) w.push('rearToeOut');
+    if (values.frontCaster > 5.5) w.push('casterHigh');
+    if (values.rearCamber > 0.25) w.push('rearCamberPositive');
+    if (values.frontCamber > 0.25) w.push('frontCamberPositive');
+    return w;
+  });
+
+  // ---- save ----
+  const showSaveForm = ref(false);
+  const saveName = ref('');
+  const saveNote = ref('');
+  const savePublic = ref(false);
+  const saving = ref(false);
+  const saveError = ref('');
+  const saveSuccess = ref(false);
+
+  async function handleSave() {
+    if (!saveName.value.trim()) {
+      saveError.value = t('save.name_required');
+      return;
+    }
+    saving.value = true;
+    saveError.value = '';
+    const journal = saveNote.value.trim()
+      ? [
+          {
+            id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`,
+            date: new Date().toISOString().slice(0, 10),
+            body: saveNote.value.trim(),
+          },
+        ]
+      : [];
+    const result = await saveConfig({
+      name: saveName.value.trim(),
+      ...alignmentValuesToColumns(values),
+      wheel_size: String(wheelSize.value),
+      preset: matchedPresetId.value,
+      journal,
+      is_public: savePublic.value,
+    });
+    saving.value = false;
+    if (result) {
+      saveSuccess.value = true;
+      showSaveForm.value = false;
+      saveName.value = '';
+      saveNote.value = '';
+      savePublic.value = false;
+      track('alignment_config_saved', { preset: matchedPresetId.value ?? 'custom' });
+      setTimeout(() => (saveSuccess.value = false), 4000);
+    } else {
+      saveError.value = t('save.error');
+    }
+  }
+
+  // ---- load ----
+  const showLoadModal = ref(false);
+  function onLoad(config: SavedAlignmentConfig) {
+    Object.assign(values, columnsToAlignmentValues(config));
+    if (config.wheel_size && ALIGNMENT_WHEEL_SIZES.includes(Number(config.wheel_size) as any)) {
+      wheelSize.value = Number(config.wheel_size);
+    }
+    showLoadModal.value = false;
+    track('alignment_config_loaded', { config_id: config.id });
+  }
+
+  // ---- analytics (debounced) ----
+  let captureTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(
+    () => ({ ...values }),
+    () => {
+      if (captureTimer) clearTimeout(captureTimer);
+      captureTimer = setTimeout(() => {
+        capture('calculator_used', { calculator: 'alignment', preset: matchedPresetId.value ?? 'custom' });
+      }, 1000);
+    },
+    { deep: true }
+  );
+  onUnmounted(() => {
+    if (captureTimer) clearTimeout(captureTimer);
+  });
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <!-- Preset selector -->
+    <section>
+      <h3 class="fancy-font-bold text-lg mb-1">{{ t('presets_title') }}</h3>
+      <p class="text-sm opacity-70 mb-3">{{ t('presets_subtitle') }}</p>
+      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2">
+        <button
+          v-for="preset in ALIGNMENT_PRESETS"
+          :key="preset.id"
+          class="btn btn-sm h-auto py-2 flex-col gap-1 normal-case"
+          :class="matchedPresetId === preset.id ? 'btn-primary' : 'btn-outline'"
+          @click="applyPreset(preset.id)"
+        >
+          <span class="font-semibold">{{ t(`presets.${preset.id}.name`) }}</span>
+          <span class="badge badge-xs" :class="`confidence-${preset.confidence}`">
+            {{ t(`confidence.${preset.confidence}`) }}
+          </span>
+        </button>
+      </div>
+    </section>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Controls -->
+      <section class="flex flex-col gap-5">
+        <!-- Wheel size -->
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend flex items-center gap-2">
+            <i class="fad fa-tire"></i>
+            {{ t('wheel_size') }}
+          </legend>
+          <div class="join">
+            <button
+              v-for="size in ALIGNMENT_WHEEL_SIZES"
+              :key="size"
+              class="btn btn-sm join-item"
+              :class="wheelSize === size ? 'btn-primary' : 'btn-outline'"
+              @click="wheelSize = size"
+            >
+              {{ size }}"
+            </button>
+          </div>
+          <p class="text-xs opacity-60 mt-1">{{ t('wheel_size_help') }}</p>
+        </fieldset>
+
+        <!-- Front group -->
+        <div>
+          <h4 class="fancy-font-bold text-base mb-2 flex items-center gap-2">
+            <i class="fad fa-arrow-up"></i> {{ t('front_axle') }}
+          </h4>
+          <div class="flex flex-col gap-4">
+            <div v-for="param in frontParams" :key="param.id" class="rounded-lg border border-base-300 p-3">
+              <div class="flex items-center justify-between gap-2 mb-1">
+                <label class="text-sm font-medium">{{ t(`params.${param.id}.label`) }}</label>
+                <span class="text-sm font-bold tabular-nums">{{ paramReadout(param.id) }}</span>
+              </div>
+              <div class="flex items-center gap-3">
+                <input
+                  v-model.number="values[param.id]"
+                  type="range"
+                  class="range range-primary range-sm grow"
+                  :min="param.min"
+                  :max="param.max"
+                  :step="param.step"
+                />
+                <input
+                  v-model.number="values[param.id]"
+                  type="number"
+                  class="input input-bordered input-sm w-20"
+                  :min="param.min"
+                  :max="param.max"
+                  :step="param.step"
+                />
+                <span class="text-xs opacity-60 w-6">{{ param.unit === 'deg' ? '°' : 'mm' }}</span>
+              </div>
+              <p class="text-xs opacity-60 mt-1">{{ t(`params.${param.id}.help`) }}</p>
+              <p v-if="param.kind === 'toe'" class="text-xs opacity-50 mt-0.5">
+                {{ t('approx_total_deg', { deg: toeDegTotal(values[param.id]).toFixed(2) }) }}
+              </p>
+              <p v-if="param.kind === 'camber'" class="text-xs opacity-50 mt-0.5">
+                {{ t('camber_guidance', { size: wheelSize, range: camberRangeText(param.axle) }) }}
+              </p>
+              <p v-if="param.kind === 'camber' && isCamberAggressive(param.id)" class="text-xs text-warning mt-0.5">
+                <i class="fas fa-triangle-exclamation"></i> {{ t('camber_aggressive', { size: wheelSize }) }}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Rear group -->
+        <div>
+          <h4 class="fancy-font-bold text-base mb-2 flex items-center gap-2">
+            <i class="fad fa-arrow-down"></i> {{ t('rear_axle') }}
+          </h4>
+          <div class="flex flex-col gap-4">
+            <div v-for="param in rearParams" :key="param.id" class="rounded-lg border border-base-300 p-3">
+              <div class="flex items-center justify-between gap-2 mb-1">
+                <label class="text-sm font-medium">{{ t(`params.${param.id}.label`) }}</label>
+                <span class="text-sm font-bold tabular-nums">{{ paramReadout(param.id) }}</span>
+              </div>
+              <div class="flex items-center gap-3">
+                <input
+                  v-model.number="values[param.id]"
+                  type="range"
+                  class="range range-primary range-sm grow"
+                  :min="param.min"
+                  :max="param.max"
+                  :step="param.step"
+                />
+                <input
+                  v-model.number="values[param.id]"
+                  type="number"
+                  class="input input-bordered input-sm w-20"
+                  :min="param.min"
+                  :max="param.max"
+                  :step="param.step"
+                />
+                <span class="text-xs opacity-60 w-6">{{ param.unit === 'deg' ? '°' : 'mm' }}</span>
+              </div>
+              <p class="text-xs opacity-60 mt-1">{{ t(`params.${param.id}.help`) }}</p>
+              <p v-if="param.kind === 'toe'" class="text-xs opacity-50 mt-0.5">
+                {{ t('approx_total_deg', { deg: toeDegTotal(values[param.id]).toFixed(2) }) }}
+              </p>
+              <p v-if="param.kind === 'camber'" class="text-xs opacity-50 mt-0.5">
+                {{ t('camber_guidance', { size: wheelSize, range: camberRangeText(param.axle) }) }}
+              </p>
+              <p v-if="param.kind === 'camber' && isCamberAggressive(param.id)" class="text-xs text-warning mt-0.5">
+                <i class="fas fa-triangle-exclamation"></i> {{ t('camber_aggressive', { size: wheelSize }) }}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <button class="btn btn-sm btn-ghost" @click="resetStock">
+            <i class="fas fa-rotate-left"></i> {{ t('reset_to_stock') }}
+          </button>
+        </div>
+      </section>
+
+      <!-- Diagram + readouts -->
+      <section class="flex flex-col gap-4">
+        <CalculatorsAlignmentDiagram
+          :front-camber="values.frontCamber"
+          :front-caster="values.frontCaster"
+          :front-toe="values.frontToe"
+          :rear-camber="values.rearCamber"
+          :rear-toe="values.rearToe"
+        />
+
+        <!-- Warnings -->
+        <div v-if="warnings.length" class="flex flex-col gap-2">
+          <div v-for="w in warnings" :key="w" class="alert alert-warning py-2 text-sm">
+            <i class="fas fa-triangle-exclamation"></i>
+            <span>{{ t(`warnings.${w}`) }}</span>
+          </div>
+        </div>
+
+        <!-- Active preset info -->
+        <div class="card bg-base-100 border border-base-300">
+          <div class="card-body p-4">
+            <div class="flex items-center justify-between gap-2">
+              <h4 class="fancy-font-bold text-base">
+                {{ activePreset ? t(`presets.${activePreset.id}.name`) : t('custom_setup') }}
+              </h4>
+              <span v-if="activePreset" class="badge badge-sm" :class="`confidence-${activePreset.confidence}`">
+                {{ t('confidence_label') }}: {{ t(`confidence.${activePreset.confidence}`) }}
+              </span>
+            </div>
+            <p class="text-sm opacity-80">
+              {{ activePreset ? t(`presets.${activePreset.id}.rationale`) : t('custom_setup_desc') }}
+            </p>
+            <div v-if="activePreset?.sources?.length" class="text-xs opacity-60">
+              <span class="font-semibold">{{ t('sources') }}:</span>
+              <a
+                v-for="(src, i) in activePreset.sources"
+                :key="src"
+                :href="src"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="link link-primary ml-1"
+                >[{{ i + 1 }}]</a
+              >
+            </div>
+          </div>
+        </div>
+
+        <!-- Save / Load -->
+        <div class="card bg-base-100 border border-base-300">
+          <div class="card-body p-4">
+            <template v-if="isAuthenticated">
+              <div class="flex flex-wrap gap-2">
+                <button class="btn btn-sm btn-primary" @click="showSaveForm = !showSaveForm">
+                  <i class="fas fa-bookmark"></i> {{ t('save.button') }}
+                </button>
+                <button class="btn btn-sm btn-outline" @click="showLoadModal = true">
+                  <i class="fas fa-folder-open"></i> {{ t('load.button') }}
+                </button>
+                <NuxtLink to="/dashboard/alignment-configs" class="btn btn-sm btn-ghost">
+                  <i class="fas fa-list"></i> {{ t('manage') }}
+                </NuxtLink>
+              </div>
+
+              <div v-if="saveSuccess" class="alert alert-success py-2 text-sm mt-2">
+                <i class="fas fa-circle-check"></i> <span>{{ t('save.success') }}</span>
+              </div>
+
+              <div v-if="showSaveForm" class="mt-3 flex flex-col gap-3">
+                <fieldset class="fieldset">
+                  <legend class="fieldset-legend">{{ t('save.name_label') }}</legend>
+                  <input
+                    v-model="saveName"
+                    type="text"
+                    maxlength="100"
+                    class="input input-bordered w-full"
+                    :placeholder="t('save.name_placeholder')"
+                  />
+                </fieldset>
+                <fieldset class="fieldset">
+                  <legend class="fieldset-legend">{{ t('save.note_label') }}</legend>
+                  <textarea
+                    v-model="saveNote"
+                    rows="2"
+                    class="textarea textarea-bordered w-full"
+                    :placeholder="t('save.note_placeholder')"
+                  ></textarea>
+                </fieldset>
+                <label class="flex items-center gap-2 text-sm cursor-pointer">
+                  <input v-model="savePublic" type="checkbox" class="toggle toggle-primary toggle-sm" />
+                  {{ t('save.make_public') }}
+                </label>
+                <p v-if="saveError" class="text-error text-sm">{{ saveError }}</p>
+                <div class="flex gap-2">
+                  <button class="btn btn-sm btn-primary" :disabled="saving" @click="handleSave">
+                    <span v-if="saving" class="loading loading-spinner loading-xs"></span>
+                    {{ t('save.confirm') }}
+                  </button>
+                  <button class="btn btn-sm btn-ghost" @click="showSaveForm = false">{{ t('save.cancel') }}</button>
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <p class="text-sm opacity-70 mb-2">{{ t('save.sign_in_prompt') }}</p>
+              <NuxtLink to="/login" class="btn btn-sm btn-primary w-fit">
+                <i class="fas fa-right-to-bracket"></i> {{ t('save.sign_in') }}
+              </NuxtLink>
+            </template>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Disclaimer -->
+    <div class="alert alert-info py-3 text-sm">
+      <i class="fas fa-circle-info"></i>
+      <span>{{ t('disclaimer') }}</span>
+    </div>
+
+    <CalculatorsAlignmentSaveLoadModal v-model="showLoadModal" @load="onLoad" />
+  </div>
+</template>
+
+<style scoped>
+  .confidence-high {
+    background: color-mix(in srgb, #4caf50 22%, transparent);
+    color: #2e7d32;
+    border: none;
+  }
+  .confidence-medium {
+    background: color-mix(in srgb, var(--cm-fa-orange, #f3b140) 28%, transparent);
+    color: #8a6d00;
+    border: none;
+  }
+  .confidence-low {
+    background: color-mix(in srgb, var(--cm-secondary, #ed7135) 22%, transparent);
+    color: #b34a17;
+    border: none;
+  }
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "presets_title": "Start from a preset",
+    "presets_subtitle": "Research-derived starting points from MED, Mini Spares, Calver, The Mini Forum and the factory manuals. Tweak from here.",
+    "front_axle": "Front axle",
+    "rear_axle": "Rear axle",
+    "wheel_size": "Wheel size",
+    "wheel_size_help": "Used for the toe degree readout and camber guidance — camber recommendations scale with rim size. Presets assume ~10\" wheels.",
+    "reset_to_stock": "Reset to factory",
+    "parallel": "parallel",
+    "toe_in": "toe-in",
+    "toe_out": "toe-out",
+    "approx_total_deg": "≈ {deg}° total at the rim",
+    "camber_guidance": "Typical {size}\" range: {range}",
+    "camber_aggressive": "More negative than typical for {size}\" — watch inner-edge tyre wear",
+    "custom_setup": "Custom setup",
+    "custom_setup_desc": "You've adjusted away from the presets. Remember: front runs toe-out, rear runs toe-in, and caster stays positive. Match left and right within 0.5°.",
+    "confidence_label": "Confidence",
+    "sources": "Sources",
+    "manage": "Manage saved",
+    "params": {
+      "frontCamber": {
+        "label": "Front camber",
+        "help": "Positive = top leans out, negative = top leans in. Stock is positive; performance runs negative. Needs adjustable/offset lower arms."
+      },
+      "frontCaster": {
+        "label": "Front caster",
+        "help": "Always positive. Set via adjustable tie-bars. Keep both sides within 0.5° and don't exceed ~5.5°."
+      },
+      "frontToe": {
+        "label": "Front toe (total)",
+        "help": "Negative = toe-out, positive = toe-in. Total across both wheels — set each side to half. Adjusted at the track-rod ends."
+      },
+      "rearCamber": {
+        "label": "Rear camber",
+        "help": "Negative = top leans in. Never run notable positive at the rear. Set via eccentric washers or adjustable brackets."
+      },
+      "rearToe": {
+        "label": "Rear toe (total)",
+        "help": "Positive = toe-in (mandatory for road stability). Negative (toe-out) is race-only. Set via shims or adjustable brackets."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "Stock Road",
+        "rationale": "Factory workshop-manual geometry. Note the front camber is positive (+2°) and the front runs slight toe-out — both are correct for the Mini, not typos. The rear runs 1/8\" toe-in for straight-line stability."
+      },
+      "fastRoad": {
+        "name": "Fast Road",
+        "rationale": "Sharper turn-in than stock while staying streetable and easy on tyres. Flips front camber negative to keep the loaded tyre flat through body roll, with a touch more caster for self-centring. Keeps mild front toe-out and lighter rear toe-in."
+      },
+      "trackDay": {
+        "name": "Track Day",
+        "rationale": "Maximum cornering grip on road or semi-slick tyres; accepts faster tyre wear. More negative front camber and more caster; rear set straight to let the back rotate on turn-in. The tyre sets the camber ceiling — verify on a rig."
+      },
+      "boostedRoad": {
+        "name": "Boosted Road",
+        "rationale": "Turbo or supercharged street car. The key change is front toe set parallel (zero) to cut torque steer and improve drive off the line, with healthy caster for stability under power and larger rear toe-in for traction."
+      },
+      "boostedTrack": {
+        "name": "Boosted Track",
+        "rationale": "High-power forced-induction circuit car — the most extrapolated preset, so treat it as a starting point only. Aggressive front camber and caster with only a small front toe-out so power still goes down, plus mild rear toe-in for stability under acceleration."
+      }
+    },
+    "confidence": {
+      "high": "High confidence",
+      "medium": "Medium",
+      "low": "Low / extrapolated"
+    },
+    "warnings": {
+      "rearToeOut": "Rear toe-out can cause snap oversteer — only suitable for experienced drivers on a full-race rotation setup.",
+      "casterHigh": "Caster above 5.5° is beyond the usual practical limit and adds heavy steering effort.",
+      "rearCamberPositive": "Positive rear camber makes the back nervous — the rear should run neutral to mild negative.",
+      "frontCamberPositive": "Positive front camber is the factory figure for skinny crossplies; most modern setups run negative for grip."
+    },
+    "save": {
+      "button": "Save setup",
+      "confirm": "Save",
+      "cancel": "Cancel",
+      "name_label": "Configuration name",
+      "name_placeholder": "e.g. My 1275 fast road",
+      "name_required": "Please enter a name",
+      "note_label": "First journal note (optional)",
+      "note_placeholder": "e.g. Baseline before track day — car understeers on turn-in",
+      "make_public": "Make this configuration public",
+      "success": "Configuration saved to your profile",
+      "error": "Could not save configuration. Please try again.",
+      "sign_in_prompt": "Sign in to save this setup to your profile and keep a driving journal over time.",
+      "sign_in": "Sign in to save"
+    },
+    "load": {
+      "button": "Load saved"
+    },
+    "disclaimer": "These are starting points, not gospel. Always verify on a proper alignment rig (eyeballed toe is frequently wrong by 1/8\" or more), match caster and camber side-to-side within 0.5°, and re-check after any ride-height change. Alignment only partially tames torque steer on a boosted Mini."
+  },
+  "es": {
+    "presets_title": "Empieza desde un preajuste",
+    "presets_subtitle": "Puntos de partida basados en investigación de MED, Mini Spares, Calver, The Mini Forum y los manuales de fábrica. Ajusta a partir de aquí.",
+    "front_axle": "Eje delantero",
+    "rear_axle": "Eje trasero",
+    "wheel_size": "Tamaño de llanta",
+    "wheel_size_help": "Se usa para la lectura de la convergencia en grados y la orientación de la caída — las recomendaciones de caída varían según el tamaño de la llanta. Los preajustes asumen llantas de ~10\".",
+    "reset_to_stock": "Restablecer a fábrica",
+    "parallel": "paralelo",
+    "toe_in": "convergencia",
+    "toe_out": "divergencia",
+    "approx_total_deg": "≈ {deg}° total en la llanta",
+    "camber_guidance": "Rango típico {size}\": {range}",
+    "camber_aggressive": "Más negativo de lo típico para {size}\" — vigila el desgaste interior",
+    "custom_setup": "Configuración personalizada",
+    "custom_setup_desc": "Te has alejado de los preajustes. Recuerda: el delantero lleva divergencia, el trasero lleva convergencia y el avance se mantiene positivo. Iguala izquierda y derecha dentro de 0,5°.",
+    "confidence_label": "Confianza",
+    "sources": "Fuentes",
+    "manage": "Gestionar guardados",
+    "params": {
+      "frontCamber": {
+        "label": "Caída delantera",
+        "help": "Positiva = la parte superior se inclina hacia afuera, negativa = la parte superior se inclina hacia adentro. De fábrica es positiva; las versiones de rendimiento llevan negativa. Requiere brazos inferiores ajustables/descentrados."
+      },
+      "frontCaster": {
+        "label": "Avance delantero",
+        "help": "Siempre positivo. Se ajusta mediante las barras de tracción ajustables. Mantén ambos lados dentro de 0,5° y no superes los ~5,5°."
+      },
+      "frontToe": {
+        "label": "Convergencia delantera (total)",
+        "help": "Negativa = divergencia, positiva = convergencia. Total entre ambas ruedas — ajusta cada lado a la mitad. Se regula en los extremos de las barras de dirección."
+      },
+      "rearCamber": {
+        "label": "Caída trasera",
+        "help": "Negativa = la parte superior se inclina hacia adentro. Nunca lleves caída positiva notable en el eje trasero. Se ajusta mediante arandelas excéntricas o soportes ajustables."
+      },
+      "rearToe": {
+        "label": "Convergencia trasera (total)",
+        "help": "Positiva = convergencia (obligatoria para la estabilidad en carretera). Negativa (divergencia) es solo para competición. Se ajusta mediante suplementos o soportes ajustables."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "Carretera estándar",
+        "rationale": "Geometría del manual de taller de fábrica. Fíjate en que la caída delantera es positiva (+2°) y el delantero lleva ligera divergencia — ambos son correctos para el Mini, no son errores. El trasero lleva 1/8\" de convergencia para la estabilidad en línea recta."
+      },
+      "fastRoad": {
+        "name": "Carretera rápida",
+        "rationale": "Entrada en curva más afilada que la estándar, pero apta para calle y suave con los neumáticos. Pasa la caída delantera a negativa para mantener plano el neumático cargado durante el balanceo de la carrocería, con algo más de avance para el autocentrado. Conserva una leve divergencia delantera y menos convergencia trasera."
+      },
+      "trackDay": {
+        "name": "Día de circuito",
+        "rationale": "Máximo agarre en curva con neumáticos de calle o semislick; acepta un desgaste más rápido de los neumáticos. Más caída delantera negativa y más avance; el trasero se ajusta recto para dejar que la parte trasera rote en la entrada. El neumático marca el límite de caída — verifícalo en un banco."
+      },
+      "boostedRoad": {
+        "name": "Carretera sobrealimentada",
+        "rationale": "Coche de calle turbo o sobrealimentado. El cambio clave es ajustar la convergencia delantera en paralelo (cero) para reducir el tiro de par y mejorar la salida desde parado, con un buen avance para la estabilidad bajo potencia y más convergencia trasera para la tracción."
+      },
+      "boostedTrack": {
+        "name": "Circuito sobrealimentado",
+        "rationale": "Coche de circuito de alta potencia con sobrealimentación — el preajuste más extrapolado, así que trátalo solo como punto de partida. Caída y avance delanteros agresivos con apenas una pequeña divergencia delantera para que la potencia siga llegando al suelo, más una leve convergencia trasera para la estabilidad bajo aceleración."
+      }
+    },
+    "confidence": {
+      "high": "Confianza alta",
+      "medium": "Media",
+      "low": "Baja / extrapolada"
+    },
+    "warnings": {
+      "rearToeOut": "La divergencia trasera puede provocar sobreviraje brusco — solo apta para conductores experimentados en una configuración de rotación de pura competición.",
+      "casterHigh": "Un avance superior a 5,5° está más allá del límite práctico habitual y aumenta mucho el esfuerzo de dirección.",
+      "rearCamberPositive": "La caída trasera positiva vuelve nerviosa la parte trasera — el eje trasero debe llevar de neutra a ligeramente negativa.",
+      "frontCamberPositive": "La caída delantera positiva es el valor de fábrica para los neumáticos diagonales estrechos; la mayoría de las configuraciones modernas llevan negativa para mejorar el agarre."
+    },
+    "save": {
+      "button": "Guardar configuración",
+      "confirm": "Guardar",
+      "cancel": "Cancelar",
+      "name_label": "Nombre de la configuración",
+      "name_placeholder": "p. ej. Mi 1275 de carretera rápida",
+      "name_required": "Introduce un nombre",
+      "note_label": "Primera nota del diario (opcional)",
+      "note_placeholder": "p. ej. Referencia antes del día de circuito — el coche subvira en la entrada",
+      "make_public": "Hacer pública esta configuración",
+      "success": "Configuración guardada en tu perfil",
+      "error": "No se pudo guardar la configuración. Inténtalo de nuevo.",
+      "sign_in_prompt": "Inicia sesión para guardar esta configuración en tu perfil y mantener un diario de conducción a lo largo del tiempo.",
+      "sign_in": "Inicia sesión para guardar"
+    },
+    "load": {
+      "button": "Cargar guardada"
+    },
+    "disclaimer": "Estos son puntos de partida, no dogmas. Verifica siempre en un banco de alineación adecuado (la convergencia medida a ojo suele estar mal por 1/8\" o más), iguala el avance y la caída entre ambos lados dentro de 0,5° y vuelve a comprobar tras cualquier cambio de altura de marcha. La alineación solo dompta parcialmente el tiro de par en un Mini sobrealimentado."
+  },
+  "fr": {
+    "presets_title": "Partir d'un préréglage",
+    "presets_subtitle": "Points de départ issus de recherches chez MED, Mini Spares, Calver, The Mini Forum et les manuels d'usine. Ajustez à partir de là.",
+    "front_axle": "Train avant",
+    "rear_axle": "Train arrière",
+    "wheel_size": "Taille de roue",
+    "wheel_size_help": "Utilisée pour l'affichage du parallélisme en degrés et les conseils de carrossage — les recommandations de carrossage évoluent selon la taille de jante. Les préréglages supposent des roues d'environ 10\".",
+    "reset_to_stock": "Réinitialiser aux valeurs d'usine",
+    "parallel": "parallèle",
+    "toe_in": "pincement",
+    "toe_out": "ouverture",
+    "approx_total_deg": "≈ {deg}° au total à la jante",
+    "camber_guidance": "Plage typique {size}\" : {range}",
+    "camber_aggressive": "Plus négatif que la normale pour {size}\" — surveille l'usure intérieure",
+    "custom_setup": "Réglage personnalisé",
+    "custom_setup_desc": "Vous vous êtes écarté des préréglages. Rappelez-vous : l'avant est en ouverture, l'arrière en pincement, et la chasse reste positive. Faites correspondre gauche et droite à 0,5° près.",
+    "confidence_label": "Confiance",
+    "sources": "Sources",
+    "manage": "Gérer les enregistrements",
+    "params": {
+      "frontCamber": {
+        "label": "Carrossage avant",
+        "help": "Positif = le haut penche vers l'extérieur, négatif = le haut penche vers l'intérieur. La valeur d'usine est positive ; les configurations sport sont négatives. Nécessite des bras inférieurs réglables/décalés."
+      },
+      "frontCaster": {
+        "label": "Chasse avant",
+        "help": "Toujours positive. Réglée via des barres de réaction réglables. Gardez les deux côtés à 0,5° près et ne dépassez pas ~5,5°."
+      },
+      "frontToe": {
+        "label": "Parallélisme avant (total)",
+        "help": "Négatif = ouverture, positif = pincement. Total sur les deux roues — réglez chaque côté à la moitié. Réglé au niveau des embouts de biellette de direction."
+      },
+      "rearCamber": {
+        "label": "Carrossage arrière",
+        "help": "Négatif = le haut penche vers l'intérieur. Ne jamais rouler avec un carrossage nettement positif à l'arrière. Réglé via des rondelles excentriques ou des supports réglables."
+      },
+      "rearToe": {
+        "label": "Parallélisme arrière (total)",
+        "help": "Positif = pincement (obligatoire pour la stabilité sur route). Négatif (ouverture) réservé à la compétition. Réglé via des cales ou des supports réglables."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "Route d'origine",
+        "rationale": "Géométrie du manuel d'atelier d'usine. Notez que le carrossage avant est positif (+2°) et que l'avant roule en légère ouverture — les deux sont corrects pour la Mini, ce ne sont pas des erreurs. L'arrière roule avec 1/8\" de pincement pour la stabilité en ligne droite."
+      },
+      "fastRoad": {
+        "name": "Route sportive",
+        "rationale": "Mise en virage plus incisive que d'origine tout en restant utilisable sur route et indulgent pour les pneus. Passe le carrossage avant en négatif pour garder le pneu chargé à plat dans le roulis, avec un peu plus de chasse pour le rappel. Conserve une légère ouverture à l'avant et un pincement plus léger à l'arrière."
+      },
+      "trackDay": {
+        "name": "Journée circuit",
+        "rationale": "Adhérence maximale en virage sur pneus route ou semi-slicks ; accepte une usure plus rapide des pneus. Carrossage avant plus négatif et plus de chasse ; arrière réglé droit pour laisser l'arrière pivoter en entrée de virage. Le pneu fixe le plafond de carrossage — vérifiez sur un banc."
+      },
+      "boostedRoad": {
+        "name": "Route suralimentée",
+        "rationale": "Voiture de route turbo ou compressée. Le changement clé est le parallélisme avant réglé parallèle (zéro) pour réduire l'effet de couple dans la direction et améliorer la motricité au départ, avec une bonne dose de chasse pour la stabilité en charge et un pincement arrière plus important pour la traction."
+      },
+      "boostedTrack": {
+        "name": "Circuit suralimenté",
+        "rationale": "Voiture de circuit suralimentée à forte puissance — le préréglage le plus extrapolé, à considérer donc uniquement comme un point de départ. Carrossage et chasse avant agressifs avec seulement une petite ouverture avant pour que la puissance passe au sol, plus un léger pincement arrière pour la stabilité à l'accélération."
+      }
+    },
+    "confidence": {
+      "high": "Confiance élevée",
+      "medium": "Moyenne",
+      "low": "Faible / extrapolée"
+    },
+    "warnings": {
+      "rearToeOut": "Une ouverture à l'arrière peut provoquer un survirage brutal — réservée aux pilotes expérimentés sur une configuration de pivotement full-race.",
+      "casterHigh": "Une chasse supérieure à 5,5° dépasse la limite pratique habituelle et alourdit fortement la direction.",
+      "rearCamberPositive": "Un carrossage arrière positif rend l'arrière nerveux — l'arrière doit rouler de neutre à légèrement négatif.",
+      "frontCamberPositive": "Le carrossage avant positif est la valeur d'usine pour les pneus diagonaux étroits ; la plupart des configurations modernes roulent en négatif pour l'adhérence."
+    },
+    "save": {
+      "button": "Enregistrer le réglage",
+      "confirm": "Enregistrer",
+      "cancel": "Annuler",
+      "name_label": "Nom de la configuration",
+      "name_placeholder": "ex. Ma 1275 route sportive",
+      "name_required": "Veuillez saisir un nom",
+      "note_label": "Première note de journal (facultatif)",
+      "note_placeholder": "ex. Référence avant la journée circuit — la voiture sous-vire en entrée de virage",
+      "make_public": "Rendre cette configuration publique",
+      "success": "Configuration enregistrée dans votre profil",
+      "error": "Impossible d'enregistrer la configuration. Veuillez réessayer.",
+      "sign_in_prompt": "Connectez-vous pour enregistrer ce réglage dans votre profil et tenir un journal de conduite dans le temps.",
+      "sign_in": "Se connecter pour enregistrer"
+    },
+    "load": {
+      "button": "Charger un enregistrement"
+    },
+    "disclaimer": "Ce sont des points de départ, pas des vérités absolues. Vérifiez toujours sur un banc de géométrie approprié (le parallélisme estimé à l'œil est souvent faux de 1/8\" ou plus), faites correspondre chasse et carrossage côté à côté à 0,5° près, et revérifiez après tout changement de hauteur de caisse. La géométrie ne maîtrise que partiellement l'effet de couple dans la direction sur une Mini suralimentée."
+  },
+  "de": {
+    "presets_title": "Mit einer Voreinstellung beginnen",
+    "presets_subtitle": "Recherchierte Ausgangswerte von MED, Mini Spares, Calver, The Mini Forum und den Werkstatthandbüchern. Von hier aus anpassen.",
+    "front_axle": "Vorderachse",
+    "rear_axle": "Hinterachse",
+    "wheel_size": "Radgröße",
+    "wheel_size_help": "Wird für die Spuranzeige in Grad und die Sturzempfehlung verwendet — Sturzempfehlungen skalieren mit der Felgengröße. Voreinstellungen gehen von ~10\"-Rädern aus.",
+    "reset_to_stock": "Auf Werkseinstellung zurücksetzen",
+    "parallel": "parallel",
+    "toe_in": "Vorspur",
+    "toe_out": "Nachspur",
+    "approx_total_deg": "≈ {deg}° gesamt an der Felge",
+    "camber_guidance": "Typischer {size}\"-Bereich: {range}",
+    "camber_aggressive": "Negativer als üblich für {size}\" — auf inneren Reifenverschleiß achten",
+    "custom_setup": "Individuelles Setup",
+    "custom_setup_desc": "Du hast die Voreinstellungen verändert. Denk daran: vorne läuft Nachspur, hinten läuft Vorspur, und der Nachlauf bleibt positiv. Links und rechts auf 0,5° abgleichen.",
+    "confidence_label": "Verlässlichkeit",
+    "sources": "Quellen",
+    "manage": "Gespeicherte verwalten",
+    "params": {
+      "frontCamber": {
+        "label": "Sturz vorne",
+        "help": "Positiv = oben neigt nach außen, negativ = oben neigt nach innen. Serie ist positiv; Performance läuft negativ. Erfordert verstellbare/versetzte untere Querlenker."
+      },
+      "frontCaster": {
+        "label": "Nachlauf vorne",
+        "help": "Immer positiv. Über verstellbare Zugstreben eingestellt. Beide Seiten auf 0,5° halten und ~5,5° nicht überschreiten."
+      },
+      "frontToe": {
+        "label": "Spur vorne (gesamt)",
+        "help": "Negativ = Nachspur, positiv = Vorspur. Gesamtwert über beide Räder — jede Seite auf die Hälfte einstellen. An den Spurstangenköpfen eingestellt."
+      },
+      "rearCamber": {
+        "label": "Sturz hinten",
+        "help": "Negativ = oben neigt nach innen. Hinten niemals nennenswert positiv fahren. Über exzentrische Scheiben oder verstellbare Halterungen eingestellt."
+      },
+      "rearToe": {
+        "label": "Spur hinten (gesamt)",
+        "help": "Positiv = Vorspur (zwingend erforderlich für Straßenstabilität). Negativ (Nachspur) ist nur für den Rennsport. Über Distanzscheiben oder verstellbare Halterungen eingestellt."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "Serie Straße",
+        "rationale": "Werksgeometrie aus dem Werkstatthandbuch. Beachte, dass der Sturz vorne positiv ist (+2°) und vorne leichte Nachspur läuft — beides ist beim Mini korrekt, keine Tippfehler. Hinten läuft 1/8\" Vorspur für Geradeauslaufstabilität."
+      },
+      "fastRoad": {
+        "name": "Schnelle Straße",
+        "rationale": "Schärferes Einlenken als Serie, dabei alltagstauglich und reifenschonend. Kippt den Sturz vorne ins Negative, damit der belastete Reifen bei Wankbewegungen flach bleibt, mit etwas mehr Nachlauf für die Selbstzentrierung. Behält milde Nachspur vorne und leichtere Vorspur hinten bei."
+      },
+      "trackDay": {
+        "name": "Trackday",
+        "rationale": "Maximaler Kurvengrip auf Straßen- oder Semislick-Reifen; nimmt schnelleren Reifenverschleiß in Kauf. Mehr negativer Sturz vorne und mehr Nachlauf; hinten auf parallel gestellt, damit das Heck beim Einlenken eindreht. Der Reifen gibt die Sturzobergrenze vor — auf dem Prüfstand verifizieren."
+      },
+      "boostedRoad": {
+        "name": "Aufgeladen Straße",
+        "rationale": "Turbo- oder kompressoraufgeladenes Straßenfahrzeug. Die wichtigste Änderung ist die Spur vorne auf parallel (null), um Antriebseinflüsse auf die Lenkung zu reduzieren und den Vortrieb von der Linie weg zu verbessern, mit ausreichend Nachlauf für Stabilität unter Last und größerer Vorspur hinten für Traktion."
+      },
+      "boostedTrack": {
+        "name": "Aufgeladen Rennstrecke",
+        "rationale": "Hochleistungs-Rennstreckenfahrzeug mit Aufladung — die am weitesten extrapolierte Voreinstellung, daher nur als Ausgangspunkt behandeln. Aggressiver Sturz und Nachlauf vorne mit nur geringer Nachspur vorne, damit die Leistung noch auf die Straße kommt, plus milde Vorspur hinten für Stabilität unter Beschleunigung."
+      }
+    },
+    "confidence": {
+      "high": "Hohe Verlässlichkeit",
+      "medium": "Mittel",
+      "low": "Niedrig / extrapoliert"
+    },
+    "warnings": {
+      "rearToeOut": "Nachspur hinten kann zu plötzlichem Übersteuern führen — nur geeignet für erfahrene Fahrer mit einem reinen Renn-Setup auf Eindrehen.",
+      "casterHigh": "Ein Nachlauf über 5,5° liegt jenseits der üblichen praktischen Grenze und erhöht die Lenkkräfte erheblich.",
+      "rearCamberPositive": "Positiver Sturz hinten macht das Heck nervös — hinten sollte neutral bis leicht negativ laufen.",
+      "frontCamberPositive": "Positiver Sturz vorne ist der Werkswert für schmale Diagonalreifen; die meisten modernen Setups laufen für den Grip negativ."
+    },
+    "save": {
+      "button": "Setup speichern",
+      "confirm": "Speichern",
+      "cancel": "Abbrechen",
+      "name_label": "Konfigurationsname",
+      "name_placeholder": "z. B. Meine 1275 schnelle Straße",
+      "name_required": "Bitte einen Namen eingeben",
+      "note_label": "Erste Journalnotiz (optional)",
+      "note_placeholder": "z. B. Basis vor dem Trackday — Auto untersteuert beim Einlenken",
+      "make_public": "Diese Konfiguration öffentlich machen",
+      "success": "Konfiguration in deinem Profil gespeichert",
+      "error": "Konfiguration konnte nicht gespeichert werden. Bitte erneut versuchen.",
+      "sign_in_prompt": "Melde dich an, um dieses Setup in deinem Profil zu speichern und mit der Zeit ein Fahrtenjournal zu führen.",
+      "sign_in": "Zum Speichern anmelden"
+    },
+    "load": {
+      "button": "Gespeicherte laden"
+    },
+    "disclaimer": "Dies sind Ausgangspunkte, kein Dogma. Verifiziere immer auf einem ordentlichen Achsvermessungsstand (per Augenmaß geschätzte Spur liegt häufig um 1/8\" oder mehr daneben), gleiche Nachlauf und Sturz seitenweise auf 0,5° ab und überprüfe nach jeder Änderung der Fahrzeughöhe erneut. Die Achsvermessung zähmt Antriebseinflüsse auf die Lenkung bei einem aufgeladenen Mini nur teilweise."
+  },
+  "it": {
+    "presets_title": "Parti da un preset",
+    "presets_subtitle": "Punti di partenza derivati da ricerche di MED, Mini Spares, Calver, The Mini Forum e dai manuali ufficiali. Affina da qui.",
+    "front_axle": "Assale anteriore",
+    "rear_axle": "Assale posteriore",
+    "wheel_size": "Dimensione ruota",
+    "wheel_size_help": "Usata per la lettura della convergenza in gradi e le indicazioni sulla campanatura — le raccomandazioni di campanatura variano con la dimensione del cerchio. I preset presuppongono ruote da ~10\".",
+    "reset_to_stock": "Ripristina a valori di serie",
+    "parallel": "parallelo",
+    "toe_in": "convergenza",
+    "toe_out": "divergenza",
+    "approx_total_deg": "≈ {deg}° totali al cerchio",
+    "camber_guidance": "Intervallo tipico {size}\": {range}",
+    "camber_aggressive": "Più negativo del tipico per {size}\" — attenzione all'usura interna",
+    "custom_setup": "Configurazione personalizzata",
+    "custom_setup_desc": "Hai modificato i valori rispetto ai preset. Ricorda: l'anteriore lavora in divergenza, il posteriore in convergenza, e l'incidenza resta positiva. Allinea sinistra e destra entro 0,5°.",
+    "confidence_label": "Affidabilità",
+    "sources": "Fonti",
+    "manage": "Gestisci salvati",
+    "params": {
+      "frontCamber": {
+        "label": "Campanatura anteriore",
+        "help": "Positiva = parte superiore inclinata verso l'esterno, negativa = parte superiore inclinata verso l'interno. Di serie è positiva; in assetto sportivo è negativa. Richiede bracci inferiori regolabili/con offset."
+      },
+      "frontCaster": {
+        "label": "Incidenza anteriore",
+        "help": "Sempre positiva. Si imposta con i tiranti regolabili. Mantieni i due lati entro 0,5° e non superare i ~5,5°."
+      },
+      "frontToe": {
+        "label": "Convergenza anteriore (totale)",
+        "help": "Negativa = divergenza, positiva = convergenza. Totale sulle due ruote — imposta ciascun lato alla metà. Si regola sui terminali della barra di sterzo."
+      },
+      "rearCamber": {
+        "label": "Campanatura posteriore",
+        "help": "Negativa = parte superiore inclinata verso l'interno. Non usare mai una campanatura positiva marcata al posteriore. Si imposta con rondelle eccentriche o staffe regolabili."
+      },
+      "rearToe": {
+        "label": "Convergenza posteriore (totale)",
+        "help": "Positiva = convergenza (obbligatoria per la stabilità su strada). Negativa (divergenza) è solo per le competizioni. Si imposta con spessori o staffe regolabili."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "Strada di serie",
+        "rationale": "Geometria del manuale d'officina di serie. Nota che la campanatura anteriore è positiva (+2°) e l'anteriore lavora in leggera divergenza — entrambi sono corretti per la Mini, non errori. Il posteriore lavora con 1/8\" di convergenza per la stabilità in rettilineo."
+      },
+      "fastRoad": {
+        "name": "Strada sportiva",
+        "rationale": "Inserimento in curva più reattivo rispetto a quello di serie, restando guidabile su strada e poco usurante per gli pneumatici. Rende la campanatura anteriore negativa per mantenere a contatto lo pneumatico carico durante il rollio, con un po' più di incidenza per l'autocentraggio. Mantiene una lieve divergenza anteriore e una convergenza posteriore più leggera."
+      },
+      "trackDay": {
+        "name": "Giornata in pista",
+        "rationale": "Massima aderenza in curva su pneumatici stradali o semi-slick; accetta un'usura più rapida degli pneumatici. Maggiore campanatura anteriore negativa e più incidenza; posteriore impostato dritto per far ruotare il retrotreno in inserimento. Lo pneumatico fissa il limite massimo di campanatura — verifica su un banco."
+      },
+      "boostedRoad": {
+        "name": "Strada sovralimentata",
+        "rationale": "Auto da strada turbo o sovralimentata. La modifica chiave è la convergenza anteriore impostata parallela (zero) per ridurre il torque steer e migliorare la trazione in partenza, con un'incidenza generosa per la stabilità sotto carico e una maggiore convergenza posteriore per la trazione."
+      },
+      "boostedTrack": {
+        "name": "Pista sovralimentata",
+        "rationale": "Auto da circuito a sovralimentazione e alta potenza — il preset più estrapolato, quindi consideralo solo come punto di partenza. Campanatura e incidenza anteriori aggressive con solo una leggera divergenza anteriore per far comunque scaricare la potenza, più una lieve convergenza posteriore per la stabilità in accelerazione."
+      }
+    },
+    "confidence": {
+      "high": "Affidabilità alta",
+      "medium": "Media",
+      "low": "Bassa / estrapolata"
+    },
+    "warnings": {
+      "rearToeOut": "La divergenza posteriore può causare sovrasterzo improvviso — adatta solo a piloti esperti in un assetto da rotazione full-race.",
+      "casterHigh": "Un'incidenza superiore a 5,5° supera il consueto limite pratico e aumenta notevolmente lo sforzo allo sterzo.",
+      "rearCamberPositive": "Una campanatura posteriore positiva rende il retrotreno nervoso — il posteriore dovrebbe lavorare da neutro a lievemente negativo.",
+      "frontCamberPositive": "La campanatura anteriore positiva è il valore di serie per gli stretti pneumatici crossply; la maggior parte degli assetti moderni usa valori negativi per l'aderenza."
+    },
+    "save": {
+      "button": "Salva configurazione",
+      "confirm": "Salva",
+      "cancel": "Annulla",
+      "name_label": "Nome configurazione",
+      "name_placeholder": "es. La mia 1275 strada sportiva",
+      "name_required": "Inserisci un nome",
+      "note_label": "Prima nota del diario (facoltativa)",
+      "note_placeholder": "es. Riferimento prima della giornata in pista — l'auto sottosterza in inserimento",
+      "make_public": "Rendi pubblica questa configurazione",
+      "success": "Configurazione salvata nel tuo profilo",
+      "error": "Impossibile salvare la configurazione. Riprova.",
+      "sign_in_prompt": "Accedi per salvare questa configurazione nel tuo profilo e tenere un diario di guida nel tempo.",
+      "sign_in": "Accedi per salvare"
+    },
+    "load": {
+      "button": "Carica salvati"
+    },
+    "disclaimer": "Questi sono punti di partenza, non verità assolute. Verifica sempre su un banco di allineamento adeguato (la convergenza valutata a occhio è spesso sbagliata di 1/8\" o più), allinea incidenza e campanatura tra i due lati entro 0,5° e ricontrolla dopo ogni modifica dell'altezza da terra. L'allineamento attenua solo in parte il torque steer su una Mini sovralimentata."
+  },
+  "pt": {
+    "presets_title": "Comece a partir de uma predefinição",
+    "presets_subtitle": "Pontos de partida derivados de pesquisa da MED, Mini Spares, Calver, The Mini Forum e dos manuais de fábrica. Ajuste a partir daqui.",
+    "front_axle": "Eixo dianteiro",
+    "rear_axle": "Eixo traseiro",
+    "wheel_size": "Tamanho da roda",
+    "wheel_size_help": "Usado para a leitura da convergência em graus e para a orientação da cambagem — as recomendações de cambagem variam conforme o tamanho do aro. As predefinições assumem rodas de ~10\".",
+    "reset_to_stock": "Repor para fábrica",
+    "parallel": "paralelo",
+    "toe_in": "convergência",
+    "toe_out": "divergência",
+    "approx_total_deg": "≈ {deg}° total no aro",
+    "camber_guidance": "Faixa típica {size}\": {range}",
+    "camber_aggressive": "Mais negativo que o típico para {size}\" — atenção ao desgaste interno",
+    "custom_setup": "Configuração personalizada",
+    "custom_setup_desc": "Afastou-se das predefinições. Lembre-se: o dianteiro corre com divergência, o traseiro com convergência, e o cáster mantém-se positivo. Iguale o lado esquerdo e direito dentro de 0,5°.",
+    "confidence_label": "Confiança",
+    "sources": "Fontes",
+    "manage": "Gerir guardadas",
+    "params": {
+      "frontCamber": {
+        "label": "Cambagem dianteira",
+        "help": "Positiva = topo inclina para fora, negativa = topo inclina para dentro. De fábrica é positiva; o uso desportivo corre negativa. Requer braços inferiores ajustáveis/com desvio."
+      },
+      "frontCaster": {
+        "label": "Cáster dianteiro",
+        "help": "Sempre positivo. Definido através de barras de ligação ajustáveis. Mantenha ambos os lados dentro de 0,5° e não exceda ~5,5°."
+      },
+      "frontToe": {
+        "label": "Convergência dianteira (total)",
+        "help": "Negativa = divergência, positiva = convergência. Total entre ambas as rodas — defina cada lado para metade. Ajustada nas extremidades das barras de direção."
+      },
+      "rearCamber": {
+        "label": "Cambagem traseira",
+        "help": "Negativa = topo inclina para dentro. Nunca corra com valor positivo notável na traseira. Definida através de anilhas excêntricas ou suportes ajustáveis."
+      },
+      "rearToe": {
+        "label": "Convergência traseira (total)",
+        "help": "Positiva = convergência (obrigatória para estabilidade em estrada). Negativa (divergência) é só para competição. Definida através de calços ou suportes ajustáveis."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "Estrada de Série",
+        "rationale": "Geometria do manual de oficina de fábrica. Repare que a cambagem dianteira é positiva (+2°) e o dianteiro corre com ligeira divergência — ambos estão corretos para o Mini, não são erros. A traseira corre com 1/8\" de convergência para estabilidade em linha reta."
+      },
+      "fastRoad": {
+        "name": "Estrada Rápida",
+        "rationale": "Entrada em curva mais incisiva do que a de série, mantendo-se utilizável na estrada e suave para os pneus. Inverte a cambagem dianteira para negativa de modo a manter o pneu carregado plano durante a inclinação da carroçaria, com um pouco mais de cáster para autocentragem. Mantém ligeira divergência dianteira e convergência traseira mais leve."
+      },
+      "trackDay": {
+        "name": "Dia de Pista",
+        "rationale": "Aderência máxima em curva com pneus de estrada ou semi-slick; aceita um desgaste mais rápido dos pneus. Mais cambagem dianteira negativa e mais cáster; a traseira definida a direito para deixar a parte de trás rodar na entrada da curva. O pneu define o limite máximo de cambagem — verifique numa bancada."
+      },
+      "boostedRoad": {
+        "name": "Estrada Turbo",
+        "rationale": "Carro de rua turbo ou sobrealimentado. A alteração-chave é a convergência dianteira definida paralela (zero) para reduzir o efeito de torque na direção e melhorar a tração na arrancada, com cáster saudável para estabilidade sob potência e maior convergência traseira para tração."
+      },
+      "boostedTrack": {
+        "name": "Pista Turbo",
+        "rationale": "Carro de circuito de indução forçada de alta potência — a predefinição mais extrapolada, por isso trate-a apenas como ponto de partida. Cambagem e cáster dianteiros agressivos com apenas uma pequena divergência dianteira para a potência ainda ir ao chão, mais ligeira convergência traseira para estabilidade sob aceleração."
+      }
+    },
+    "confidence": {
+      "high": "Confiança alta",
+      "medium": "Média",
+      "low": "Baixa / extrapolada"
+    },
+    "warnings": {
+      "rearToeOut": "A divergência traseira pode causar sobreviragem brusca — só adequada para condutores experientes numa configuração de rotação de competição total.",
+      "casterHigh": "Cáster acima de 5,5° está além do limite prático habitual e acrescenta um esforço de direção pesado.",
+      "rearCamberPositive": "A cambagem traseira positiva torna a traseira nervosa — a traseira deve correr entre neutra e ligeiramente negativa.",
+      "frontCamberPositive": "A cambagem dianteira positiva é o valor de fábrica para os pneus diagonais estreitos; a maioria das configurações modernas corre negativa para aderência."
+    },
+    "save": {
+      "button": "Guardar configuração",
+      "confirm": "Guardar",
+      "cancel": "Cancelar",
+      "name_label": "Nome da configuração",
+      "name_placeholder": "ex. O meu 1275 de estrada rápida",
+      "name_required": "Por favor, introduza um nome",
+      "note_label": "Primeira nota do diário (opcional)",
+      "note_placeholder": "ex. Referência antes do dia de pista — o carro subvira na entrada da curva",
+      "make_public": "Tornar esta configuração pública",
+      "success": "Configuração guardada no seu perfil",
+      "error": "Não foi possível guardar a configuração. Por favor, tente novamente.",
+      "sign_in_prompt": "Inicie sessão para guardar esta configuração no seu perfil e manter um diário de condução ao longo do tempo.",
+      "sign_in": "Iniciar sessão para guardar"
+    },
+    "load": {
+      "button": "Carregar guardada"
+    },
+    "disclaimer": "Estes são pontos de partida, não dogmas. Verifique sempre numa bancada de alinhamento adequada (a convergência avaliada a olho está frequentemente errada em 1/8\" ou mais), iguale o cáster e a cambagem de lado a lado dentro de 0,5°, e volte a verificar após qualquer alteração da altura de rodagem. O alinhamento só dompta parcialmente o efeito de torque na direção num Mini turbo."
+  },
+  "ru": {
+    "presets_title": "Начните с пресета",
+    "presets_subtitle": "Отправные точки, основанные на исследованиях MED, Mini Spares, Calver, The Mini Forum и заводских руководств. Дальше подстраивайте под себя.",
+    "front_axle": "Передняя ось",
+    "rear_axle": "Задняя ось",
+    "wheel_size": "Размер колеса",
+    "wheel_size_help": "Используется для отображения схождения в градусах и рекомендаций по развалу — рекомендации по развалу масштабируются с размером обода. Пресеты рассчитаны на колёса ~10\".",
+    "reset_to_stock": "Сбросить к заводским",
+    "parallel": "параллельно",
+    "toe_in": "схождение",
+    "toe_out": "расхождение",
+    "approx_total_deg": "≈ {deg}° всего на ободе",
+    "camber_guidance": "Типичный диапазон {size}\": {range}",
+    "camber_aggressive": "Отрицательнее обычного для {size}\" — следите за износом внутренней кромки",
+    "custom_setup": "Своя настройка",
+    "custom_setup_desc": "Вы отклонились от пресетов. Помните: спереди задаётся расхождение, сзади — схождение, а кастер остаётся положительным. Согласуйте левую и правую стороны в пределах 0,5°.",
+    "confidence_label": "Достоверность",
+    "sources": "Источники",
+    "manage": "Управление сохранёнными",
+    "params": {
+      "frontCamber": {
+        "label": "Передний развал",
+        "help": "Положительный = верх наклонён наружу, отрицательный = верх наклонён внутрь. Заводское значение положительное; для производительности задают отрицательное. Требуются регулируемые/смещённые нижние рычаги."
+      },
+      "frontCaster": {
+        "label": "Передний кастер",
+        "help": "Всегда положительный. Регулируется через регулируемые продольные тяги. Держите обе стороны в пределах 0,5° и не превышайте ~5.5°."
+      },
+      "frontToe": {
+        "label": "Переднее схождение (всего)",
+        "help": "Отрицательное = расхождение, положительное = схождение. Суммарно по обоим колёсам — задавайте по половине на каждую сторону. Регулируется на наконечниках рулевых тяг."
+      },
+      "rearCamber": {
+        "label": "Задний развал",
+        "help": "Отрицательный = верх наклонён внутрь. Никогда не задавайте заметный положительный развал сзади. Регулируется эксцентриковыми шайбами или регулируемыми кронштейнами."
+      },
+      "rearToe": {
+        "label": "Заднее схождение (всего)",
+        "help": "Положительное = схождение (обязательно для устойчивости на дороге). Отрицательное (расхождение) только для гонок. Регулируется прокладками или регулируемыми кронштейнами."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "Сток дорога",
+        "rationale": "Геометрия из заводского руководства. Обратите внимание: передний развал положительный (+2°), а спереди задано небольшое расхождение — для Mini это правильно, а не опечатки. Сзади задано схождение 1/8\" для устойчивости по прямой."
+      },
+      "fastRoad": {
+        "name": "Спорт дорога",
+        "rationale": "Более острый вход в поворот, чем у стока, при этом пригоден для улицы и щадит шины. Делает передний развал отрицательным, чтобы нагруженная шина оставалась плоской при кренах кузова, с чуть большим кастером для самовозврата руля. Сохраняет умеренное переднее расхождение и меньшее заднее схождение."
+      },
+      "trackDay": {
+        "name": "Трек-день",
+        "rationale": "Максимальное сцепление в поворотах на дорожных или полуслик-шинах; за это платите ускоренным износом шин. Больше отрицательного переднего развала и больше кастера; сзади задано прямо, чтобы корма доворачивалась при входе в поворот. Предел развала задаёт шина — проверяйте на стенде."
+      },
+      "boostedRoad": {
+        "name": "Наддув дорога",
+        "rationale": "Уличный автомобиль с турбонаддувом или компрессором. Ключевое изменение — переднее схождение выставлено параллельно (ноль), чтобы убрать рулевой увод от тяги и улучшить разгон со старта, со здоровым кастером для устойчивости под нагрузкой и большим задним схождением для сцепления."
+      },
+      "boostedTrack": {
+        "name": "Наддув трек",
+        "rationale": "Мощный трековый автомобиль с наддувом — самый экстраполированный пресет, поэтому относитесь к нему лишь как к отправной точке. Агрессивные передний развал и кастер с лишь небольшим передним расхождением, чтобы мощность всё же доходила до колёс, плюс умеренное заднее схождение для устойчивости при разгоне."
+      }
+    },
+    "confidence": {
+      "high": "Высокая достоверность",
+      "medium": "Средняя",
+      "low": "Низкая / экстраполировано"
+    },
+    "warnings": {
+      "rearToeOut": "Заднее расхождение может вызвать резкую избыточную поворачиваемость — подходит только опытным водителям при чисто гоночной настройке на доворот.",
+      "casterHigh": "Кастер выше 5.5° выходит за обычный практический предел и сильно утяжеляет руль.",
+      "rearCamberPositive": "Положительный задний развал делает корму нервной — сзади развал должен быть нейтральным или слегка отрицательным.",
+      "frontCamberPositive": "Положительный передний развал — заводское значение для узких диагональных шин; большинство современных настроек используют отрицательный развал ради сцепления."
+    },
+    "save": {
+      "button": "Сохранить настройку",
+      "confirm": "Сохранить",
+      "cancel": "Отмена",
+      "name_label": "Название конфигурации",
+      "name_placeholder": "напр. Мой 1275 для спорт-дороги",
+      "name_required": "Пожалуйста, введите название",
+      "note_label": "Первая запись в журнале (необязательно)",
+      "note_placeholder": "напр. Базовая настройка перед трек-днём — машина недостаточно поворачивает на входе",
+      "make_public": "Сделать эту конфигурацию публичной",
+      "success": "Конфигурация сохранена в вашем профиле",
+      "error": "Не удалось сохранить конфигурацию. Пожалуйста, попробуйте снова.",
+      "sign_in_prompt": "Войдите, чтобы сохранить эту настройку в свой профиль и со временем вести журнал поездок.",
+      "sign_in": "Войти, чтобы сохранить"
+    },
+    "load": {
+      "button": "Загрузить сохранённое"
+    },
+    "disclaimer": "Это отправные точки, а не истина в последней инстанции. Всегда проверяйте на нормальном стенде развал-схождения (схождение на глаз часто ошибочно на 1/8\" и более), согласуйте кастер и развал по сторонам в пределах 0,5° и перепроверяйте после любого изменения дорожного просвета. Регулировка лишь частично укрощает рулевой увод от тяги на Mini с наддувом."
+  },
+  "ja": {
+    "presets_title": "プリセットから始める",
+    "presets_subtitle": "MED、Mini Spares、Calver、The Mini Forum、そして純正マニュアルから導き出した出発点です。ここから微調整してください。",
+    "front_axle": "フロントアクスル",
+    "rear_axle": "リアアクスル",
+    "wheel_size": "ホイールサイズ",
+    "wheel_size_help": "トーの角度表示とキャンバーのガイダンスに使用します。キャンバーの推奨値はリムサイズに応じて変化します。プリセットは約10\"ホイールを想定しています。",
+    "reset_to_stock": "純正値にリセット",
+    "parallel": "平行",
+    "toe_in": "トーイン",
+    "toe_out": "トーアウト",
+    "approx_total_deg": "≈ リムで合計 {deg}°",
+    "camber_guidance": "{size}\" の標準範囲: {range}",
+    "camber_aggressive": "{size}\" の標準より強い負キャンバー — 内側の偏摩耗に注意",
+    "custom_setup": "カスタムセットアップ",
+    "custom_setup_desc": "プリセットから調整を加えました。覚えておいてください：フロントはトーアウト、リアはトーイン、キャスターはプラスを維持します。左右を0.5°以内で揃えてください。",
+    "confidence_label": "信頼度",
+    "sources": "出典",
+    "manage": "保存済みを管理",
+    "params": {
+      "frontCamber": {
+        "label": "フロントキャンバー",
+        "help": "プラス＝上側が外側に傾く、マイナス＝上側が内側に傾く。純正はプラス、パフォーマンス仕様はマイナス。調整式／オフセットのロワアームが必要です。"
+      },
+      "frontCaster": {
+        "label": "フロントキャスター",
+        "help": "常にプラス。調整式タイバーで設定します。左右を0.5°以内に揃え、約5.5°を超えないようにしてください。"
+      },
+      "frontToe": {
+        "label": "フロントトー（合計）",
+        "help": "マイナス＝トーアウト、プラス＝トーイン。両輪の合計値で、片側はその半分に設定します。タイロッドエンドで調整します。"
+      },
+      "rearCamber": {
+        "label": "リアキャンバー",
+        "help": "マイナス＝上側が内側に傾く。リアで目立つほどのプラスにしてはいけません。偏心ワッシャーまたは調整式ブラケットで設定します。"
+      },
+      "rearToe": {
+        "label": "リアトー（合計）",
+        "help": "プラス＝トーイン（路上での安定性に必須）。マイナス（トーアウト）はレース専用です。シムまたは調整式ブラケットで設定します。"
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "ノーマル公道",
+        "rationale": "純正ワークショップマニュアルのジオメトリー。フロントキャンバーがプラス（+2°）で、フロントが軽いトーアウトであることに注目してください。どちらもMiniにとって正しい値で、誤記ではありません。リアは直進安定性のために1/8\"のトーインです。"
+      },
+      "fastRoad": {
+        "name": "ファストロード",
+        "rationale": "ノーマルより鋭いターンインを実現しつつ、街乗りに対応しタイヤにも優しい設定。フロントキャンバーをマイナスに反転させ、ロール時に荷重のかかったタイヤを路面にフラットに保ち、セルフセンタリングのためにキャスターをやや増やします。フロントは軽いトーアウト、リアは控えめなトーインを維持します。"
+      },
+      "trackDay": {
+        "name": "トラックデー",
+        "rationale": "公道用またはセミスリックタイヤでのコーナリンググリップを最大化。タイヤの摩耗が早まることを許容します。フロントキャンバーをよりマイナスに、キャスターをより多くし、リアはストレートに設定してターンインで後輪を回頭させます。タイヤがキャンバーの上限を決めます。測定機で確認してください。"
+      },
+      "boostedRoad": {
+        "name": "過給公道",
+        "rationale": "ターボまたはスーパーチャージャー付きのストリートカー。重要な変更点はフロントトーを平行（ゼロ）に設定してトルクステアを抑え、発進時の駆動力を改善することです。パワー下での安定性のために十分なキャスターを確保し、トラクションのためにリアトーインを大きめにします。"
+      },
+      "boostedTrack": {
+        "name": "過給サーキット",
+        "rationale": "ハイパワーの過給サーキットカー。最も外挿の度合いが大きいプリセットなので、あくまで出発点として扱ってください。アグレッシブなフロントキャンバーとキャスターに、パワーをしっかり路面に伝えるための小さなフロントトーアウトのみを組み合わせ、加速時の安定性のために控えめなリアトーインを加えます。"
+      }
+    },
+    "confidence": {
+      "high": "信頼度：高",
+      "medium": "中",
+      "low": "低／外挿"
+    },
+    "warnings": {
+      "rearToeOut": "リアのトーアウトは急なオーバーステアを引き起こす可能性があります。フルレースの回頭セットアップに慣れた経験豊富なドライバーにのみ適しています。",
+      "casterHigh": "5.5°を超えるキャスターは通常の実用的な限界を超えており、ステアリングが重くなります。",
+      "rearCamberPositive": "リアのプラスキャンバーは後輪を神経質にします。リアはニュートラルから軽いマイナスにすべきです。",
+      "frontCamberPositive": "フロントのプラスキャンバーは細身のクロスプライタイヤ向けの純正値です。現代の多くのセットアップではグリップのためにマイナスにします。"
+    },
+    "save": {
+      "button": "セットアップを保存",
+      "confirm": "保存",
+      "cancel": "キャンセル",
+      "name_label": "設定名",
+      "name_placeholder": "例：私の1275ファストロード",
+      "name_required": "名前を入力してください",
+      "note_label": "最初のジャーナルメモ（任意）",
+      "note_placeholder": "例：トラックデー前のベースライン — ターンインでアンダーステア",
+      "make_public": "この設定を公開する",
+      "success": "設定をプロフィールに保存しました",
+      "error": "設定を保存できませんでした。もう一度お試しください。",
+      "sign_in_prompt": "サインインすると、このセットアップをプロフィールに保存し、長期にわたるドライビングジャーナルを記録できます。",
+      "sign_in": "サインインして保存"
+    },
+    "load": {
+      "button": "保存済みを読み込む"
+    },
+    "disclaimer": "これらは出発点であり、絶対的なものではありません。必ず適切なアライメント測定機で確認し（目視によるトー測定は1/8\"以上ずれていることがよくあります）、キャスターとキャンバーを左右0.5°以内で揃え、車高を変更した後は再確認してください。過給したMiniでは、アライメントはトルクステアを部分的にしか抑えられません。"
+  },
+  "zh": {
+    "presets_title": "从预设开始",
+    "presets_subtitle": "源自 MED、Mini Spares、Calver、The Mini Forum 以及原厂手册研究得出的起始参数。可在此基础上微调。",
+    "front_axle": "前桥",
+    "rear_axle": "后桥",
+    "wheel_size": "轮辋尺寸",
+    "wheel_size_help": "用于前束角度读数和外倾角指导——外倾角推荐值会随轮辋尺寸变化。预设以 ~10\" 轮辋为基准。",
+    "reset_to_stock": "恢复原厂设置",
+    "parallel": "平行",
+    "toe_in": "前束内束",
+    "toe_out": "前束外束",
+    "approx_total_deg": "≈ 轮辋处总计 {deg}°",
+    "camber_guidance": "{size}\" 典型范围：{range}",
+    "camber_aggressive": "比 {size}\" 的典型值更负——注意内侧轮胎磨损",
+    "custom_setup": "自定义设置",
+    "custom_setup_desc": "您已偏离预设进行调整。请记住：前轮采用外束，后轮采用内束，主销后倾角保持正值。左右两侧需在 0.5° 范围内匹配一致。",
+    "confidence_label": "可信度",
+    "sources": "来源",
+    "manage": "管理已保存",
+    "params": {
+      "frontCamber": {
+        "label": "前轮外倾角",
+        "help": "正值=顶部外倾，负值=顶部内倾。原厂为正值；性能设置采用负值。需要可调式/偏置下摆臂。"
+      },
+      "frontCaster": {
+        "label": "前轮主销后倾角",
+        "help": "始终为正值。通过可调式拉杆设定。两侧保持在 0.5° 范围内，且不要超过 ~5.5°。"
+      },
+      "frontToe": {
+        "label": "前轮前束（总计）",
+        "help": "负值=外束，正值=内束。为两轮总计值——每侧设定为一半。在转向横拉杆端部进行调整。"
+      },
+      "rearCamber": {
+        "label": "后轮外倾角",
+        "help": "负值=顶部内倾。后轮切勿采用明显正值。通过偏心垫片或可调支架设定。"
+      },
+      "rearToe": {
+        "label": "后轮前束（总计）",
+        "help": "正值=内束（道路稳定性必需）。负值（外束）仅适用于赛道。通过垫片或可调支架设定。"
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "原厂街道",
+        "rationale": "原厂维修手册几何参数。请注意前轮外倾角为正值（+2°），且前轮采用轻微外束——这两点对 Mini 而言都是正确的，并非笔误。后轮采用 1/8\" 内束以保证直线行驶稳定性。"
+      },
+      "fastRoad": {
+        "name": "高性能街道",
+        "rationale": "比原厂更敏锐的入弯响应，同时保持街道适用性且对轮胎友好。将前轮外倾角翻转为负值，使受载轮胎在车身侧倾时保持平整，并略微增加主销后倾角以增强回正力。保持轻微的前轮外束和较小的后轮内束。"
+      },
+      "trackDay": {
+        "name": "赛道日",
+        "rationale": "在公路或半热熔轮胎上获得最大过弯抓地力；可接受较快的轮胎磨损。更大的前轮负外倾角和更大的主销后倾角；后轮设为平直以便后部在入弯时转动。轮胎决定外倾角上限——务必在调校台上验证。"
+      },
+      "boostedRoad": {
+        "name": "增压街道",
+        "rationale": "涡轮增压或机械增压街车。关键变化是将前轮前束设为平行（零），以减少扭矩转向并改善起步动力，配合充足的主销后倾角以保证动力下的稳定性，并加大后轮内束以提升牵引力。"
+      },
+      "boostedTrack": {
+        "name": "增压赛道",
+        "rationale": "大功率强制进气赛道车——这是外推程度最高的预设，因此仅应作为起始点对待。激进的前轮外倾角和主销后倾角，仅配合少量前轮外束以便动力仍能落地，外加轻微的后轮内束以保证加速时的稳定性。"
+      }
+    },
+    "confidence": {
+      "high": "高可信度",
+      "medium": "中等",
+      "low": "低 / 外推"
+    },
+    "warnings": {
+      "rearToeOut": "后轮外束可能导致突发性转向过度——仅适合经验丰富的驾驶者在全赛车转动设置下使用。",
+      "casterHigh": "主销后倾角超过 5.5° 已超出常规实用极限，并会大幅增加转向力度。",
+      "rearCamberPositive": "后轮正外倾角会使后部变得不安定——后轮应采用中性至轻微负值。",
+      "frontCamberPositive": "前轮正外倾角是针对窄胎面斜交胎的原厂数值；大多数现代设置采用负值以获得抓地力。"
+    },
+    "save": {
+      "button": "保存设置",
+      "confirm": "保存",
+      "cancel": "取消",
+      "name_label": "配置名称",
+      "name_placeholder": "例如：我的 1275 高性能街道",
+      "name_required": "请输入名称",
+      "note_label": "首条日志记录（可选）",
+      "note_placeholder": "例如：赛道日前的基准设置——车辆入弯时转向不足",
+      "make_public": "将此配置设为公开",
+      "success": "配置已保存到您的个人资料",
+      "error": "无法保存配置。请重试。",
+      "sign_in_prompt": "登录以将此设置保存到您的个人资料，并随时间记录驾驶日志。",
+      "sign_in": "登录以保存"
+    },
+    "load": {
+      "button": "加载已保存"
+    },
+    "disclaimer": "这些只是起始参数，并非金科玉律。请始终在专业的四轮定位调校台上验证（目测的前束经常会有 1/8\" 甚至更大的偏差），将主销后倾角和外倾角左右两侧匹配在 0.5° 范围内，并在任何车身高度变更后重新检查。在增压 Mini 上，四轮定位只能部分抑制扭矩转向。"
+  },
+  "ko": {
+    "presets_title": "프리셋에서 시작하기",
+    "presets_subtitle": "MED, Mini Spares, Calver, The Mini Forum 및 공장 정비 매뉴얼에서 도출한 출발점입니다. 여기서부터 세부 조정하세요.",
+    "front_axle": "앞 차축",
+    "rear_axle": "뒤 차축",
+    "wheel_size": "휠 사이즈",
+    "wheel_size_help": "토 각도 표시와 캠버 가이드에 사용됩니다 — 캠버 권장값은 림 사이즈에 따라 달라집니다. 프리셋은 약 10\" 휠을 기준으로 합니다.",
+    "reset_to_stock": "공장 사양으로 초기화",
+    "parallel": "평행",
+    "toe_in": "토인",
+    "toe_out": "토아웃",
+    "approx_total_deg": "≈ 림 기준 합계 {deg}°",
+    "camber_guidance": "{size}\" 일반 범위: {range}",
+    "camber_aggressive": "{size}\"의 일반값보다 큰 네거티브 — 안쪽 타이어 마모 주의",
+    "custom_setup": "사용자 설정",
+    "custom_setup_desc": "프리셋에서 벗어나 조정했습니다. 기억하세요: 앞은 토아웃, 뒤는 토인이며, 캐스터는 양(+)을 유지합니다. 좌우를 0.5° 이내로 맞추세요.",
+    "confidence_label": "신뢰도",
+    "sources": "출처",
+    "manage": "저장 항목 관리",
+    "params": {
+      "frontCamber": {
+        "label": "앞 캠버",
+        "help": "양(+) = 윗부분이 바깥쪽으로 기울고, 음(-) = 윗부분이 안쪽으로 기웁니다. 순정은 양(+)이며, 성능 세팅은 음(-)으로 갑니다. 조절식/오프셋 로어 암이 필요합니다."
+      },
+      "frontCaster": {
+        "label": "앞 캐스터",
+        "help": "항상 양(+)입니다. 조절식 타이바로 설정합니다. 양쪽을 0.5° 이내로 맞추고 약 5.5°를 넘지 마세요."
+      },
+      "frontToe": {
+        "label": "앞 토(합계)",
+        "help": "음(-) = 토아웃, 양(+) = 토인. 양쪽 바퀴의 합계 — 각 측을 절반씩 설정하세요. 타이로드 엔드에서 조정합니다."
+      },
+      "rearCamber": {
+        "label": "뒤 캠버",
+        "help": "음(-) = 윗부분이 안쪽으로 기웁니다. 뒤쪽은 절대로 뚜렷한 양(+)으로 세팅하지 마세요. 편심 와셔나 조절식 브래킷으로 설정합니다."
+      },
+      "rearToe": {
+        "label": "뒤 토(합계)",
+        "help": "양(+) = 토인(도로 안정성을 위해 필수). 음(-)(토아웃)은 레이스 전용입니다. 심이나 조절식 브래킷으로 설정합니다."
+      }
+    },
+    "presets": {
+      "stockRoad": {
+        "name": "순정 도로",
+        "rationale": "공장 정비 매뉴얼 지오메트리입니다. 앞 캠버가 양(+2°)이고 앞이 약간의 토아웃으로 세팅된 점에 유의하세요 — 둘 다 오타가 아니라 Mini에 맞는 정상값입니다. 뒤는 직진 안정성을 위해 1/8\" 토인으로 세팅됩니다."
+      },
+      "fastRoad": {
+        "name": "패스트 로드",
+        "rationale": "도로 주행에 적합하고 타이어에 무리가 없으면서도 순정보다 날카로운 턴인을 제공합니다. 차체 롤 시 하중이 실린 타이어를 평평하게 유지하기 위해 앞 캠버를 음(-)으로 바꾸고, 셀프 센터링을 위해 캐스터를 약간 더 줍니다. 가벼운 앞 토아웃과 약한 뒤 토인을 유지합니다."
+      },
+      "trackDay": {
+        "name": "트랙 데이",
+        "rationale": "도로용 또는 세미슬릭 타이어에서 최대 코너링 그립을 냅니다; 더 빠른 타이어 마모를 감수합니다. 앞 캠버를 더 음(-)으로, 캐스터를 더 많이 주며; 턴인 시 뒤가 회전하도록 뒤는 일직선으로 세팅합니다. 캠버 한계는 타이어가 결정합니다 — 정비 장비로 확인하세요."
+      },
+      "boostedRoad": {
+        "name": "부스트 도로",
+        "rationale": "터보 또는 슈퍼차저 도로용 차량입니다. 핵심 변경점은 토크 스티어를 줄이고 출발 가속을 개선하기 위해 앞 토를 평행(0)으로 세팅하는 것이며, 출력 하에서의 안정성을 위한 충분한 캐스터와 접지력을 위한 더 큰 뒤 토인을 함께 적용합니다."
+      },
+      "boostedTrack": {
+        "name": "부스트 트랙",
+        "rationale": "고출력 강제 흡기 서킷 차량 — 가장 추정에 의존한 프리셋이므로 출발점으로만 취급하세요. 공격적인 앞 캠버와 캐스터에 출력 전달을 유지하도록 작은 앞 토아웃만 주고, 가속 시 안정성을 위해 약한 뒤 토인을 더합니다."
+      }
+    },
+    "confidence": {
+      "high": "높은 신뢰도",
+      "medium": "보통",
+      "low": "낮음 / 추정값"
+    },
+    "warnings": {
+      "rearToeOut": "뒤 토아웃은 급격한 오버스티어를 유발할 수 있습니다 — 풀레이스 회전 세팅에서 숙련된 운전자에게만 적합합니다.",
+      "casterHigh": "5.5°를 넘는 캐스터는 통상적인 실용 한계를 벗어나며 조향이 매우 무거워집니다.",
+      "rearCamberPositive": "뒤 캠버가 양(+)이면 후미가 불안정해집니다 — 뒤는 중립에서 약한 음(-)으로 세팅해야 합니다.",
+      "frontCamberPositive": "앞 캠버 양(+)은 가는 크로스플라이 타이어용 공장 수치입니다; 대부분의 현대적 세팅은 그립을 위해 음(-)으로 갑니다."
+    },
+    "save": {
+      "button": "세팅 저장",
+      "confirm": "저장",
+      "cancel": "취소",
+      "name_label": "구성 이름",
+      "name_placeholder": "예: 내 1275 패스트 로드",
+      "name_required": "이름을 입력하세요",
+      "note_label": "첫 저널 메모(선택)",
+      "note_placeholder": "예: 트랙 데이 전 기준값 — 턴인 시 언더스티어 발생",
+      "make_public": "이 구성을 공개로 설정",
+      "success": "구성이 프로필에 저장되었습니다",
+      "error": "구성을 저장할 수 없습니다. 다시 시도하세요.",
+      "sign_in_prompt": "로그인하면 이 세팅을 프로필에 저장하고 시간에 따라 주행 저널을 기록할 수 있습니다.",
+      "sign_in": "로그인하여 저장"
+    },
+    "load": {
+      "button": "저장 항목 불러오기"
+    },
+    "disclaimer": "이는 출발점일 뿐 절대적인 정답이 아닙니다. 항상 제대로 된 얼라인먼트 장비로 확인하고(눈대중 토는 1/8\" 이상 틀린 경우가 흔합니다), 캐스터와 캠버 좌우를 0.5° 이내로 맞추며, 차고 변경 후에는 다시 점검하세요. 얼라인먼트는 부스트 Mini의 토크 스티어를 부분적으로만 완화합니다."
+  }
+}
+</i18n>

--- a/app/components/Calculators/AlignmentDiagram.vue
+++ b/app/components/Calculators/AlignmentDiagram.vue
@@ -1,0 +1,464 @@
+<script setup lang="ts">
+  import { mmToInchFraction } from '../../../data/models/alignment';
+
+  const props = defineProps<{
+    frontCamber: number;
+    frontCaster: number;
+    frontToe: number; // mm total, negative = toe-out
+    rearCamber: number;
+    rearToe: number; // mm total, positive = toe-in
+  }>();
+
+  const { t } = useI18n();
+
+  // Visual exaggeration factors — real alignment angles are tiny (<0.5° of toe), so the
+  // diagram amplifies them for legibility while the numeric readouts show true values.
+  const TOE_SCALE = 4; // deg shown per mm of total toe
+  const CAMBER_SCALE = 6; // deg shown per deg of camber
+  const CASTER_SCALE = 3.2; // deg shown per deg of caster
+
+  const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+
+  // Top-down wheel rotations. Left wheel rotates by value*scale; right is its mirror.
+  // Negative toe (toe-out) splays the leading (front) edges outward; positive (toe-in) draws them in.
+  const flRot = computed(() => clamp(props.frontToe * TOE_SCALE, -20, 20));
+  const frRot = computed(() => -flRot.value);
+  const rlRot = computed(() => clamp(props.rearToe * TOE_SCALE, -20, 20));
+  const rrRot = computed(() => -rlRot.value);
+
+  // Elevation camber rotations (about the contact patch). Negative camber leans the top inward.
+  const fCamber = computed(() => clamp(props.frontCamber * CAMBER_SCALE, -24, 24));
+  const fCamberLeft = computed(() => -fCamber.value);
+  const fCamberRight = computed(() => fCamber.value);
+  const rCamber = computed(() => clamp(props.rearCamber * CAMBER_SCALE, -24, 24));
+  const rCamberLeft = computed(() => -rCamber.value);
+  const rCamberRight = computed(() => rCamber.value);
+
+  // Caster: side view, front to the left. Positive caster tilts the steering axis top rearward.
+  const casterRot = computed(() => clamp(props.frontCaster * CASTER_SCALE, 0, 30));
+
+  // ---- Readout labels ----
+  const fmtDeg = (v: number) => `${v > 0 ? '+' : ''}${v.toFixed(1)}°`;
+
+  const toeLabel = (mm: number) => {
+    if (Math.abs(mm) < 0.05) return t('parallel');
+    const dir = mm < 0 ? t('out') : t('in');
+    return `${mmToInchFraction(mm)} ${dir}`;
+  };
+
+  const frontToeLabel = computed(() => toeLabel(props.frontToe));
+  const rearToeLabel = computed(() => toeLabel(props.rearToe));
+</script>
+
+<template>
+  <div class="align-diagram">
+    <!-- Top-down plan view: toe -->
+    <figure class="align-diagram__panel align-diagram__topdown">
+      <svg viewBox="0 0 360 540" role="img" :aria-label="t('aria.topdown')">
+        <!-- centerline -->
+        <line x1="180" y1="44" x2="180" y2="500" class="ad-centerline" />
+        <!-- body silhouette -->
+        <rect x="112" y="86" width="136" height="392" rx="46" class="ad-body" />
+        <rect x="130" y="150" width="100" height="150" rx="22" class="ad-cabin" />
+        <!-- front axle line -->
+        <line x1="84" y1="172" x2="276" y2="172" class="ad-axle" />
+        <line x1="84" y1="404" x2="276" y2="404" class="ad-axle" />
+
+        <!-- front-left wheel -->
+        <g class="ad-wheel-top" :style="{ transform: `rotate(${flRot}deg)` }" style="transform-origin: 96px 172px">
+          <rect x="84" y="143" width="24" height="58" rx="6" class="ad-tyre" />
+          <rect x="84" y="143" width="24" height="5" rx="2.5" class="ad-lead" />
+        </g>
+        <!-- front-right wheel -->
+        <g class="ad-wheel-top" :style="{ transform: `rotate(${frRot}deg)` }" style="transform-origin: 264px 172px">
+          <rect x="252" y="143" width="24" height="58" rx="6" class="ad-tyre" />
+          <rect x="252" y="143" width="24" height="5" rx="2.5" class="ad-lead" />
+        </g>
+        <!-- rear-left wheel -->
+        <g class="ad-wheel-top" :style="{ transform: `rotate(${rlRot}deg)` }" style="transform-origin: 96px 404px">
+          <rect x="84" y="375" width="24" height="58" rx="6" class="ad-tyre" />
+          <rect x="84" y="375" width="24" height="5" rx="2.5" class="ad-lead" />
+        </g>
+        <!-- rear-right wheel -->
+        <g class="ad-wheel-top" :style="{ transform: `rotate(${rrRot}deg)` }" style="transform-origin: 264px 404px">
+          <rect x="252" y="375" width="24" height="58" rx="6" class="ad-tyre" />
+          <rect x="252" y="375" width="24" height="5" rx="2.5" class="ad-lead" />
+        </g>
+
+        <!-- labels -->
+        <text x="180" y="34" class="ad-end-label">{{ t('front') }}</text>
+        <text x="180" y="524" class="ad-end-label">{{ t('rear') }}</text>
+      </svg>
+      <figcaption class="align-diagram__cap">
+        <span class="ad-chip">{{ t('front') }} {{ t('toe') }}: {{ frontToeLabel }}</span>
+        <span class="ad-chip">{{ t('rear') }} {{ t('toe') }}: {{ rearToeLabel }}</span>
+      </figcaption>
+    </figure>
+
+    <!-- Elevation / side insets -->
+    <div class="align-diagram__insets">
+      <!-- front camber -->
+      <figure class="align-diagram__panel">
+        <svg viewBox="0 0 200 132" role="img" :aria-label="t('aria.frontCamber')">
+          <line x1="16" y1="112" x2="184" y2="112" class="ad-ground" />
+          <g class="ad-wheel-elev" :style="{ transform: `rotate(${fCamberLeft}deg)` }" style="transform-origin: 67px 112px">
+            <rect x="60" y="44" width="14" height="68" rx="4" class="ad-tyre" />
+          </g>
+          <g class="ad-wheel-elev" :style="{ transform: `rotate(${fCamberRight}deg)` }" style="transform-origin: 133px 112px">
+            <rect x="126" y="44" width="14" height="68" rx="4" class="ad-tyre" />
+          </g>
+        </svg>
+        <figcaption class="align-diagram__cap align-diagram__cap--single">
+          <span class="ad-cap-title">{{ t('front') }} {{ t('camber') }}</span>
+          <span class="ad-cap-val">{{ fmtDeg(props.frontCamber) }}</span>
+        </figcaption>
+      </figure>
+
+      <!-- rear camber -->
+      <figure class="align-diagram__panel">
+        <svg viewBox="0 0 200 132" role="img" :aria-label="t('aria.rearCamber')">
+          <line x1="16" y1="112" x2="184" y2="112" class="ad-ground" />
+          <g class="ad-wheel-elev" :style="{ transform: `rotate(${rCamberLeft}deg)` }" style="transform-origin: 67px 112px">
+            <rect x="60" y="44" width="14" height="68" rx="4" class="ad-tyre" />
+          </g>
+          <g class="ad-wheel-elev" :style="{ transform: `rotate(${rCamberRight}deg)` }" style="transform-origin: 133px 112px">
+            <rect x="126" y="44" width="14" height="68" rx="4" class="ad-tyre" />
+          </g>
+        </svg>
+        <figcaption class="align-diagram__cap align-diagram__cap--single">
+          <span class="ad-cap-title">{{ t('rear') }} {{ t('camber') }}</span>
+          <span class="ad-cap-val">{{ fmtDeg(props.rearCamber) }}</span>
+        </figcaption>
+      </figure>
+
+      <!-- caster (side view) -->
+      <figure class="align-diagram__panel">
+        <svg viewBox="0 0 200 132" role="img" :aria-label="t('aria.caster')">
+          <line x1="16" y1="112" x2="184" y2="112" class="ad-ground" />
+          <circle cx="100" cy="76" r="36" class="ad-wheel-side" />
+          <g class="ad-caster-axis" :style="{ transform: `rotate(${casterRot}deg)` }" style="transform-origin: 100px 112px">
+            <line x1="100" y1="30" x2="100" y2="112" class="ad-axis" />
+          </g>
+          <text x="24" y="128" class="ad-side-hint">← {{ t('front') }}</text>
+        </svg>
+        <figcaption class="align-diagram__cap align-diagram__cap--single">
+          <span class="ad-cap-title">{{ t('caster') }}</span>
+          <span class="ad-cap-val">{{ fmtDeg(props.frontCaster) }}</span>
+        </figcaption>
+      </figure>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .align-diagram {
+    display: grid;
+    grid-template-columns: minmax(200px, 280px) 1fr;
+    gap: 1.5rem;
+    align-items: start;
+  }
+  @media (max-width: 768px) {
+    .align-diagram {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .align-diagram__panel {
+    margin: 0;
+    background: var(--bg-2, #f3f3f3);
+    border: 1px solid var(--border-1, rgba(0, 0, 0, 0.08));
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+  }
+  .align-diagram__topdown svg {
+    width: 100%;
+    height: auto;
+    max-height: 460px;
+  }
+  .align-diagram__insets {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem;
+  }
+  @media (max-width: 520px) {
+    .align-diagram__insets {
+      grid-template-columns: 1fr;
+    }
+  }
+  .align-diagram__insets svg {
+    width: 100%;
+    height: auto;
+  }
+
+  .align-diagram__cap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    justify-content: center;
+    margin-top: 0.5rem;
+  }
+  .align-diagram__cap--single {
+    flex-direction: column;
+    gap: 0.1rem;
+    text-align: center;
+  }
+  .ad-cap-title {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--fg-3, #76767c);
+    font-weight: 600;
+  }
+  .ad-cap-val {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--fg-1, #1c1c20);
+  }
+  .ad-chip {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--fg-2, #4a4a4f);
+    background: var(--bg-1, #fff);
+    border: 1px solid var(--border-1, rgba(0, 0, 0, 0.08));
+    border-radius: 999px;
+    padding: 0.18rem 0.55rem;
+  }
+
+  /* SVG primitives */
+  .ad-centerline {
+    stroke: var(--border-2, rgba(0, 0, 0, 0.14));
+    stroke-width: 1.5;
+    stroke-dasharray: 4 6;
+  }
+  .ad-body {
+    fill: var(--bg-1, #fff);
+    stroke: var(--border-2, rgba(0, 0, 0, 0.14));
+    stroke-width: 2;
+  }
+  .ad-cabin {
+    fill: color-mix(in srgb, var(--cm-primary, #859369) 12%, transparent);
+    stroke: var(--border-1, rgba(0, 0, 0, 0.08));
+    stroke-width: 1.5;
+  }
+  .ad-axle,
+  .ad-ground {
+    stroke: var(--border-2, rgba(0, 0, 0, 0.14));
+    stroke-width: 2;
+  }
+  .ad-ground {
+    stroke-dasharray: 3 4;
+  }
+  .ad-tyre {
+    fill: var(--fg-2, #4a4a4f);
+  }
+  .ad-lead {
+    fill: var(--cm-secondary, #ed7135);
+  }
+  .ad-wheel-side {
+    fill: none;
+    stroke: var(--fg-2, #4a4a4f);
+    stroke-width: 4;
+  }
+  .ad-axis {
+    stroke: var(--cm-secondary, #ed7135);
+    stroke-width: 3;
+    stroke-linecap: round;
+  }
+  .ad-end-label,
+  .ad-side-hint {
+    fill: var(--fg-3, #76767c);
+    font-size: 13px;
+    font-weight: 700;
+    text-anchor: middle;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .ad-side-hint {
+    text-anchor: start;
+    font-size: 11px;
+  }
+
+  /* Animated rotations */
+  .ad-wheel-top,
+  .ad-wheel-elev,
+  .ad-caster-axis {
+    /* Resolve transform-origin against the SVG viewBox so the px origins below are
+       in user-space coordinates (the wheel's own centre / contact patch). With
+       fill-box they'd be relative to each element's tiny bbox and the pivot would
+       fly off toward the car centre, making wheels slide across when toe changes. */
+    transform-box: view-box;
+    transition: transform var(--t-base, 200ms) var(--ease-out, cubic-bezier(0.16, 1, 0.3, 1));
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .ad-wheel-top,
+    .ad-wheel-elev,
+    .ad-caster-axis {
+      transition: none;
+    }
+  }
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "front": "Front",
+    "rear": "Rear",
+    "toe": "toe",
+    "camber": "camber",
+    "caster": "caster",
+    "in": "in",
+    "out": "out",
+    "parallel": "parallel",
+    "aria": {
+      "topdown": "Top-down view of the car showing front and rear wheel toe",
+      "frontCamber": "Front view showing front wheel camber",
+      "rearCamber": "Rear view showing rear wheel camber",
+      "caster": "Side view showing front wheel caster angle"
+    }
+  },
+  "es": {
+    "front": "Delantero",
+    "rear": "Trasero",
+    "toe": "convergencia",
+    "camber": "caída",
+    "caster": "avance",
+    "in": "positiva",
+    "out": "negativa",
+    "parallel": "paralelo",
+    "aria": {
+      "topdown": "Vista cenital del coche que muestra la convergencia de las ruedas delanteras y traseras",
+      "frontCamber": "Vista frontal que muestra la caída de las ruedas delanteras",
+      "rearCamber": "Vista trasera que muestra la caída de las ruedas traseras",
+      "caster": "Vista lateral que muestra el ángulo de avance de la rueda delantera"
+    }
+  },
+  "fr": {
+    "front": "Avant",
+    "rear": "Arrière",
+    "toe": "parallélisme",
+    "camber": "carrossage",
+    "caster": "chasse",
+    "in": "vers l'intérieur",
+    "out": "vers l'extérieur",
+    "parallel": "parallèle",
+    "aria": {
+      "topdown": "Vue de dessus de la voiture montrant le parallélisme des roues avant et arrière",
+      "frontCamber": "Vue de face montrant le carrossage des roues avant",
+      "rearCamber": "Vue arrière montrant le carrossage des roues arrière",
+      "caster": "Vue de côté montrant l'angle de chasse des roues avant"
+    }
+  },
+  "de": {
+    "front": "Vorne",
+    "rear": "Hinten",
+    "toe": "Spur",
+    "camber": "Sturz",
+    "caster": "Nachlauf",
+    "in": "innen",
+    "out": "außen",
+    "parallel": "parallel",
+    "aria": {
+      "topdown": "Draufsicht des Fahrzeugs mit der Spur der Vorder- und Hinterräder",
+      "frontCamber": "Frontansicht mit dem Sturz der Vorderräder",
+      "rearCamber": "Heckansicht mit dem Sturz der Hinterräder",
+      "caster": "Seitenansicht mit dem Nachlaufwinkel der Vorderräder"
+    }
+  },
+  "it": {
+    "front": "Anteriore",
+    "rear": "Posteriore",
+    "toe": "convergenza",
+    "camber": "campanatura",
+    "caster": "incidenza",
+    "in": "in",
+    "out": "out",
+    "parallel": "parallelo",
+    "aria": {
+      "topdown": "Vista dall'alto dell'auto che mostra la convergenza delle ruote anteriori e posteriori",
+      "frontCamber": "Vista anteriore che mostra la campanatura delle ruote anteriori",
+      "rearCamber": "Vista posteriore che mostra la campanatura delle ruote posteriori",
+      "caster": "Vista laterale che mostra l'angolo di incidenza delle ruote anteriori"
+    }
+  },
+  "pt": {
+    "front": "Dianteiro",
+    "rear": "Traseiro",
+    "toe": "convergência",
+    "camber": "cambagem",
+    "caster": "cáster",
+    "in": "para dentro",
+    "out": "para fora",
+    "parallel": "paralelo",
+    "aria": {
+      "topdown": "Vista de cima do carro mostrando a convergência das rodas dianteiras e traseiras",
+      "frontCamber": "Vista frontal mostrando a cambagem das rodas dianteiras",
+      "rearCamber": "Vista traseira mostrando a cambagem das rodas traseiras",
+      "caster": "Vista lateral mostrando o ângulo de cáster da roda dianteira"
+    }
+  },
+  "ru": {
+    "front": "Перед",
+    "rear": "Зад",
+    "toe": "схождение",
+    "camber": "развал",
+    "caster": "кастер",
+    "in": "внутрь",
+    "out": "наружу",
+    "parallel": "параллельно",
+    "aria": {
+      "topdown": "Вид сверху на автомобиль, показывающий схождение передних и задних колёс",
+      "frontCamber": "Вид спереди, показывающий развал передних колёс",
+      "rearCamber": "Вид сзади, показывающий развал задних колёс",
+      "caster": "Вид сбоку, показывающий угол кастера передних колёс"
+    }
+  },
+  "ja": {
+    "front": "フロント",
+    "rear": "リア",
+    "toe": "トー",
+    "camber": "キャンバー",
+    "caster": "キャスター",
+    "in": "イン",
+    "out": "アウト",
+    "parallel": "平行",
+    "aria": {
+      "topdown": "フロントとリアのホイールのトーを示す車両の上面図",
+      "frontCamber": "フロントホイールのキャンバーを示す正面図",
+      "rearCamber": "リアホイールのキャンバーを示す後面図",
+      "caster": "フロントホイールのキャスター角を示す側面図"
+    }
+  },
+  "zh": {
+    "front": "前轮",
+    "rear": "后轮",
+    "toe": "前束",
+    "camber": "外倾角",
+    "caster": "主销后倾角",
+    "in": "内束",
+    "out": "外束",
+    "parallel": "平行",
+    "aria": {
+      "topdown": "车辆俯视图，显示前后车轮的前束",
+      "frontCamber": "前视图，显示前轮外倾角",
+      "rearCamber": "后视图，显示后轮外倾角",
+      "caster": "侧视图，显示前轮主销后倾角"
+    }
+  },
+  "ko": {
+    "front": "앞",
+    "rear": "뒤",
+    "toe": "토",
+    "camber": "캠버",
+    "caster": "캐스터",
+    "in": "인",
+    "out": "아웃",
+    "parallel": "평행",
+    "aria": {
+      "topdown": "앞바퀴와 뒷바퀴의 토를 보여주는 차량 평면도(위에서 본 모습)",
+      "frontCamber": "앞바퀴 캠버를 보여주는 정면도",
+      "rearCamber": "뒷바퀴 캠버를 보여주는 후면도",
+      "caster": "앞바퀴 캐스터 각도를 보여주는 측면도"
+    }
+  }
+}
+</i18n>

--- a/app/components/Calculators/AlignmentDiagram.vue
+++ b/app/components/Calculators/AlignmentDiagram.vue
@@ -41,9 +41,11 @@
   const fmtDeg = (v: number) => `${v > 0 ? '+' : ''}${v.toFixed(1)}°`;
 
   const toeLabel = (mm: number) => {
-    if (Math.abs(mm) < 0.05) return t('parallel');
+    const fraction = mmToInchFraction(mm);
+    // A non-zero mm that rounds to 0 sixteenths has no meaningful direction — show "parallel".
+    if (Math.abs(mm) < 0.05 || fraction === '0') return t('parallel');
     const dir = mm < 0 ? t('out') : t('in');
-    return `${mmToInchFraction(mm)} ${dir}`;
+    return `${fraction} ${dir}`;
   };
 
   const frontToeLabel = computed(() => toeLabel(props.frontToe));

--- a/app/components/Calculators/AlignmentSaveLoadModal.vue
+++ b/app/components/Calculators/AlignmentSaveLoadModal.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+  import { mmToInchFraction } from '../../../data/models/alignment';
+  import { useAlignmentConfigs, type SavedAlignmentConfig } from '../../composables/useAlignmentConfigs';
+
+  const { t } = useI18n();
+
+  const open = defineModel<boolean>({ required: true });
+  const emit = defineEmits<{ load: [config: SavedAlignmentConfig] }>();
+
+  const { configs, loading, fetchConfigs, deleteConfig } = useAlignmentConfigs();
+
+  watch(open, (isOpen) => {
+    if (isOpen) fetchConfigs();
+  });
+
+  function toeShort(mm: number) {
+    if (Math.abs(mm) < 0.05) return t('parallel');
+    return `${mmToInchFraction(mm)} ${mm < 0 ? t('out') : t('in')}`;
+  }
+  function summary(c: SavedAlignmentConfig) {
+    return `${t('front')}: ${c.front_camber}° · ${toeShort(c.front_toe)}  ·  ${t('rear')}: ${c.rear_camber}° · ${toeShort(
+      c.rear_toe
+    )}`;
+  }
+
+  async function handleDelete(id: string) {
+    await deleteConfig(id);
+  }
+</script>
+
+<template>
+  <div class="modal" :class="{ 'modal-open': open }">
+    <div class="modal-box max-w-2xl">
+      <h3 class="text-lg font-semibold"><i class="fad fa-folder-open mr-2"></i>{{ t('title') }}</h3>
+
+      <div class="py-4">
+        <div v-if="loading" class="flex justify-center py-8">
+          <span class="loading loading-spinner loading-lg text-primary"></span>
+        </div>
+
+        <div v-else-if="configs.length === 0" class="text-center py-8 opacity-60">
+          <i class="fas fa-inbox text-4xl mb-3 block"></i>
+          <p>{{ t('no_configs') }}</p>
+        </div>
+
+        <div v-else class="space-y-3 max-h-96 overflow-y-auto">
+          <div
+            v-for="config in configs"
+            :key="config.id"
+            class="flex items-center justify-between p-3 rounded-lg border border-base-300 hover:bg-base-200 transition-colors"
+          >
+            <div class="min-w-0 flex-1">
+              <p class="font-medium truncate">{{ config.name }}</p>
+              <p class="text-xs opacity-60 mt-1 truncate">{{ summary(config) }}</p>
+            </div>
+            <div class="flex items-center gap-2 ml-4 shrink-0">
+              <button class="btn btn-sm btn-primary" @click="emit('load', config)">{{ t('load') }}</button>
+              <button class="btn btn-sm btn-ghost text-error" :aria-label="t('delete')" @click="handleDelete(config.id)">
+                <i class="fas fa-trash"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal-action">
+        <button class="btn btn-ghost" @click="open = false">{{ t('close') }}</button>
+      </div>
+    </div>
+    <div class="modal-backdrop" @click="open = false"></div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Load Saved Alignment",
+    "no_configs": "No saved alignments yet. Save one from the calculator to see it here.",
+    "load": "Load",
+    "delete": "Delete configuration",
+    "close": "Close",
+    "front": "F",
+    "rear": "R",
+    "in": "in",
+    "out": "out",
+    "parallel": "parallel"
+  },
+  "es": {
+    "title": "Cargar alineación guardada",
+    "no_configs": "Aún no hay alineaciones guardadas. Guarda una desde la calculadora para verla aquí.",
+    "load": "Cargar",
+    "delete": "Eliminar configuración",
+    "close": "Cerrar",
+    "front": "D",
+    "rear": "T",
+    "in": "positiva",
+    "out": "negativa",
+    "parallel": "paralelo"
+  },
+  "fr": {
+    "title": "Charger une géométrie enregistrée",
+    "no_configs": "Aucune géométrie enregistrée pour l'instant. Enregistrez-en une depuis le calculateur pour la voir ici.",
+    "load": "Charger",
+    "delete": "Supprimer la configuration",
+    "close": "Fermer",
+    "front": "Av",
+    "rear": "Ar",
+    "in": "pincement",
+    "out": "ouverture",
+    "parallel": "parallèle"
+  },
+  "de": {
+    "title": "Gespeicherte Achseinstellung laden",
+    "no_configs": "Noch keine gespeicherten Achseinstellungen. Speichere eine aus dem Rechner, um sie hier zu sehen.",
+    "load": "Laden",
+    "delete": "Konfiguration löschen",
+    "close": "Schließen",
+    "front": "V",
+    "rear": "H",
+    "in": "innen",
+    "out": "außen",
+    "parallel": "parallel"
+  },
+  "it": {
+    "title": "Carica allineamento salvato",
+    "no_configs": "Nessun allineamento salvato. Salvane uno dal calcolatore per vederlo qui.",
+    "load": "Carica",
+    "delete": "Elimina configurazione",
+    "close": "Chiudi",
+    "front": "A",
+    "rear": "P",
+    "in": "in",
+    "out": "out",
+    "parallel": "parallelo"
+  },
+  "pt": {
+    "title": "Carregar Alinhamento Guardado",
+    "no_configs": "Ainda não há alinhamentos guardados. Guarde um a partir da calculadora para o ver aqui.",
+    "load": "Carregar",
+    "delete": "Eliminar configuração",
+    "close": "Fechar",
+    "front": "D",
+    "rear": "T",
+    "in": "dentro",
+    "out": "fora",
+    "parallel": "paralelo"
+  },
+  "ru": {
+    "title": "Загрузить сохранённую настройку",
+    "no_configs": "Сохранённых настроек пока нет. Сохраните одну из калькулятора, чтобы увидеть её здесь.",
+    "load": "Загрузить",
+    "delete": "Удалить конфигурацию",
+    "close": "Закрыть",
+    "front": "П",
+    "rear": "З",
+    "in": "внутрь",
+    "out": "наружу",
+    "parallel": "параллельно"
+  },
+  "ja": {
+    "title": "保存済みアライメントを読み込む",
+    "no_configs": "保存済みのアライメントはまだありません。計算機から保存するとここに表示されます。",
+    "load": "読み込む",
+    "delete": "設定を削除",
+    "close": "閉じる",
+    "front": "F",
+    "rear": "R",
+    "in": "イン",
+    "out": "アウト",
+    "parallel": "平行"
+  },
+  "zh": {
+    "title": "加载已保存的四轮定位",
+    "no_configs": "尚无已保存的四轮定位。在计算器中保存一个即可在此处查看。",
+    "load": "加载",
+    "delete": "删除配置",
+    "close": "关闭",
+    "front": "前",
+    "rear": "后",
+    "in": "内束",
+    "out": "外束",
+    "parallel": "平行"
+  },
+  "ko": {
+    "title": "저장된 얼라인먼트 불러오기",
+    "no_configs": "아직 저장된 얼라인먼트가 없습니다. 계산기에서 하나를 저장하면 여기에 표시됩니다.",
+    "load": "불러오기",
+    "delete": "구성 삭제",
+    "close": "닫기",
+    "front": "F",
+    "rear": "R",
+    "in": "인",
+    "out": "아웃",
+    "parallel": "평행"
+  }
+}
+</i18n>

--- a/app/components/Calculators/AlignmentSaveLoadModal.vue
+++ b/app/components/Calculators/AlignmentSaveLoadModal.vue
@@ -14,8 +14,9 @@
   });
 
   function toeShort(mm: number) {
-    if (Math.abs(mm) < 0.05) return t('parallel');
-    return `${mmToInchFraction(mm)} ${mm < 0 ? t('out') : t('in')}`;
+    const fraction = mmToInchFraction(mm);
+    if (Math.abs(mm) < 0.05 || fraction === '0') return t('parallel');
+    return `${fraction} ${mm < 0 ? t('out') : t('in')}`;
   }
   function summary(c: SavedAlignmentConfig) {
     return `${t('front')}: ${c.front_camber}° · ${toeShort(c.front_toe)}  ·  ${t('rear')}: ${c.rear_camber}° · ${toeShort(

--- a/app/composables/useAlignmentConfigs.ts
+++ b/app/composables/useAlignmentConfigs.ts
@@ -1,0 +1,197 @@
+import type { AlignmentValues } from '~~/data/models/alignment';
+
+/** A single dated entry in a config's driving journal. */
+export interface JournalEntry {
+  id: string;
+  date: string; // ISO date (YYYY-MM-DD)
+  body: string;
+}
+
+export interface SavedAlignmentConfig {
+  id: string;
+  user_id: string;
+  name: string;
+  is_public: boolean;
+  front_camber: number;
+  front_caster: number;
+  front_toe: number;
+  rear_camber: number;
+  rear_toe: number;
+  wheel_size: string | null;
+  preset: string | null;
+  notes: string | null;
+  journal: JournalEntry[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateAlignmentConfigInput {
+  name: string;
+  front_camber: number;
+  front_caster: number;
+  front_toe: number;
+  rear_camber: number;
+  rear_toe: number;
+  wheel_size?: string | null;
+  preset?: string | null;
+  notes?: string | null;
+  journal?: JournalEntry[];
+  is_public?: boolean;
+}
+
+/** Map the tool's camelCase values to the snake_case columns. */
+export function alignmentValuesToColumns(v: AlignmentValues) {
+  return {
+    front_camber: v.frontCamber,
+    front_caster: v.frontCaster,
+    front_toe: v.frontToe,
+    rear_camber: v.rearCamber,
+    rear_toe: v.rearToe,
+  };
+}
+
+/** Map a saved row back to the tool's camelCase values. */
+export function columnsToAlignmentValues(c: SavedAlignmentConfig): AlignmentValues {
+  return {
+    frontCamber: c.front_camber,
+    frontCaster: c.front_caster,
+    frontToe: c.front_toe,
+    rearCamber: c.rear_camber,
+    rearToe: c.rear_toe,
+  };
+}
+
+export const useAlignmentConfigs = () => {
+  const supabase = useSupabase();
+  const { user } = useAuth();
+
+  const configs = useState<SavedAlignmentConfig[]>('alignment-configs', () => []);
+  const loading = useState<boolean>('alignment-configs-loading', () => false);
+
+  const getAuthHeaders = async (): Promise<Record<string, string>> => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session?.access_token) {
+      throw new Error('Not authenticated');
+    }
+    return { Authorization: `Bearer ${session.access_token}` };
+  };
+
+  const fetchConfigs = async () => {
+    if (!user.value) return;
+    loading.value = true;
+    try {
+      const headers = await getAuthHeaders();
+      const data = await $fetch<SavedAlignmentConfig[]>('/api/alignment-configs', { headers });
+      configs.value = data;
+    } catch (error) {
+      console.error('Failed to fetch alignment configs:', error);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const saveConfig = async (input: CreateAlignmentConfigInput): Promise<SavedAlignmentConfig | null> => {
+    try {
+      const headers = await getAuthHeaders();
+      const data = await $fetch<SavedAlignmentConfig>('/api/alignment-configs', {
+        method: 'POST',
+        headers,
+        body: input,
+      });
+      configs.value.unshift(data);
+      return data;
+    } catch (error) {
+      console.error('Failed to save alignment config:', error);
+      return null;
+    }
+  };
+
+  const updateConfig = async (
+    id: string,
+    updates: Partial<CreateAlignmentConfigInput & { is_public: boolean }>
+  ): Promise<SavedAlignmentConfig | null> => {
+    try {
+      const headers = await getAuthHeaders();
+      const data = await $fetch<SavedAlignmentConfig>(`/api/alignment-configs/${id}`, {
+        method: 'PUT',
+        headers,
+        body: updates,
+      });
+      const index = configs.value.findIndex((c) => c.id === id);
+      if (index !== -1) configs.value[index] = data;
+      return data;
+    } catch (error) {
+      console.error('Failed to update alignment config:', error);
+      return null;
+    }
+  };
+
+  const deleteConfig = async (id: string): Promise<boolean> => {
+    try {
+      const headers = await getAuthHeaders();
+      await $fetch(`/api/alignment-configs/${id}`, { method: 'DELETE', headers });
+      configs.value = configs.value.filter((c) => c.id !== id);
+      return true;
+    } catch (error) {
+      console.error('Failed to delete alignment config:', error);
+      return false;
+    }
+  };
+
+  const fetchPublicConfigs = async (userId: string): Promise<SavedAlignmentConfig[]> => {
+    try {
+      return await $fetch<SavedAlignmentConfig[]>(`/api/alignment-configs/public/${userId}`);
+    } catch (error) {
+      console.error('Failed to fetch public alignment configs:', error);
+      return [];
+    }
+  };
+
+  // ---- Journal helpers (driving notes over time) ----
+  // Each mutation recomputes the journal array and persists it via updateConfig.
+
+  const addJournalEntry = async (id: string, body: string): Promise<SavedAlignmentConfig | null> => {
+    const config = configs.value.find((c) => c.id === id);
+    if (!config) return null;
+    const entry: JournalEntry = {
+      id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.round(Math.random() * 1e6)}`,
+      date: new Date().toISOString().slice(0, 10),
+      body: body.trim(),
+    };
+    const journal = [entry, ...(config.journal ?? [])];
+    return updateConfig(id, { journal });
+  };
+
+  const updateJournalEntry = async (
+    id: string,
+    entryId: string,
+    body: string
+  ): Promise<SavedAlignmentConfig | null> => {
+    const config = configs.value.find((c) => c.id === id);
+    if (!config) return null;
+    const journal = (config.journal ?? []).map((e) => (e.id === entryId ? { ...e, body: body.trim() } : e));
+    return updateConfig(id, { journal });
+  };
+
+  const deleteJournalEntry = async (id: string, entryId: string): Promise<SavedAlignmentConfig | null> => {
+    const config = configs.value.find((c) => c.id === id);
+    if (!config) return null;
+    const journal = (config.journal ?? []).filter((e) => e.id !== entryId);
+    return updateConfig(id, { journal });
+  };
+
+  return {
+    configs,
+    loading,
+    fetchConfigs,
+    saveConfig,
+    updateConfig,
+    deleteConfig,
+    fetchPublicConfigs,
+    addJournalEntry,
+    updateJournalEntry,
+    deleteJournalEntry,
+  };
+};

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -8,6 +8,7 @@
   const tabs = [
     { to: '/dashboard/models', key: 'models', icon: 'fa-cube' },
     { to: '/dashboard/gear-configs', key: 'gear_configs', icon: 'fa-gears' },
+    { to: '/dashboard/alignment-configs', key: 'alignment_configs', icon: 'fa-tire' },
     { to: '/dashboard/submissions', key: 'submissions', icon: 'fa-file-lines' },
     { to: '/dashboard/external', key: 'external', icon: 'fa-link' },
     { to: '/dashboard/selling', key: 'selling', icon: 'fa-store' },
@@ -81,7 +82,7 @@
     "hero_title": "Dashboard",
     "breadcrumb_title": "Dashboard",
     "eyebrow": "ACCOUNT",
-    "tabs": { "models": "3D Models", "gear_configs": "Gear Configs", "submissions": "Submissions", "external": "External Links", "selling": "Selling", "purchases": "Purchases" },
+    "tabs": { "models": "3D Models", "gear_configs": "Gear Configs", "alignment_configs": "Alignment", "submissions": "Submissions", "external": "External Links", "selling": "Selling", "purchases": "Purchases" },
     "auth": {
       "sign_in_title": "Sign In to View Dashboard",
       "sign_in_description": "You need to be signed in to access your dashboard. Create a free account to get started.",
@@ -94,7 +95,7 @@
     "hero_title": "Panel",
     "breadcrumb_title": "Panel",
     "eyebrow": "CUENTA",
-    "tabs": { "models": "Modelos 3D", "gear_configs": "Engranajes", "submissions": "Envíos", "external": "Enlaces externos", "selling": "Ventas", "purchases": "Compras" },
+    "tabs": { "models": "Modelos 3D", "gear_configs": "Engranajes", "alignment_configs": "Alineación", "submissions": "Envíos", "external": "Enlaces externos", "selling": "Ventas", "purchases": "Compras" },
     "auth": {
       "sign_in_title": "Inicia Sesión para Ver el Panel",
       "sign_in_description": "Debes iniciar sesión para acceder a tu panel. Crea una cuenta gratuita para empezar.",
@@ -107,7 +108,7 @@
     "hero_title": "Tableau de Bord",
     "breadcrumb_title": "Tableau de Bord",
     "eyebrow": "COMPTE",
-    "tabs": { "models": "Modèles 3D", "gear_configs": "Engrenages", "submissions": "Soumissions", "external": "Liens externes", "selling": "Ventes", "purchases": "Achats" },
+    "tabs": { "models": "Modèles 3D", "gear_configs": "Engrenages", "alignment_configs": "Géométrie", "submissions": "Soumissions", "external": "Liens externes", "selling": "Ventes", "purchases": "Achats" },
     "auth": {
       "sign_in_title": "Connectez-vous pour Voir le Tableau de Bord",
       "sign_in_description": "Vous devez être connecté pour accéder à votre tableau de bord. Créez un compte gratuit pour commencer.",
@@ -120,7 +121,7 @@
     "hero_title": "Dashboard",
     "breadcrumb_title": "Dashboard",
     "eyebrow": "KONTO",
-    "tabs": { "models": "3D-Modelle", "gear_configs": "Getriebe", "submissions": "Einreichungen", "external": "Externe Links", "selling": "Verkauf", "purchases": "Käufe" },
+    "tabs": { "models": "3D-Modelle", "gear_configs": "Getriebe", "alignment_configs": "Achseinstellung", "submissions": "Einreichungen", "external": "Externe Links", "selling": "Verkauf", "purchases": "Käufe" },
     "auth": {
       "sign_in_title": "Anmelden zum Dashboard",
       "sign_in_description": "Sie müssen angemeldet sein, um auf Ihr Dashboard zuzugreifen. Erstellen Sie ein kostenloses Konto.",
@@ -133,7 +134,7 @@
     "hero_title": "Dashboard",
     "breadcrumb_title": "Dashboard",
     "eyebrow": "ACCOUNT",
-    "tabs": { "models": "Modelli 3D", "gear_configs": "Ingranaggi", "submissions": "Proposte", "external": "Link esterni", "selling": "Vendite", "purchases": "Acquisti" },
+    "tabs": { "models": "Modelli 3D", "gear_configs": "Ingranaggi", "alignment_configs": "Allineamento", "submissions": "Proposte", "external": "Link esterni", "selling": "Vendite", "purchases": "Acquisti" },
     "auth": {
       "sign_in_title": "Accedi per Vedere la Dashboard",
       "sign_in_description": "Devi essere connesso per accedere alla tua dashboard. Crea un account gratuito per iniziare.",
@@ -146,7 +147,7 @@
     "hero_title": "Painel",
     "breadcrumb_title": "Painel",
     "eyebrow": "CONTA",
-    "tabs": { "models": "Modelos 3D", "gear_configs": "Engrenagens", "submissions": "Envios", "external": "Links externos", "selling": "Vendas", "purchases": "Compras" },
+    "tabs": { "models": "Modelos 3D", "gear_configs": "Engrenagens", "alignment_configs": "Alinhamento", "submissions": "Envios", "external": "Links externos", "selling": "Vendas", "purchases": "Compras" },
     "auth": {
       "sign_in_title": "Entre para Ver o Painel",
       "sign_in_description": "Você precisa estar conectado para acessar seu painel. Crie uma conta gratuita para começar.",
@@ -159,7 +160,7 @@
     "hero_title": "Панель управления",
     "breadcrumb_title": "Панель управления",
     "eyebrow": "АККАУНТ",
-    "tabs": { "models": "3D-модели", "gear_configs": "Передачи", "submissions": "Заявки", "external": "Внешние ссылки", "selling": "Продажи", "purchases": "Покупки" },
+    "tabs": { "models": "3D-модели", "gear_configs": "Передачи", "alignment_configs": "Развал-схождение", "submissions": "Заявки", "external": "Внешние ссылки", "selling": "Продажи", "purchases": "Покупки" },
     "auth": {
       "sign_in_title": "Войдите для Доступа к Панели",
       "sign_in_description": "Вы должны быть авторизованы для доступа к панели управления. Создайте бесплатную учётную запись.",
@@ -172,7 +173,7 @@
     "hero_title": "ダッシュボード",
     "breadcrumb_title": "ダッシュボード",
     "eyebrow": "アカウント",
-    "tabs": { "models": "3Dモデル", "gear_configs": "ギア設定", "submissions": "申請", "external": "外部リンク", "selling": "販売", "purchases": "購入" },
+    "tabs": { "models": "3Dモデル", "gear_configs": "ギア設定", "alignment_configs": "アライメント", "submissions": "申請", "external": "外部リンク", "selling": "販売", "purchases": "購入" },
     "auth": {
       "sign_in_title": "ダッシュボード表示にはログインが必要です",
       "sign_in_description": "ダッシュボードにアクセスするにはログインが必要です。無料アカウントを作成して始めましょう。",
@@ -185,7 +186,7 @@
     "hero_title": "仪表板",
     "breadcrumb_title": "仪表板",
     "eyebrow": "账户",
-    "tabs": { "models": "3D模型", "gear_configs": "齿轮配置", "submissions": "提交", "external": "外部链接", "selling": "销售", "purchases": "购买" },
+    "tabs": { "models": "3D模型", "gear_configs": "齿轮配置", "alignment_configs": "四轮定位", "submissions": "提交", "external": "外部链接", "selling": "销售", "purchases": "购买" },
     "auth": {
       "sign_in_title": "登录以查看仪表板",
       "sign_in_description": "您需要登录才能访问您的仪表板。创建免费账户即可开始。",
@@ -198,7 +199,7 @@
     "hero_title": "대시보드",
     "breadcrumb_title": "대시보드",
     "eyebrow": "계정",
-    "tabs": { "models": "3D 모델", "gear_configs": "기어 구성", "submissions": "제출", "external": "외부 링크", "selling": "판매", "purchases": "구매" },
+    "tabs": { "models": "3D 모델", "gear_configs": "기어 구성", "alignment_configs": "얼라인먼트", "submissions": "제출", "external": "외부 링크", "selling": "판매", "purchases": "구매" },
     "auth": {
       "sign_in_title": "대시보드 보기를 위해 로그인하세요",
       "sign_in_description": "대시보드에 접근하려면 로그인해야 합니다. 무료 계정을 만들어 시작하세요.",

--- a/app/pages/dashboard/alignment-configs.vue
+++ b/app/pages/dashboard/alignment-configs.vue
@@ -1,0 +1,380 @@
+<script lang="ts" setup>
+  import { mmToInchFraction } from '~~/data/models/alignment';
+  import type { SavedAlignmentConfig } from '~/composables/useAlignmentConfigs';
+
+  const { t } = useI18n();
+  const { isAuthenticated } = useAuth();
+  const { track } = useAnalytics();
+  const { configs, loading, fetchConfigs, updateConfig, deleteConfig, addJournalEntry, deleteJournalEntry } =
+    useAlignmentConfigs();
+
+  watch(
+    isAuthenticated,
+    (authed) => {
+      if (authed) fetchConfigs();
+    },
+    { immediate: true }
+  );
+
+  // Per-config draft note + expanded state
+  const newNotes = reactive<Record<string, string>>({});
+  const expanded = reactive<Record<string, boolean>>({});
+
+  function toeText(mm: number) {
+    if (Math.abs(mm) < 0.05) return t('parallel');
+    const dir = mm < 0 ? t('toe_out') : t('toe_in');
+    return `${Math.abs(mm).toFixed(2).replace(/\.?0+$/, '')} mm ${dir} (${mmToInchFraction(mm)})`;
+  }
+  const degText = (v: number) => `${v > 0 ? '+' : ''}${v.toFixed(2).replace(/\.?0+$/, '')}°`;
+
+  async function togglePublic(config: SavedAlignmentConfig) {
+    await updateConfig(config.id, { is_public: !config.is_public });
+    track('alignment_config_visibility_toggled', { config_id: config.id, is_public: !config.is_public });
+  }
+
+  async function handleDelete(id: string) {
+    await deleteConfig(id);
+    track('alignment_config_deleted', { config_id: id });
+  }
+
+  async function handleAddNote(id: string) {
+    const body = (newNotes[id] ?? '').trim();
+    if (!body) return;
+    await addJournalEntry(id, body);
+    newNotes[id] = '';
+    track('alignment_journal_entry_added', { config_id: id });
+  }
+
+  async function handleDeleteNote(id: string, entryId: string) {
+    await deleteJournalEntry(id, entryId);
+  }
+</script>
+
+<template>
+  <div class="card bg-base-100 shadow-sm border border-base-300">
+    <div class="card-body">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <i class="fad fa-tire mr-2"></i>
+          <h2 class="text-lg font-semibold">{{ t('title') }}</h2>
+        </div>
+        <NuxtLink to="/technical/alignment" class="btn btn-outline btn-sm">
+          <i class="fas fa-calculator"></i>
+          {{ t('open_calculator') }}
+        </NuxtLink>
+      </div>
+
+      <div v-if="loading" class="flex justify-center py-8">
+        <span class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></span>
+      </div>
+
+      <div v-else-if="configs.length === 0" class="text-center py-8 opacity-60">
+        <i class="fas fa-inbox text-4xl mb-3 block"></i>
+        <p class="mb-4">{{ t('empty') }}</p>
+        <NuxtLink to="/technical/alignment" class="btn btn-primary btn-soft">{{ t('go_to_calculator') }}</NuxtLink>
+      </div>
+
+      <div v-else class="space-y-4">
+        <div v-for="config in configs" :key="config.id" class="rounded-lg border border-base-300 p-4">
+          <div class="flex flex-col md:flex-row md:items-start justify-between gap-4">
+            <div class="min-w-0 flex-1">
+              <p class="font-medium">{{ config.name }}</p>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 mt-2 text-xs opacity-70">
+                <span><b>{{ t('front') }} {{ t('camber') }}:</b> {{ degText(config.front_camber) }}</span>
+                <span><b>{{ t('rear') }} {{ t('camber') }}:</b> {{ degText(config.rear_camber) }}</span>
+                <span><b>{{ t('front') }} {{ t('caster') }}:</b> {{ degText(config.front_caster) }}</span>
+                <span><b>{{ t('rear') }} {{ t('toe') }}:</b> {{ toeText(config.rear_toe) }}</span>
+                <span><b>{{ t('front') }} {{ t('toe') }}:</b> {{ toeText(config.front_toe) }}</span>
+                <span v-if="config.wheel_size"><b>{{ t('wheel') }}:</b> {{ config.wheel_size }}"</span>
+              </div>
+            </div>
+            <div class="flex items-center gap-3 shrink-0">
+              <div class="flex items-center gap-2">
+                <label class="text-xs opacity-60">{{ t('public') }}</label>
+                <input
+                  type="checkbox"
+                  class="toggle toggle-primary toggle-sm"
+                  :checked="config.is_public"
+                  @change="togglePublic(config)"
+                />
+              </div>
+              <button class="btn btn-ghost btn-sm btn-square text-error" :title="t('delete')" @click="handleDelete(config.id)">
+                <i class="fas fa-trash"></i>
+              </button>
+            </div>
+          </div>
+
+          <!-- Journal -->
+          <div class="mt-3 border-t border-base-300 pt-3">
+            <button class="btn btn-ghost btn-xs gap-2" @click="expanded[config.id] = !expanded[config.id]">
+              <i class="fas" :class="expanded[config.id] ? 'fa-chevron-down' : 'fa-chevron-right'"></i>
+              {{ t('journal') }}
+              <span class="badge badge-xs">{{ config.journal?.length || 0 }}</span>
+            </button>
+
+            <div v-if="expanded[config.id]" class="mt-2 space-y-3">
+              <div class="flex gap-2">
+                <input
+                  v-model="newNotes[config.id]"
+                  type="text"
+                  class="input input-bordered input-sm grow"
+                  :placeholder="t('note_placeholder')"
+                  @keyup.enter="handleAddNote(config.id)"
+                />
+                <button class="btn btn-sm btn-primary" @click="handleAddNote(config.id)">
+                  <i class="fas fa-plus"></i> {{ t('add_note') }}
+                </button>
+              </div>
+
+              <div v-if="!config.journal?.length" class="text-xs opacity-50">{{ t('no_notes') }}</div>
+              <ul v-else class="space-y-2">
+                <li
+                  v-for="entry in config.journal"
+                  :key="entry.id"
+                  class="flex items-start justify-between gap-3 text-sm rounded bg-base-200 px-3 py-2"
+                >
+                  <div class="min-w-0">
+                    <span class="text-xs opacity-50 mr-2">{{ entry.date }}</span>
+                    <span>{{ entry.body }}</span>
+                  </div>
+                  <button
+                    class="btn btn-ghost btn-xs btn-square text-error shrink-0"
+                    :title="t('delete_note')"
+                    @click="handleDeleteNote(config.id, entry.id)"
+                  >
+                    <i class="fas fa-xmark"></i>
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Saved Alignments",
+    "open_calculator": "Open Calculator",
+    "empty": "No saved alignments yet. Use the alignment calculator to save your first setup.",
+    "go_to_calculator": "Go to Alignment Calculator",
+    "front": "Front",
+    "rear": "Rear",
+    "camber": "camber",
+    "caster": "caster",
+    "toe": "toe",
+    "wheel": "Wheel",
+    "toe_in": "toe-in",
+    "toe_out": "toe-out",
+    "parallel": "parallel",
+    "public": "Public",
+    "delete": "Delete configuration",
+    "journal": "Driving journal",
+    "note_placeholder": "Add a dated note — handling, tyre wear, track day...",
+    "add_note": "Add",
+    "no_notes": "No notes yet. Log how the car feels as you tune.",
+    "delete_note": "Delete note"
+  },
+  "es": {
+    "title": "Alineaciones guardadas",
+    "open_calculator": "Abrir calculadora",
+    "empty": "Aún no hay alineaciones guardadas. Usa la calculadora de alineación para guardar tu primera configuración.",
+    "go_to_calculator": "Ir a la calculadora de alineación",
+    "front": "Delantero",
+    "rear": "Trasero",
+    "camber": "caída",
+    "caster": "avance",
+    "toe": "convergencia",
+    "wheel": "Rueda",
+    "toe_in": "convergencia",
+    "toe_out": "divergencia",
+    "parallel": "paralelo",
+    "public": "Pública",
+    "delete": "Eliminar configuración",
+    "journal": "Diario de conducción",
+    "note_placeholder": "Añade una nota fechada — comportamiento, desgaste de neumáticos, día de circuito...",
+    "add_note": "Añadir",
+    "no_notes": "Aún no hay notas. Registra cómo se siente el coche mientras lo ajustas.",
+    "delete_note": "Eliminar nota"
+  },
+  "fr": {
+    "title": "Géométries enregistrées",
+    "open_calculator": "Ouvrir le calculateur",
+    "empty": "Aucune géométrie enregistrée pour l'instant. Utilisez le calculateur de géométrie pour enregistrer votre premier réglage.",
+    "go_to_calculator": "Aller au calculateur de géométrie",
+    "front": "Avant",
+    "rear": "Arrière",
+    "camber": "carrossage",
+    "caster": "chasse",
+    "toe": "parallélisme",
+    "wheel": "Roue",
+    "toe_in": "pincement",
+    "toe_out": "ouverture",
+    "parallel": "parallèle",
+    "public": "Publique",
+    "delete": "Supprimer la configuration",
+    "journal": "Journal de conduite",
+    "note_placeholder": "Ajoutez une note datée — comportement, usure des pneus, journée circuit...",
+    "add_note": "Ajouter",
+    "no_notes": "Aucune note pour l'instant. Consignez le ressenti de la voiture au fil de vos réglages.",
+    "delete_note": "Supprimer la note"
+  },
+  "de": {
+    "title": "Gespeicherte Achseinstellungen",
+    "open_calculator": "Rechner öffnen",
+    "empty": "Noch keine gespeicherten Achseinstellungen. Nutze den Achsvermessungsrechner, um dein erstes Setup zu speichern.",
+    "go_to_calculator": "Zum Achsvermessungsrechner",
+    "front": "Vorne",
+    "rear": "Hinten",
+    "camber": "Sturz",
+    "caster": "Nachlauf",
+    "toe": "Spur",
+    "wheel": "Rad",
+    "toe_in": "Vorspur",
+    "toe_out": "Nachspur",
+    "parallel": "parallel",
+    "public": "Öffentlich",
+    "delete": "Konfiguration löschen",
+    "journal": "Fahrtenjournal",
+    "note_placeholder": "Datierte Notiz hinzufügen — Fahrverhalten, Reifenverschleiß, Trackday...",
+    "add_note": "Hinzufügen",
+    "no_notes": "Noch keine Notizen. Halte fest, wie sich das Auto beim Abstimmen anfühlt.",
+    "delete_note": "Notiz löschen"
+  },
+  "it": {
+    "title": "Allineamenti salvati",
+    "open_calculator": "Apri calcolatore",
+    "empty": "Nessun allineamento salvato. Usa il calcolatore di allineamento per salvare la tua prima configurazione.",
+    "go_to_calculator": "Vai al calcolatore di allineamento",
+    "front": "Anteriore",
+    "rear": "Posteriore",
+    "camber": "campanatura",
+    "caster": "incidenza",
+    "toe": "convergenza",
+    "wheel": "Ruota",
+    "toe_in": "convergenza",
+    "toe_out": "divergenza",
+    "parallel": "parallelo",
+    "public": "Pubblico",
+    "delete": "Elimina configurazione",
+    "journal": "Diario di guida",
+    "note_placeholder": "Aggiungi una nota datata — comportamento, usura pneumatici, giornata in pista...",
+    "add_note": "Aggiungi",
+    "no_notes": "Nessuna nota. Annota come si comporta l'auto mentre la metti a punto.",
+    "delete_note": "Elimina nota"
+  },
+  "pt": {
+    "title": "Alinhamentos Guardados",
+    "open_calculator": "Abrir Calculadora",
+    "empty": "Ainda não há alinhamentos guardados. Use a calculadora de alinhamento para guardar a sua primeira configuração.",
+    "go_to_calculator": "Ir para a Calculadora de Alinhamento",
+    "front": "Dianteiro",
+    "rear": "Traseiro",
+    "camber": "cambagem",
+    "caster": "cáster",
+    "toe": "convergência",
+    "wheel": "Roda",
+    "toe_in": "convergência",
+    "toe_out": "divergência",
+    "parallel": "paralelo",
+    "public": "Pública",
+    "delete": "Eliminar configuração",
+    "journal": "Diário de condução",
+    "note_placeholder": "Adicione uma nota datada — comportamento, desgaste dos pneus, dia de pista...",
+    "add_note": "Adicionar",
+    "no_notes": "Ainda não há notas. Registe como o carro se comporta à medida que afina.",
+    "delete_note": "Eliminar nota"
+  },
+  "ru": {
+    "title": "Сохранённые настройки",
+    "open_calculator": "Открыть калькулятор",
+    "empty": "Сохранённых настроек пока нет. Используйте калькулятор развал-схождения, чтобы сохранить первую настройку.",
+    "go_to_calculator": "Перейти к калькулятору развал-схождения",
+    "front": "Перед",
+    "rear": "Зад",
+    "camber": "развал",
+    "caster": "кастер",
+    "toe": "схождение",
+    "wheel": "Колесо",
+    "toe_in": "схождение",
+    "toe_out": "расхождение",
+    "parallel": "параллельно",
+    "public": "Публичная",
+    "delete": "Удалить конфигурацию",
+    "journal": "Журнал поездок",
+    "note_placeholder": "Добавьте датированную запись — управляемость, износ шин, трек-день...",
+    "add_note": "Добавить",
+    "no_notes": "Записей пока нет. Фиксируйте ощущения от машины по мере настройки.",
+    "delete_note": "Удалить запись"
+  },
+  "ja": {
+    "title": "保存済みアライメント",
+    "open_calculator": "計算機を開く",
+    "empty": "保存済みのアライメントはまだありません。アライメント計算機を使って最初のセットアップを保存してください。",
+    "go_to_calculator": "アライメント計算機へ",
+    "front": "フロント",
+    "rear": "リア",
+    "camber": "キャンバー",
+    "caster": "キャスター",
+    "toe": "トー",
+    "wheel": "ホイール",
+    "toe_in": "トーイン",
+    "toe_out": "トーアウト",
+    "parallel": "平行",
+    "public": "公開",
+    "delete": "設定を削除",
+    "journal": "ドライビングジャーナル",
+    "note_placeholder": "日付付きのメモを追加 — ハンドリング、タイヤの摩耗、トラックデー...",
+    "add_note": "追加",
+    "no_notes": "メモはまだありません。チューニングしながら車の感触を記録しましょう。",
+    "delete_note": "メモを削除"
+  },
+  "zh": {
+    "title": "已保存的四轮定位",
+    "open_calculator": "打开计算器",
+    "empty": "尚无已保存的四轮定位。使用四轮定位计算器保存您的首个设置。",
+    "go_to_calculator": "前往四轮定位计算器",
+    "front": "前轮",
+    "rear": "后轮",
+    "camber": "外倾角",
+    "caster": "主销后倾角",
+    "toe": "前束",
+    "wheel": "车轮",
+    "toe_in": "前束内束",
+    "toe_out": "前束外束",
+    "parallel": "平行",
+    "public": "公开",
+    "delete": "删除配置",
+    "journal": "驾驶日志",
+    "note_placeholder": "添加带日期的记录——操控性、轮胎磨损、赛道日……",
+    "add_note": "添加",
+    "no_notes": "尚无记录。在调校过程中记录车辆的感受。",
+    "delete_note": "删除记录"
+  },
+  "ko": {
+    "title": "저장된 얼라인먼트",
+    "open_calculator": "계산기 열기",
+    "empty": "아직 저장된 얼라인먼트가 없습니다. 얼라인먼트 계산기를 사용해 첫 세팅을 저장하세요.",
+    "go_to_calculator": "얼라인먼트 계산기로 이동",
+    "front": "앞",
+    "rear": "뒤",
+    "camber": "캠버",
+    "caster": "캐스터",
+    "toe": "토",
+    "wheel": "휠",
+    "toe_in": "토인",
+    "toe_out": "토아웃",
+    "parallel": "평행",
+    "public": "공개",
+    "delete": "구성 삭제",
+    "journal": "주행 저널",
+    "note_placeholder": "날짜가 기록된 메모 추가 — 핸들링, 타이어 마모, 트랙 데이...",
+    "add_note": "추가",
+    "no_notes": "아직 메모가 없습니다. 튜닝하면서 차량의 느낌을 기록하세요.",
+    "delete_note": "메모 삭제"
+  }
+}
+</i18n>

--- a/app/pages/dashboard/alignment-configs.vue
+++ b/app/pages/dashboard/alignment-configs.vue
@@ -23,7 +23,9 @@
   function toeText(mm: number) {
     if (Math.abs(mm) < 0.05) return t('parallel');
     const dir = mm < 0 ? t('toe_out') : t('toe_in');
-    return `${Math.abs(mm).toFixed(2).replace(/\.?0+$/, '')} mm ${dir} (${mmToInchFraction(mm)})`;
+    const mmText = `${Math.abs(mm).toFixed(2).replace(/\.?0+$/, '')} mm ${dir}`;
+    const fraction = mmToInchFraction(mm);
+    return fraction === '0' ? mmText : `${mmText} (${fraction})`;
   }
   const degText = (v: number) => `${v > 0 ? '+' : ''}${v.toFixed(2).replace(/\.?0+$/, '')}°`;
 
@@ -40,9 +42,11 @@
   async function handleAddNote(id: string) {
     const body = (newNotes[id] ?? '').trim();
     if (!body) return;
-    await addJournalEntry(id, body);
-    newNotes[id] = '';
-    track('alignment_journal_entry_added', { config_id: id });
+    const result = await addJournalEntry(id, body);
+    if (result) {
+      newNotes[id] = '';
+      track('alignment_journal_entry_added', { config_id: id });
+    }
   }
 
   async function handleDeleteNote(id: string, entryId: string) {

--- a/app/pages/technical/alignment.vue
+++ b/app/pages/technical/alignment.vue
@@ -1,0 +1,537 @@
+<script lang="ts" setup>
+  import { BREADCRUMB_VERSIONS, HERO_TYPES } from '../../../data/models/generic';
+
+  const { t } = useI18n();
+  const isCalculatorLoaded = ref(false);
+
+  useHead({
+    title: t('title'),
+    meta: [
+      { key: 'description', name: 'description', content: t('description') },
+      { key: 'keywords', name: 'keywords', content: t('keywords') },
+    ],
+    link: [
+      { rel: 'canonical', href: 'https://www.classicminidiy.com/technical/alignment' },
+      { rel: 'preconnect', href: 'https://classicminidiy.s3.amazonaws.com' },
+    ],
+  });
+
+  const calculatorJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: t('structured_data.calculator_name'),
+    applicationCategory: 'AutomotiveApplication',
+    operatingSystem: 'Web Browser',
+    description: t('structured_data.calculator_description'),
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  };
+
+  const howToJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: t('structured_data.how_to_name'),
+    description: t('structured_data.how_to_description'),
+    step: [
+      {
+        '@type': 'HowToStep',
+        name: t('structured_data.steps.preset.name'),
+        text: t('structured_data.steps.preset.text'),
+      },
+      {
+        '@type': 'HowToStep',
+        name: t('structured_data.steps.adjust.name'),
+        text: t('structured_data.steps.adjust.text'),
+      },
+      {
+        '@type': 'HowToStep',
+        name: t('structured_data.steps.visualize.name'),
+        text: t('structured_data.steps.visualize.text'),
+      },
+      {
+        '@type': 'HowToStep',
+        name: t('structured_data.steps.save.name'),
+        text: t('structured_data.steps.save.text'),
+      },
+    ],
+  };
+
+  useHead({
+    script: [
+      { type: 'application/ld+json', innerHTML: JSON.stringify(calculatorJsonLd) },
+      { type: 'application/ld+json', innerHTML: JSON.stringify(howToJsonLd) },
+    ],
+  });
+
+  useSeoMeta({
+    ogTitle: t('og_title'),
+    ogDescription: t('og_description'),
+    ogUrl: 'https://www.classicminidiy.com/technical/alignment',
+    ogImage: 'https://classicminidiy.s3.amazonaws.com/social-share/technical.png',
+    ogType: 'website',
+    twitterCard: 'summary_large_image',
+    twitterTitle: t('twitter_title'),
+    twitterDescription: t('twitter_description'),
+    twitterImage: 'https://classicminidiy.s3.amazonaws.com/social-share/technical.png',
+  });
+</script>
+
+<template>
+  <hero :navigation="true" :title="t('hero_title')" :heroType="HERO_TYPES.TECH" />
+  <div class="container mx-auto px-4">
+    <div class="grid grid-cols-12 gap-6">
+      <div class="col-span-12">
+        <breadcrumb class="my-6" :version="BREADCRUMB_VERSIONS.TECH" :page="t('breadcrumb_title')"></breadcrumb>
+        <PageIntro :eyebrow="t('eyebrow')" :title="t('main_heading')" :description="t('description_text')" as="h2" />
+      </div>
+      <div class="col-span-12">
+        <ClientOnly>
+          <div class="min-h-96 flex items-center justify-center" v-if="!isCalculatorLoaded">
+            <div class="flex flex-col items-center space-y-4">
+              <span class="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></span>
+              <p class="opacity-70">{{ t('ui.loading_text') }}</p>
+            </div>
+          </div>
+          <LazyCalculatorsAlignment @vue:mounted="isCalculatorLoaded = true" />
+          <template #fallback>
+            <div class="min-h-96 flex items-center justify-center">
+              <div class="flex flex-col items-center space-y-4">
+                <span class="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></span>
+                <p class="opacity-70">{{ t('ui.loading_text') }}</p>
+              </div>
+            </div>
+          </template>
+        </ClientOnly>
+      </div>
+
+      <div class="col-span-12 md:col-span-10 md:col-start-2">
+        <div class="divider">{{ t('support_section') }}</div>
+        <patreon-card size="large" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Tech - Alignment Calculator",
+    "description": "Set up and visualize your Classic Mini's wheel alignment — camber, caster, and toe — with a live top-down diagram, research-derived presets, and saveable setups.",
+    "keywords": "Classic Mini alignment, camber, caster, toe, wheel alignment calculator, Mini suspension geometry, fast road alignment, track alignment, negative camber",
+    "hero_title": "Alignment Calculator",
+    "breadcrumb_title": "Alignment Calculator",
+    "og_title": "Classic Mini Alignment Calculator",
+    "og_description": "Dial in camber, caster, and toe with a live top-down diagram and proven presets for stock, fast road, track, and boosted Minis. Save your setups and keep a driving journal.",
+    "twitter_title": "Classic Mini Alignment Calculator",
+    "twitter_description": "Dial in camber, caster, and toe with a live diagram and proven presets. Save your setups and keep a driving journal.",
+    "main_heading": "Alignment Calculator",
+    "description_text": "Visualize and plan your Classic Mini's wheel alignment in real time. Start from a research-derived preset (stock, fast road, track, or boosted), fine-tune camber, caster, and toe, and watch the top-down diagram update live. Sign in to save setups and keep a dated driving journal for each one.",
+    "eyebrow": "CALCULATOR",
+    "support_section": "Support",
+    "ui": {
+      "loading_text": "Loading alignment calculator..."
+    },
+    "structured_data": {
+      "calculator_name": "Classic Mini Alignment Calculator",
+      "calculator_description": "An interactive tool to set up and visualize Classic Mini wheel alignment (camber, caster, toe) with presets and saveable configurations.",
+      "how_to_name": "How to Set Up Classic Mini Wheel Alignment",
+      "how_to_description": "Use presets and a live diagram to plan camber, caster, and toe for a Classic Mini.",
+      "steps": {
+        "preset": {
+          "name": "Pick a preset",
+          "text": "Choose a starting point — stock, fast road, track day, or boosted."
+        },
+        "adjust": {
+          "name": "Adjust the angles",
+          "text": "Fine-tune front and rear camber, caster, and toe with the sliders."
+        },
+        "visualize": {
+          "name": "Read the diagram",
+          "text": "Watch the top-down and elevation views update live as you change settings."
+        },
+        "save": {
+          "name": "Save your setup",
+          "text": "Sign in to save the configuration and keep a dated driving journal."
+        }
+      }
+    }
+  },
+  "es": {
+    "title": "Técnica - Calculadora de alineación",
+    "description": "Configura y visualiza la alineación de las ruedas de tu Classic Mini — caída, avance y convergencia — con un diagrama cenital en vivo, preajustes basados en investigación y configuraciones que puedes guardar.",
+    "keywords": "alineación Classic Mini, caída, avance, convergencia, calculadora de alineación de ruedas, geometría de suspensión Mini, alineación de carretera rápida, alineación de circuito, caída negativa",
+    "hero_title": "Calculadora de alineación",
+    "breadcrumb_title": "Calculadora de alineación",
+    "og_title": "Calculadora de alineación Classic Mini",
+    "og_description": "Ajusta caída, avance y convergencia con un diagrama cenital en vivo y preajustes probados para Minis estándar, de carretera rápida, de circuito y sobrealimentados. Guarda tus configuraciones y mantén un diario de conducción.",
+    "twitter_title": "Calculadora de alineación Classic Mini",
+    "twitter_description": "Ajusta caída, avance y convergencia con un diagrama en vivo y preajustes probados. Guarda tus configuraciones y mantén un diario de conducción.",
+    "main_heading": "Calculadora de alineación",
+    "description_text": "Visualiza y planifica la alineación de las ruedas de tu Classic Mini en tiempo real. Empieza desde un preajuste basado en investigación (estándar, carretera rápida, circuito o sobrealimentado), ajusta con precisión la caída, el avance y la convergencia, y observa cómo el diagrama cenital se actualiza en vivo. Inicia sesión para guardar configuraciones y mantener un diario de conducción fechado para cada una.",
+    "eyebrow": "CALCULADORA",
+    "support_section": "Apoyo",
+    "ui": {
+      "loading_text": "Cargando calculadora de alineación..."
+    },
+    "structured_data": {
+      "calculator_name": "Calculadora de alineación Classic Mini",
+      "calculator_description": "Una herramienta interactiva para configurar y visualizar la alineación de las ruedas del Classic Mini (caída, avance, convergencia) con preajustes y configuraciones que se pueden guardar.",
+      "how_to_name": "Cómo configurar la alineación de las ruedas del Classic Mini",
+      "how_to_description": "Usa preajustes y un diagrama en vivo para planificar la caída, el avance y la convergencia de un Classic Mini.",
+      "steps": {
+        "preset": {
+          "name": "Elige un preajuste",
+          "text": "Elige un punto de partida — estándar, carretera rápida, día de circuito o sobrealimentado."
+        },
+        "adjust": {
+          "name": "Ajusta los ángulos",
+          "text": "Ajusta con precisión la caída, el avance y la convergencia delanteras y traseras con los controles deslizantes."
+        },
+        "visualize": {
+          "name": "Lee el diagrama",
+          "text": "Observa cómo las vistas cenital y de alzado se actualizan en vivo a medida que cambias los ajustes."
+        },
+        "save": {
+          "name": "Guarda tu configuración",
+          "text": "Inicia sesión para guardar la configuración y mantener un diario de conducción fechado."
+        }
+      }
+    }
+  },
+  "fr": {
+    "title": "Tech - Calculateur de géométrie",
+    "description": "Configurez et visualisez la géométrie des roues de votre Classic Mini — carrossage, chasse et parallélisme — avec un schéma en vue de dessus en direct, des préréglages issus de recherches et des réglages enregistrables.",
+    "keywords": "géométrie Classic Mini, carrossage, chasse, parallélisme, calculateur de géométrie des roues, géométrie de suspension Mini, géométrie route sportive, géométrie circuit, carrossage négatif",
+    "hero_title": "Calculateur de géométrie",
+    "breadcrumb_title": "Calculateur de géométrie",
+    "og_title": "Calculateur de géométrie Classic Mini",
+    "og_description": "Réglez carrossage, chasse et parallélisme avec un schéma en vue de dessus en direct et des préréglages éprouvés pour les Mini d'origine, route sportive, circuit et suralimentées. Enregistrez vos réglages et tenez un journal de conduite.",
+    "twitter_title": "Calculateur de géométrie Classic Mini",
+    "twitter_description": "Réglez carrossage, chasse et parallélisme avec un schéma en direct et des préréglages éprouvés. Enregistrez vos réglages et tenez un journal de conduite.",
+    "main_heading": "Calculateur de géométrie",
+    "description_text": "Visualisez et planifiez en temps réel la géométrie des roues de votre Classic Mini. Partez d'un préréglage issu de recherches (origine, route sportive, circuit ou suralimentée), affinez carrossage, chasse et parallélisme, et regardez le schéma en vue de dessus se mettre à jour en direct. Connectez-vous pour enregistrer vos réglages et tenir un journal de conduite daté pour chacun.",
+    "eyebrow": "CALCULATEUR",
+    "support_section": "Soutien",
+    "ui": {
+      "loading_text": "Chargement du calculateur de géométrie..."
+    },
+    "structured_data": {
+      "calculator_name": "Calculateur de géométrie Classic Mini",
+      "calculator_description": "Un outil interactif pour configurer et visualiser la géométrie des roues d'une Classic Mini (carrossage, chasse, parallélisme) avec des préréglages et des configurations enregistrables.",
+      "how_to_name": "Comment régler la géométrie des roues d'une Classic Mini",
+      "how_to_description": "Utilisez des préréglages et un schéma en direct pour planifier carrossage, chasse et parallélisme d'une Classic Mini.",
+      "steps": {
+        "preset": {
+          "name": "Choisissez un préréglage",
+          "text": "Choisissez un point de départ — origine, route sportive, journée circuit ou suralimentée."
+        },
+        "adjust": {
+          "name": "Ajustez les angles",
+          "text": "Affinez carrossage, chasse et parallélisme avant et arrière avec les curseurs."
+        },
+        "visualize": {
+          "name": "Lisez le schéma",
+          "text": "Regardez les vues de dessus et de face se mettre à jour en direct à mesure que vous modifiez les réglages."
+        },
+        "save": {
+          "name": "Enregistrez votre réglage",
+          "text": "Connectez-vous pour enregistrer la configuration et tenir un journal de conduite daté."
+        }
+      }
+    }
+  },
+  "de": {
+    "title": "Technik - Achsvermessungsrechner",
+    "description": "Richte die Achseinstellung deines Classic Mini ein und visualisiere sie — Sturz, Nachlauf und Spur — mit einer Live-Draufsicht, recherchierten Voreinstellungen und speicherbaren Setups.",
+    "keywords": "Classic Mini Achsvermessung, Sturz, Nachlauf, Spur, Achsvermessungsrechner, Mini Fahrwerksgeometrie, Achseinstellung schnelle Straße, Achseinstellung Rennstrecke, negativer Sturz",
+    "hero_title": "Achsvermessungsrechner",
+    "breadcrumb_title": "Achsvermessungsrechner",
+    "og_title": "Classic Mini Achsvermessungsrechner",
+    "og_description": "Stelle Sturz, Nachlauf und Spur mit einer Live-Draufsicht und bewährten Voreinstellungen für Serie, schnelle Straße, Rennstrecke und aufgeladene Minis ein. Speichere deine Setups und führe ein Fahrtenjournal.",
+    "twitter_title": "Classic Mini Achsvermessungsrechner",
+    "twitter_description": "Stelle Sturz, Nachlauf und Spur mit einem Live-Diagramm und bewährten Voreinstellungen ein. Speichere deine Setups und führe ein Fahrtenjournal.",
+    "main_heading": "Achsvermessungsrechner",
+    "description_text": "Visualisiere und plane die Achseinstellung deines Classic Mini in Echtzeit. Beginne mit einer recherchierten Voreinstellung (Serie, schnelle Straße, Rennstrecke oder aufgeladen), feine Sturz, Nachlauf und Spur ab und beobachte, wie sich die Draufsicht live aktualisiert. Melde dich an, um Setups zu speichern und für jedes ein datiertes Fahrtenjournal zu führen.",
+    "eyebrow": "RECHNER",
+    "support_section": "Unterstützung",
+    "ui": {
+      "loading_text": "Achsvermessungsrechner wird geladen..."
+    },
+    "structured_data": {
+      "calculator_name": "Classic Mini Achsvermessungsrechner",
+      "calculator_description": "Ein interaktives Werkzeug, um die Achseinstellung eines Classic Mini (Sturz, Nachlauf, Spur) einzurichten und zu visualisieren, mit Voreinstellungen und speicherbaren Konfigurationen.",
+      "how_to_name": "So richtest du die Achseinstellung eines Classic Mini ein",
+      "how_to_description": "Nutze Voreinstellungen und ein Live-Diagramm, um Sturz, Nachlauf und Spur für einen Classic Mini zu planen.",
+      "steps": {
+        "preset": {
+          "name": "Eine Voreinstellung wählen",
+          "text": "Wähle einen Ausgangspunkt — Serie, schnelle Straße, Trackday oder aufgeladen."
+        },
+        "adjust": {
+          "name": "Die Winkel anpassen",
+          "text": "Feine Sturz, Nachlauf und Spur vorne und hinten mit den Schiebereglern ab."
+        },
+        "visualize": {
+          "name": "Das Diagramm ablesen",
+          "text": "Beobachte, wie sich die Drauf- und Seitenansicht live aktualisieren, während du die Einstellungen änderst."
+        },
+        "save": {
+          "name": "Dein Setup speichern",
+          "text": "Melde dich an, um die Konfiguration zu speichern und ein datiertes Fahrtenjournal zu führen."
+        }
+      }
+    }
+  },
+  "it": {
+    "title": "Tech - Calcolatore di allineamento",
+    "description": "Imposta e visualizza l'allineamento delle ruote della tua Classic Mini — campanatura, incidenza e convergenza — con un diagramma dall'alto in tempo reale, preset derivati da ricerche e configurazioni salvabili.",
+    "keywords": "allineamento Classic Mini, campanatura, incidenza, convergenza, calcolatore allineamento ruote, geometria sospensioni Mini, allineamento strada sportiva, allineamento pista, campanatura negativa",
+    "hero_title": "Calcolatore di allineamento",
+    "breadcrumb_title": "Calcolatore di allineamento",
+    "og_title": "Calcolatore di allineamento Classic Mini",
+    "og_description": "Regola campanatura, incidenza e convergenza con un diagramma dall'alto in tempo reale e preset collaudati per Mini di serie, strada sportiva, pista e sovralimentate. Salva le tue configurazioni e tieni un diario di guida.",
+    "twitter_title": "Calcolatore di allineamento Classic Mini",
+    "twitter_description": "Regola campanatura, incidenza e convergenza con un diagramma in tempo reale e preset collaudati. Salva le tue configurazioni e tieni un diario di guida.",
+    "main_heading": "Calcolatore di allineamento",
+    "description_text": "Visualizza e pianifica in tempo reale l'allineamento delle ruote della tua Classic Mini. Parti da un preset derivato da ricerche (di serie, strada sportiva, pista o sovralimentata), affina campanatura, incidenza e convergenza, e guarda il diagramma dall'alto aggiornarsi dal vivo. Accedi per salvare le configurazioni e tenere un diario di guida datato per ciascuna.",
+    "eyebrow": "CALCOLATORE",
+    "support_section": "Supporto",
+    "ui": {
+      "loading_text": "Caricamento del calcolatore di allineamento..."
+    },
+    "structured_data": {
+      "calculator_name": "Calcolatore di allineamento Classic Mini",
+      "calculator_description": "Uno strumento interattivo per impostare e visualizzare l'allineamento delle ruote della Classic Mini (campanatura, incidenza, convergenza) con preset e configurazioni salvabili.",
+      "how_to_name": "Come impostare l'allineamento delle ruote della Classic Mini",
+      "how_to_description": "Usa preset e un diagramma in tempo reale per pianificare campanatura, incidenza e convergenza di una Classic Mini.",
+      "steps": {
+        "preset": {
+          "name": "Scegli un preset",
+          "text": "Scegli un punto di partenza — di serie, strada sportiva, giornata in pista o sovralimentata."
+        },
+        "adjust": {
+          "name": "Regola gli angoli",
+          "text": "Affina campanatura, incidenza e convergenza anteriori e posteriori con i cursori."
+        },
+        "visualize": {
+          "name": "Leggi il diagramma",
+          "text": "Guarda le viste dall'alto e in elevazione aggiornarsi dal vivo mentre modifichi le impostazioni."
+        },
+        "save": {
+          "name": "Salva la tua configurazione",
+          "text": "Accedi per salvare la configurazione e tenere un diario di guida datato."
+        }
+      }
+    }
+  },
+  "pt": {
+    "title": "Técnico - Calculadora de Alinhamento",
+    "description": "Configure e visualize o alinhamento das rodas do seu Classic Mini — cambagem, cáster e convergência — com um diagrama de cima ao vivo, predefinições derivadas de pesquisa e configurações guardáveis.",
+    "keywords": "alinhamento Classic Mini, cambagem, cáster, convergência, calculadora de alinhamento de rodas, geometria de suspensão Mini, alinhamento estrada rápida, alinhamento de pista, cambagem negativa",
+    "hero_title": "Calculadora de Alinhamento",
+    "breadcrumb_title": "Calculadora de Alinhamento",
+    "og_title": "Calculadora de Alinhamento do Classic Mini",
+    "og_description": "Acerte a cambagem, o cáster e a convergência com um diagrama de cima ao vivo e predefinições comprovadas para Minis de série, estrada rápida, pista e turbo. Guarde as suas configurações e mantenha um diário de condução.",
+    "twitter_title": "Calculadora de Alinhamento do Classic Mini",
+    "twitter_description": "Acerte a cambagem, o cáster e a convergência com um diagrama ao vivo e predefinições comprovadas. Guarde as suas configurações e mantenha um diário de condução.",
+    "main_heading": "Calculadora de Alinhamento",
+    "description_text": "Visualize e planeie o alinhamento das rodas do seu Classic Mini em tempo real. Comece a partir de uma predefinição derivada de pesquisa (série, estrada rápida, pista ou turbo), afine a cambagem, o cáster e a convergência, e veja o diagrama de cima atualizar-se ao vivo. Inicie sessão para guardar configurações e manter um diário de condução datado para cada uma.",
+    "eyebrow": "CALCULADORA",
+    "support_section": "Apoio",
+    "ui": {
+      "loading_text": "A carregar a calculadora de alinhamento..."
+    },
+    "structured_data": {
+      "calculator_name": "Calculadora de Alinhamento do Classic Mini",
+      "calculator_description": "Uma ferramenta interativa para configurar e visualizar o alinhamento das rodas do Classic Mini (cambagem, cáster, convergência) com predefinições e configurações guardáveis.",
+      "how_to_name": "Como Configurar o Alinhamento das Rodas do Classic Mini",
+      "how_to_description": "Use predefinições e um diagrama ao vivo para planear a cambagem, o cáster e a convergência de um Classic Mini.",
+      "steps": {
+        "preset": {
+          "name": "Escolha uma predefinição",
+          "text": "Escolha um ponto de partida — série, estrada rápida, dia de pista ou turbo."
+        },
+        "adjust": {
+          "name": "Ajuste os ângulos",
+          "text": "Afine a cambagem, o cáster e a convergência dianteiros e traseiros com os controlos deslizantes."
+        },
+        "visualize": {
+          "name": "Leia o diagrama",
+          "text": "Veja as vistas de cima e de elevação atualizarem-se ao vivo à medida que altera as definições."
+        },
+        "save": {
+          "name": "Guarde a sua configuração",
+          "text": "Inicie sessão para guardar a configuração e manter um diário de condução datado."
+        }
+      }
+    }
+  },
+  "ru": {
+    "title": "Техника — Калькулятор развал-схождения",
+    "description": "Настройте и визуализируйте развал-схождение вашего Classic Mini — развал, кастер и схождение — с живой схемой вида сверху, пресетами на основе исследований и сохраняемыми настройками.",
+    "keywords": "развал-схождение Classic Mini, развал, кастер, схождение, калькулятор развал-схождения, геометрия подвески Mini, настройка для спорт-дороги, настройка для трека, отрицательный развал",
+    "hero_title": "Калькулятор развал-схождения",
+    "breadcrumb_title": "Калькулятор развал-схождения",
+    "og_title": "Калькулятор развал-схождения Classic Mini",
+    "og_description": "Настройте развал, кастер и схождение с живой схемой вида сверху и проверенными пресетами для стокового, спортивного, трекового Mini и Mini с наддувом. Сохраняйте свои настройки и ведите журнал поездок.",
+    "twitter_title": "Калькулятор развал-схождения Classic Mini",
+    "twitter_description": "Настройте развал, кастер и схождение с живой схемой и проверенными пресетами. Сохраняйте свои настройки и ведите журнал поездок.",
+    "main_heading": "Калькулятор развал-схождения",
+    "description_text": "Визуализируйте и планируйте развал-схождение вашего Classic Mini в реальном времени. Начните с пресета на основе исследований (сток, спорт-дорога, трек или наддув), точно подстройте развал, кастер и схождение и наблюдайте, как схема вида сверху обновляется вживую. Войдите, чтобы сохранять настройки и вести датированный журнал поездок для каждой из них.",
+    "eyebrow": "КАЛЬКУЛЯТОР",
+    "support_section": "Поддержка",
+    "ui": {
+      "loading_text": "Загрузка калькулятора развал-схождения..."
+    },
+    "structured_data": {
+      "calculator_name": "Калькулятор развал-схождения Classic Mini",
+      "calculator_description": "Интерактивный инструмент для настройки и визуализации развал-схождения Classic Mini (развал, кастер, схождение) с пресетами и сохраняемыми конфигурациями.",
+      "how_to_name": "Как настроить развал-схождение колёс Classic Mini",
+      "how_to_description": "Используйте пресеты и живую схему, чтобы спланировать развал, кастер и схождение для Classic Mini.",
+      "steps": {
+        "preset": {
+          "name": "Выберите пресет",
+          "text": "Выберите отправную точку — сток, спорт-дорога, трек-день или наддув."
+        },
+        "adjust": {
+          "name": "Отрегулируйте углы",
+          "text": "Точно подстройте передний и задний развал, кастер и схождение ползунками."
+        },
+        "visualize": {
+          "name": "Читайте схему",
+          "text": "Наблюдайте, как виды сверху и сбоку обновляются вживую по мере изменения настроек."
+        },
+        "save": {
+          "name": "Сохраните свою настройку",
+          "text": "Войдите, чтобы сохранить конфигурацию и вести датированный журнал поездок."
+        }
+      }
+    }
+  },
+  "ja": {
+    "title": "テック - アライメント計算機",
+    "description": "ライブの上面図、調査に基づくプリセット、保存可能なセットアップを使って、Classic Miniのホイールアライメント（キャンバー、キャスター、トー）を設定・可視化します。",
+    "keywords": "Classic Mini アライメント, キャンバー, キャスター, トー, ホイールアライメント計算機, Mini サスペンションジオメトリー, ファストロードアライメント, トラックアライメント, ネガティブキャンバー",
+    "hero_title": "アライメント計算機",
+    "breadcrumb_title": "アライメント計算機",
+    "og_title": "Classic Mini アライメント計算機",
+    "og_description": "ライブの上面図と、ノーマル・ファストロード・トラック・過給のMini向けに実証されたプリセットで、キャンバー、キャスター、トーを設定。セットアップを保存してドライビングジャーナルを記録できます。",
+    "twitter_title": "Classic Mini アライメント計算機",
+    "twitter_description": "ライブ図と実証済みプリセットで、キャンバー、キャスター、トーを設定。セットアップを保存してドライビングジャーナルを記録できます。",
+    "main_heading": "アライメント計算機",
+    "description_text": "Classic Miniのホイールアライメントをリアルタイムで可視化・計画します。調査に基づくプリセット（ノーマル、ファストロード、トラック、過給）から始め、キャンバー、キャスター、トーを微調整し、上面図がライブで更新される様子を確認できます。サインインするとセットアップを保存し、それぞれに日付付きのドライビングジャーナルを記録できます。",
+    "eyebrow": "計算機",
+    "support_section": "サポート",
+    "ui": {
+      "loading_text": "アライメント計算機を読み込み中..."
+    },
+    "structured_data": {
+      "calculator_name": "Classic Mini アライメント計算機",
+      "calculator_description": "プリセットと保存可能な設定を使って、Classic Miniのホイールアライメント（キャンバー、キャスター、トー）を設定・可視化するインタラクティブツール。",
+      "how_to_name": "Classic Miniのホイールアライメントの設定方法",
+      "how_to_description": "プリセットとライブ図を使って、Classic Miniのキャンバー、キャスター、トーを計画します。",
+      "steps": {
+        "preset": {
+          "name": "プリセットを選ぶ",
+          "text": "出発点を選びます — ノーマル、ファストロード、トラックデー、または過給。"
+        },
+        "adjust": {
+          "name": "角度を調整する",
+          "text": "スライダーでフロントとリアのキャンバー、キャスター、トーを微調整します。"
+        },
+        "visualize": {
+          "name": "図を読む",
+          "text": "設定を変更すると、上面図と立面図がライブで更新される様子を確認できます。"
+        },
+        "save": {
+          "name": "セットアップを保存する",
+          "text": "サインインして設定を保存し、日付付きのドライビングジャーナルを記録します。"
+        }
+      }
+    }
+  },
+  "zh": {
+    "title": "技术 - 四轮定位计算器",
+    "description": "设置并可视化您的 Classic Mini 四轮定位——外倾角、主销后倾角和前束——配有实时俯视图、研究得出的预设以及可保存的设置。",
+    "keywords": "Classic Mini 四轮定位, 外倾角, 主销后倾角, 前束, 四轮定位计算器, Mini 悬挂几何, 高性能街道定位, 赛道定位, 负外倾角",
+    "hero_title": "四轮定位计算器",
+    "breadcrumb_title": "四轮定位计算器",
+    "og_title": "Classic Mini 四轮定位计算器",
+    "og_description": "通过实时俯视图以及针对原厂、高性能街道、赛道和增压 Mini 的成熟预设，精准调校外倾角、主销后倾角和前束。保存您的设置并记录驾驶日志。",
+    "twitter_title": "Classic Mini 四轮定位计算器",
+    "twitter_description": "通过实时图示和成熟预设精准调校外倾角、主销后倾角和前束。保存您的设置并记录驾驶日志。",
+    "main_heading": "四轮定位计算器",
+    "description_text": "实时可视化并规划您的 Classic Mini 四轮定位。从研究得出的预设（原厂、高性能街道、赛道或增压）开始，微调外倾角、主销后倾角和前束，并实时观看俯视图更新。登录即可保存设置，并为每个设置记录带日期的驾驶日志。",
+    "eyebrow": "计算器",
+    "support_section": "支持",
+    "ui": {
+      "loading_text": "正在加载四轮定位计算器..."
+    },
+    "structured_data": {
+      "calculator_name": "Classic Mini 四轮定位计算器",
+      "calculator_description": "一款用于设置和可视化 Classic Mini 四轮定位（外倾角、主销后倾角、前束）的交互式工具，配有预设和可保存的配置。",
+      "how_to_name": "如何设置 Classic Mini 四轮定位",
+      "how_to_description": "使用预设和实时图示来规划 Classic Mini 的外倾角、主销后倾角和前束。",
+      "steps": {
+        "preset": {
+          "name": "选择预设",
+          "text": "选择一个起始点——原厂、高性能街道、赛道日或增压。"
+        },
+        "adjust": {
+          "name": "调整角度",
+          "text": "使用滑块微调前后轮的外倾角、主销后倾角和前束。"
+        },
+        "visualize": {
+          "name": "查看图示",
+          "text": "在更改设置时观看俯视图和立面图实时更新。"
+        },
+        "save": {
+          "name": "保存您的设置",
+          "text": "登录以保存配置并记录带日期的驾驶日志。"
+        }
+      }
+    }
+  },
+  "ko": {
+    "title": "기술 - 얼라인먼트 계산기",
+    "description": "실시간 평면도, 연구 기반 프리셋, 저장 가능한 세팅으로 Classic Mini의 휠 얼라인먼트 — 캠버, 캐스터, 토 — 를 설정하고 시각화하세요.",
+    "keywords": "Classic Mini 얼라인먼트, 캠버, 캐스터, 토, 휠 얼라인먼트 계산기, Mini 서스펜션 지오메트리, 패스트 로드 얼라인먼트, 트랙 얼라인먼트, 네거티브 캠버",
+    "hero_title": "얼라인먼트 계산기",
+    "breadcrumb_title": "얼라인먼트 계산기",
+    "og_title": "Classic Mini 얼라인먼트 계산기",
+    "og_description": "실시간 평면도와 순정, 패스트 로드, 트랙, 부스트 Mini용 검증된 프리셋으로 캠버, 캐스터, 토를 세팅하세요. 세팅을 저장하고 주행 저널을 기록하세요.",
+    "twitter_title": "Classic Mini 얼라인먼트 계산기",
+    "twitter_description": "실시간 다이어그램과 검증된 프리셋으로 캠버, 캐스터, 토를 세팅하세요. 세팅을 저장하고 주행 저널을 기록하세요.",
+    "main_heading": "얼라인먼트 계산기",
+    "description_text": "Classic Mini의 휠 얼라인먼트를 실시간으로 시각화하고 계획하세요. 연구 기반 프리셋(순정, 패스트 로드, 트랙, 부스트)에서 시작해 캠버, 캐스터, 토를 미세 조정하고 평면도가 실시간으로 갱신되는 모습을 확인하세요. 로그인하면 세팅을 저장하고 각각에 대해 날짜가 기록된 주행 저널을 남길 수 있습니다.",
+    "eyebrow": "계산기",
+    "support_section": "후원",
+    "ui": {
+      "loading_text": "얼라인먼트 계산기를 불러오는 중..."
+    },
+    "structured_data": {
+      "calculator_name": "Classic Mini 얼라인먼트 계산기",
+      "calculator_description": "프리셋과 저장 가능한 구성으로 Classic Mini 휠 얼라인먼트(캠버, 캐스터, 토)를 설정하고 시각화하는 인터랙티브 도구입니다.",
+      "how_to_name": "Classic Mini 휠 얼라인먼트 세팅 방법",
+      "how_to_description": "프리셋과 실시간 다이어그램을 사용해 Classic Mini의 캠버, 캐스터, 토를 계획하세요.",
+      "steps": {
+        "preset": {
+          "name": "프리셋 선택",
+          "text": "출발점을 선택하세요 — 순정, 패스트 로드, 트랙 데이, 또는 부스트."
+        },
+        "adjust": {
+          "name": "각도 조정",
+          "text": "슬라이더로 앞뒤 캠버, 캐스터, 토를 미세 조정하세요."
+        },
+        "visualize": {
+          "name": "다이어그램 확인",
+          "text": "설정을 변경하면 평면도와 입면도가 실시간으로 갱신되는 모습을 확인하세요."
+        },
+        "save": {
+          "name": "세팅 저장",
+          "text": "로그인하여 구성을 저장하고 날짜가 기록된 주행 저널을 남기세요."
+        }
+      }
+    }
+  }
+}
+</i18n>

--- a/app/pages/technical/index.vue
+++ b/app/pages/technical/index.vue
@@ -143,6 +143,7 @@
       "needle_configurator": "Carb Needle Configurator",
       "gearbox_calculator": "Gearbox Calculator",
       "compression_calculator": "Compression Ratio Calculator",
+      "alignment_calculator": "Alignment Calculator",
       "parts_equivalency": "Parts Equivalency",
       "common_clearances": "Common Clearances",
       "kind": {
@@ -156,6 +157,7 @@
       "needle_configurator_desc": "Compare SU HS2/HS4/HIF44 needle profiles side-by-side with chart overlays.",
       "gearbox_calculator_desc": "Final-drive math across SPi, MPi, and pre-Verto cars.",
       "compression_calculator_desc": "CR for any combo of bore, stroke, head cc and deck height.",
+      "alignment_calculator_desc": "Visualize camber, caster, and toe live, with presets for stock, fast road, track, and boosted.",
       "parts_equivalency_desc": "Cross-reference part numbers across vendors and brands.",
       "common_clearances_desc": "Tappet gaps, bearing tolerances, and assembly clearances."
     }
@@ -188,6 +190,7 @@
       "needle_configurator": "Configurador de Agujas de Carburador",
       "gearbox_calculator": "Calculadora de Caja de Cambios",
       "compression_calculator": "Calculadora de Relación de Compresión",
+      "alignment_calculator": "Calculadora de alineación",
       "parts_equivalency": "Equivalencia de Piezas",
       "common_clearances": "Holguras Comunes",
       "kind": {
@@ -201,6 +204,7 @@
       "needle_configurator_desc": "Compara perfiles de agujas SU HS2/HS4/HIF44 lado a lado con superposiciones gráficas.",
       "gearbox_calculator_desc": "Cálculos de transmisión final para SPi, MPi y coches pre-Verto.",
       "compression_calculator_desc": "CR para cualquier combinación de diámetro, carrera, cc de culata y altura de cubierta.",
+      "alignment_calculator_desc": "Visualiza caída, avance y convergencia en vivo, con preajustes para estándar, carretera rápida, circuito y sobrealimentado.",
       "parts_equivalency_desc": "Referencias cruzadas de números de pieza entre proveedores y marcas.",
       "common_clearances_desc": "Ajustes de taqués, tolerancias de cojinetes y holguras de montaje."
     }
@@ -233,6 +237,7 @@
       "needle_configurator": "Configurateur d'Aiguilles de Carburateur",
       "gearbox_calculator": "Calculatrice de Boîte de Vitesses",
       "compression_calculator": "Calculatrice de Rapport de Compression",
+      "alignment_calculator": "Calculateur de géométrie",
       "parts_equivalency": "Équivalence des Pièces",
       "common_clearances": "Jeux Communs",
       "kind": {
@@ -246,6 +251,7 @@
       "needle_configurator_desc": "Compare des profils d'aiguilles SU HS2/HS4/HIF44 côte à côte avec superpositions graphiques.",
       "gearbox_calculator_desc": "Calculs de réduction finale pour SPi, MPi et voitures pré-Verto.",
       "compression_calculator_desc": "CR pour n'importe quelle combinaison d'alésage, course, cc de culasse et hauteur de pont.",
+      "alignment_calculator_desc": "Visualisez carrossage, chasse et parallélisme en direct, avec des préréglages pour origine, route sportive, circuit et suralimentée.",
       "parts_equivalency_desc": "Recoupement des numéros de pièces entre fournisseurs et marques.",
       "common_clearances_desc": "Calage de soupapes, tolérances de paliers et jeux de montage."
     }
@@ -278,6 +284,7 @@
       "needle_configurator": "Configuratore Aghi Carburatore",
       "gearbox_calculator": "Calcolatrice Cambio",
       "compression_calculator": "Calcolatrice Rapporto Compressione",
+      "alignment_calculator": "Calcolatore di allineamento",
       "parts_equivalency": "Equivalenza Parti",
       "common_clearances": "Giochi Comuni",
       "kind": {
@@ -291,6 +298,7 @@
       "needle_configurator_desc": "Confronta i profili degli aghi SU HS2/HS4/HIF44 fianco a fianco con overlay grafici.",
       "gearbox_calculator_desc": "Calcoli di trasmissione finale per SPi, MPi e auto pre-Verto.",
       "compression_calculator_desc": "CR per qualsiasi combinazione di alesaggio, corsa, cc della testata e altezza piano.",
+      "alignment_calculator_desc": "Visualizza campanatura, incidenza e convergenza dal vivo, con preset per di serie, strada sportiva, pista e sovralimentata.",
       "parts_equivalency_desc": "Tabelle di corrispondenza dei codici ricambio tra fornitori e marchi.",
       "common_clearances_desc": "Gioco delle punterie, tolleranze dei cuscinetti e giochi di assemblaggio."
     }
@@ -323,6 +331,7 @@
       "needle_configurator": "Vergaserdüsen-Konfigurator",
       "gearbox_calculator": "Getrieberechner",
       "compression_calculator": "Kompressionsverhältnis-Rechner",
+      "alignment_calculator": "Achsvermessungsrechner",
       "parts_equivalency": "Teileäquivalenz",
       "common_clearances": "Übliche Spiele",
       "kind": {
@@ -336,6 +345,7 @@
       "needle_configurator_desc": "Vergleiche SU HS2/HS4/HIF44 Nadelprofile nebeneinander mit Diagramm-Overlays.",
       "gearbox_calculator_desc": "Achsantriebsmathematik für SPi, MPi und Pre-Verto-Fahrzeuge.",
       "compression_calculator_desc": "CR für jede Kombination aus Bohrung, Hub, Brennraumvolumen und Decköhe.",
+      "alignment_calculator_desc": "Visualisiere Sturz, Nachlauf und Spur live, mit Voreinstellungen für Serie, schnelle Straße, Rennstrecke und aufgeladen.",
       "parts_equivalency_desc": "Querverweise von Teilenummern über Lieferanten und Marken hinweg.",
       "common_clearances_desc": "Ventilspiele, Lagertoleranzen und Montagespielmaße."
     }
@@ -368,6 +378,7 @@
       "needle_configurator": "Configurador de Agulhas do Carburador",
       "gearbox_calculator": "Calculadora de Câmbio",
       "compression_calculator": "Calculadora de Razão de Compressão",
+      "alignment_calculator": "Calculadora de Alinhamento",
       "parts_equivalency": "Equivalência de Peças",
       "common_clearances": "Folgas Comuns",
       "kind": {
@@ -381,6 +392,7 @@
       "needle_configurator_desc": "Compara perfis de agulhas SU HS2/HS4/HIF44 lado a lado com sobreposições gráficas.",
       "gearbox_calculator_desc": "Cálculos de transmissão final para SPi, MPi e carros pré-Verto.",
       "compression_calculator_desc": "CR para qualquer combinação de diâmetro, curso, cc do cabeçote e altura do platô.",
+      "alignment_calculator_desc": "Visualize a cambagem, o cáster e a convergência ao vivo, com predefinições para série, estrada rápida, pista e turbo.",
       "parts_equivalency_desc": "Referência cruzada de números de peças entre fornecedores e marcas.",
       "common_clearances_desc": "Ajustes de tuchos, tolerâncias de mancais e folgas de montagem."
     }
@@ -413,6 +425,7 @@
       "needle_configurator": "Конфигуратор Игл Карбюратора",
       "gearbox_calculator": "Калькулятор Коробки Передач",
       "compression_calculator": "Калькулятор Степени Сжатия",
+      "alignment_calculator": "Калькулятор развал-схождения",
       "parts_equivalency": "Эквивалентность Деталей",
       "common_clearances": "Общие Зазоры",
       "kind": {
@@ -426,6 +439,7 @@
       "needle_configurator_desc": "Сравните профили игл SU HS2/HS4/HIF44 параллельно с наложением графиков.",
       "gearbox_calculator_desc": "Математика главной передачи для SPi, MPi и до-Verto автомобилей.",
       "compression_calculator_desc": "CR для любого сочетания диаметра цилиндра, хода поршня, объёма ГБЦ и высоты деки.",
+      "alignment_calculator_desc": "Визуализируйте развал, кастер и схождение вживую, с пресетами для стока, спорт-дороги, трека и наддува.",
       "parts_equivalency_desc": "Перекрёстная справка номеров деталей между поставщиками и брендами.",
       "common_clearances_desc": "Регулировки клапанов, допуски подшипников и сборочные зазоры."
     }
@@ -458,6 +472,7 @@
       "needle_configurator": "キャブレターニードル設定ツール",
       "gearbox_calculator": "ギアボックス計算機",
       "compression_calculator": "圧縮比計算機",
+      "alignment_calculator": "アライメント計算機",
       "parts_equivalency": "部品等価性",
       "common_clearances": "一般的なクリアランス",
       "kind": {
@@ -471,6 +486,7 @@
       "needle_configurator_desc": "SU HS2/HS4/HIF44のニードルプロファイルをグラフ重ね表示で並べて比較。",
       "gearbox_calculator_desc": "SPi、MPi、Verto以前の車のファイナルドライブ計算。",
       "compression_calculator_desc": "ボア、ストローク、ヘッドcc、デッキ高さの任意の組み合わせのCR。",
+      "alignment_calculator_desc": "キャンバー、キャスター、トーをライブで可視化。ノーマル、ファストロード、トラック、過給のプリセット付き。",
       "parts_equivalency_desc": "ベンダーとブランド間の部品番号のクロスリファレンス。",
       "common_clearances_desc": "タペット隙間、ベアリング公差、組立クリアランス。"
     }
@@ -503,6 +519,7 @@
       "needle_configurator": "化油器针配置器",
       "gearbox_calculator": "变速箱计算器",
       "compression_calculator": "压缩比计算器",
+      "alignment_calculator": "四轮定位计算器",
       "parts_equivalency": "零件等效性",
       "common_clearances": "常见间隙",
       "kind": {
@@ -516,6 +533,7 @@
       "needle_configurator_desc": "通过图表叠加并排比较 SU HS2/HS4/HIF44 化油器针型。",
       "gearbox_calculator_desc": "适用于 SPi、MPi 和 Verto 之前车型的主减速比计算。",
       "compression_calculator_desc": "适用于任意缸径、行程、燃烧室容积和甲板高度组合的CR计算。",
+      "alignment_calculator_desc": "实时可视化外倾角、主销后倾角和前束，配有原厂、高性能街道、赛道和增压预设。",
       "parts_equivalency_desc": "跨供应商和品牌的零件号交叉参考。",
       "common_clearances_desc": "气门间隙、轴承公差和装配间隙。"
     }
@@ -548,6 +566,7 @@
       "needle_configurator": "카뷰레터 니들 구성기",
       "gearbox_calculator": "기어박스 계산기",
       "compression_calculator": "압축비 계산기",
+      "alignment_calculator": "얼라인먼트 계산기",
       "parts_equivalency": "부품 등가성",
       "common_clearances": "일반적인 클리어런스",
       "kind": {
@@ -561,6 +580,7 @@
       "needle_configurator_desc": "차트 오버레이로 SU HS2/HS4/HIF44 니들 프로파일을 나란히 비교.",
       "gearbox_calculator_desc": "SPi, MPi, Verto 이전 차량을 위한 최종 감속비 계산.",
       "compression_calculator_desc": "보어, 스트로크, 헤드 cc, 데크 높이의 모든 조합에 대한 CR.",
+      "alignment_calculator_desc": "캠버, 캐스터, 토를 실시간으로 시각화하고, 순정, 패스트 로드, 트랙, 부스트용 프리셋을 제공합니다.",
       "parts_equivalency_desc": "공급업체와 브랜드 간 부품 번호 교차 참조.",
       "common_clearances_desc": "태핏 갭, 베어링 공차, 조립 간극."
     }

--- a/data/models/alignment.ts
+++ b/data/models/alignment.ts
@@ -1,0 +1,180 @@
+// Classic Mini wheel-alignment tool — parameter ranges, presets, and unit helpers.
+//
+// Research basis: docs/plans/2026-06-23-alignment-tool.md (sourced from MED Engineering,
+// Mini Spares, Calver ST, The Mini Forum, TurboMinis, and the Rover/Haynes workshop manuals).
+//
+// SIGN CONVENTIONS (load-bearing — surfaced verbatim in the UI):
+//   Camber: positive = top of wheel leans OUT, negative = leans IN. Factory FRONT camber is
+//           POSITIVE; every performance setup runs negative. Do not assume camber is negative.
+//   Caster: always POSITIVE on a Mini (steering axis trails).
+//   Toe:    NEGATIVE = toe-OUT, POSITIVE = toe-IN, for BOTH axles. The FRONT runs toe-OUT
+//           (negative); the REAR runs toe-IN (positive). Values are TOTAL across both wheels
+//           (Mini hobby convention) — set each wheel to half the figure.
+
+export type AlignmentAxle = 'front' | 'rear';
+export type AlignmentParamKind = 'camber' | 'caster' | 'toe';
+export type AlignmentParamId = 'frontCamber' | 'frontCaster' | 'frontToe' | 'rearCamber' | 'rearToe';
+export type AlignmentPresetId = 'stockRoad' | 'fastRoad' | 'trackDay' | 'boostedRoad' | 'boostedTrack';
+export type AlignmentConfidence = 'high' | 'medium' | 'low';
+
+export interface AlignmentValues {
+  frontCamber: number; // degrees
+  frontCaster: number; // degrees (positive)
+  frontToe: number; // mm, total, negative = toe-out
+  rearCamber: number; // degrees
+  rearToe: number; // mm, total, positive = toe-in
+}
+
+export interface AlignmentParameter {
+  id: AlignmentParamId;
+  axle: AlignmentAxle;
+  kind: AlignmentParamKind;
+  unit: 'deg' | 'mm';
+  min: number;
+  max: number;
+  step: number;
+  /** Factory/stock value — also the tool's initial value. */
+  stockDefault: number;
+}
+
+export interface AlignmentPreset {
+  id: AlignmentPresetId;
+  confidence: AlignmentConfidence;
+  values: AlignmentValues;
+  /** Supporting URLs (not localized — reference links). */
+  sources: string[];
+}
+
+/** Max saved alignment configs per user (enforced at the API layer, mirrors gear configs). */
+export const ALIGNMENT_MAX_CONFIGS = 25;
+
+export const MM_PER_INCH = 25.4;
+
+/** Wheel diameters offered in the tool (inches). Drives the optional toe degree readout and
+ *  the camber-guidance note — camber recommendations scale with rim size. */
+export const ALIGNMENT_WHEEL_SIZES = [10, 12, 13] as const;
+export type AlignmentWheelSize = (typeof ALIGNMENT_WHEEL_SIZES)[number];
+export const ALIGNMENT_DEFAULT_WHEEL_SIZE: AlignmentWheelSize = 10;
+
+export interface CamberRange {
+  min: number; // most negative end (degrees)
+  max: number; // least negative / neutral end (degrees)
+}
+
+/**
+ * Typical NEGATIVE (performance) camber range by rim size. Smaller rims tolerate — and want —
+ * more static negative camber to keep the tyre flat through the Mini's big body roll; bigger
+ * rims need less. Source: Mini Spares splits front 10"≈−1.5/−2.0, 12"≈−1.0/−1.5, 13"≈−0.5/−0.75;
+ * rear roughly half that. These are guidance ranges, not hard limits, and assume a grip-oriented
+ * (not factory) setup — the factory front figure is positive, flagged separately.
+ */
+export const ALIGNMENT_CAMBER_GUIDANCE: Record<number, { front: CamberRange; rear: CamberRange }> = {
+  10: { front: { min: -2.0, max: -1.5 }, rear: { min: -1.0, max: -0.75 } },
+  12: { front: { min: -1.5, max: -1.0 }, rear: { min: -0.5, max: 0 } },
+  13: { front: { min: -0.75, max: -0.5 }, rear: { min: -0.25, max: 0 } },
+};
+
+export function getCamberGuidance(wheelSize: number, axle: AlignmentAxle): CamberRange {
+  const g = ALIGNMENT_CAMBER_GUIDANCE[wheelSize] ?? ALIGNMENT_CAMBER_GUIDANCE[ALIGNMENT_DEFAULT_WHEEL_SIZE];
+  return g[axle];
+}
+
+export const ALIGNMENT_PARAMETERS: AlignmentParameter[] = [
+  { id: 'frontCamber', axle: 'front', kind: 'camber', unit: 'deg', min: -3, max: 2.5, step: 0.25, stockDefault: 2 },
+  { id: 'frontCaster', axle: 'front', kind: 'caster', unit: 'deg', min: 1, max: 6, step: 0.25, stockDefault: 3 },
+  { id: 'frontToe', axle: 'front', kind: 'toe', unit: 'mm', min: -4, max: 3, step: 0.25, stockDefault: -1.59 },
+  { id: 'rearCamber', axle: 'rear', kind: 'camber', unit: 'deg', min: -2, max: 1, step: 0.25, stockDefault: 0 },
+  { id: 'rearToe', axle: 'rear', kind: 'toe', unit: 'mm', min: -1, max: 5, step: 0.25, stockDefault: 3.18 },
+];
+
+/** Five research-derived starting points. Numeric values + sources only; display name,
+ *  summary, and rationale are localized via i18n keys (`presets.<id>.*`) in the component. */
+export const ALIGNMENT_PRESETS: AlignmentPreset[] = [
+  {
+    id: 'stockRoad',
+    confidence: 'high',
+    values: { frontCamber: 2, frontCaster: 3, frontToe: -1.59, rearCamber: 0, rearToe: 3.18 },
+    sources: [
+      'https://www.minimania.com/msgThread/110236/1/1/Alignment_Specs',
+      'https://www.theminiforum.co.uk/forums/topic/353453-camber-caster-toe-tracking-figures/page-2',
+      'https://us.haynes.com/products/mini-1969-2001-haynes-repair-manual',
+    ],
+  },
+  {
+    id: 'fastRoad',
+    confidence: 'high',
+    values: { frontCamber: -1, frontCaster: 3.5, frontToe: -1.59, rearCamber: -0.5, rearToe: 1.59 },
+    sources: [
+      'https://www.minispares.com/blog/2020/02/26/suspension-basic-set-up-method/',
+      'https://www.med-engineering.co.uk/blogs/news/classic-mini-suspension-geometry-setup-guide',
+      'https://www.calverst.com/technical-info/suspension-basic-set-up-method/',
+    ],
+  },
+  {
+    id: 'trackDay',
+    confidence: 'medium',
+    values: { frontCamber: -2, frontCaster: 4.5, frontToe: -1.59, rearCamber: -0.5, rearToe: 0 },
+    sources: [
+      'https://www.med-engineering.co.uk/blogs/news/classic-mini-suspension-geometry-setup-guide',
+      'https://www.theminiforum.co.uk/forums/topic/238535-please-help-with-front-end-alignment-specs-for-road-racing-setup/',
+      'https://www.calverst.com/technical-info/suspension-basic-set-up-method/',
+    ],
+  },
+  {
+    id: 'boostedRoad',
+    confidence: 'medium',
+    values: { frontCamber: -1, frontCaster: 4, frontToe: 0, rearCamber: -0.5, rearToe: 3.18 },
+    sources: [
+      'https://www.turbominis.co.uk/forums/index.php?p=vt&tid=593349',
+      'https://www.med-engineering.co.uk/blogs/news/classic-mini-suspension-geometry-setup-guide',
+      'https://www.hpacademy.com/forum/motorsport-wheel-alignment-fundamentals/show/fwd-alignment-loads-of-tourqe-steer/',
+    ],
+  },
+  {
+    id: 'boostedTrack',
+    confidence: 'low',
+    values: { frontCamber: -2.5, frontCaster: 5, frontToe: -1, rearCamber: -1, rearToe: 1.59 },
+    sources: [
+      'https://www.turbominis.co.uk/forums/index.php?p=vt&tid=345429',
+      'https://www.turbominis.co.uk/forums/index.php?p=vt&tid=593349',
+      'https://www.med-engineering.co.uk/blogs/news/classic-mini-suspension-geometry-setup-guide',
+    ],
+  },
+];
+
+export function getAlignmentPreset(id: AlignmentPresetId): AlignmentPreset | undefined {
+  return ALIGNMENT_PRESETS.find((p) => p.id === id);
+}
+
+/** Default tool state = factory/stock geometry. */
+export function defaultAlignmentValues(): AlignmentValues {
+  return { ...(getAlignmentPreset('stockRoad') as AlignmentPreset).values };
+}
+
+/**
+ * Convert a TOTAL toe distance (mm, measured across both wheels at the rim) to a per-axle
+ * angle in degrees. Wheel-diameter dependent, which is exactly why mm — not degrees — is the
+ * canonical toe unit; this readout is informational only.
+ */
+export function toeMmToDegrees(totalMm: number, wheelDiameterIn: number): number {
+  const diameterMm = wheelDiameterIn * MM_PER_INCH;
+  if (diameterMm === 0) return 0;
+  return 2 * Math.atan(totalMm / 2 / diameterMm) * (180 / Math.PI);
+}
+
+/**
+ * Render a mm toe value as the nearest common imperial fraction (the Mini world quotes toe in
+ * 1/16" increments). Returns an unsigned magnitude string like `1/16"` or `0`; the caller adds
+ * the in/out direction word. 1/16" = 1.5875 mm, 1/8" = 3.175 mm, 3/16" = 4.7625 mm.
+ */
+export function mmToInchFraction(mm: number): string {
+  const sixteenths = Math.round((Math.abs(mm) / MM_PER_INCH) * 16);
+  if (sixteenths === 0) return '0';
+  let num = sixteenths;
+  let den = 16;
+  while (num % 2 === 0 && den % 2 === 0) {
+    num /= 2;
+    den /= 2;
+  }
+  return den === 1 ? `${num}"` : `${num}/${den}"`;
+}

--- a/data/models/generic.ts
+++ b/data/models/generic.ts
@@ -171,6 +171,19 @@ export const ToolboxItems: ToolboxItem[] = [
       '<i class="fa-duotone fa-calculator" style="--fa-primary-color: #859369; --fa-secondary-color: #859369;"></i>',
   },
   {
+    titleKey: 'toolbox.alignment_calculator',
+    descKey: 'toolbox.alignment_calculator_desc',
+    kindKey: 'toolbox.kind.calculator',
+    path: '/technical/alignment',
+    to: '/technical/alignment',
+    iconName: 'fa-tire',
+    iconPrimary: '#417bbd',
+    iconSecondary: '#2f2f2f',
+    iconSecondaryOpacity: 0.7,
+    iconHtml:
+      '<i class="fa-duotone fa-tire" style="--fa-primary-color: #417bbd; --fa-secondary-color: #2f2f2f; --fa-secondary-opacity: 0.7;"></i>',
+  },
+  {
     titleKey: 'toolbox.parts_equivalency',
     descKey: 'toolbox.parts_equivalency_desc',
     kindKey: 'toolbox.kind.reference',

--- a/docs/plans/2026-06-23-alignment-tool.md
+++ b/docs/plans/2026-06-23-alignment-tool.md
@@ -1,0 +1,117 @@
+# Classic Mini Alignment Tool — Design Doc
+
+**Date:** 2026-06-23
+**Author:** Cole (w/ Claude)
+**Status:** In progress
+**Branch:** `claude/crazy-bouman-504d1b`
+
+## Context
+
+The technical toolbox has calculators for compression, gearing, needles, etc., but nothing
+for **wheel alignment** — one of the most-discussed and most-misunderstood setup topics in the
+Classic Mini world (factory front camber is *positive*; front runs toe-*out*; rear runs
+toe-*in* — all easy to get backwards). Owners currently piece this together from scattered
+forum threads.
+
+This adds a `/technical/alignment` tool that:
+
+1. Lets a user dial in the five adjustable alignment parameters and **see a live top-down +
+   elevation diagram** update in real time (à la hurreysoffroad / robrobinette calculators).
+2. Ships **5 research-derived presets** (Stock Road, Fast Road, Track Day, Boosted Road,
+   Boosted Track) sourced from MED, Mini Spares, Calver, The Mini Forum, TurboMinis, and the
+   Rover/Haynes workshop manuals.
+3. Lets logged-in users **save configurations with a dated journal log** to their profile
+   (mirrors saved gear configs), so they can track spec changes and driving impressions over
+   time.
+
+Web first; the data model + presets are intended to cascade to the iOS/Android toolbox later
+(GitHub Project #9 card).
+
+## Parameters (canonical units + sign conventions)
+
+| Param | Unit | Sign convention | Min | Max | Step | Stock default |
+|---|---|---|---|---|---|---|
+| Front camber | ° | + = top leans OUT, − = top leans IN (stock is **positive**) | −3 | 2.5 | 0.25 | +2 |
+| Front caster | ° | always **positive** (validate ≥0) | 1 | 6 | 0.25 | +3 |
+| Front toe (total) | mm | − = toe-**OUT**, + = toe-IN (front runs **toe-out**) | −4 | 3 | 0.25 | −1.59 |
+| Rear camber | ° | + = out, − = in | −2 | 1 | 0.25 | 0 |
+| Rear toe (total) | mm | + = toe-**IN**, − = toe-OUT (rear runs **toe-in**) | −1 | 5 | 0.25 | +3.18 |
+
+Plus a **wheel-diameter** selector (10″ / 12″ / 13″) that drives an optional toe degree readout
+(`angle = 2·atan((total/2)/diameter)`) and a camber-guidance note (camber recs scale with rim size).
+
+**Toe is TOTAL across both wheels** (Mini hobby convention), not per-wheel — surfaced explicitly
+in the UI. Key conversions: 1/16″ = 1.5875 mm, 1/8″ = 3.175 mm, 3/16″ = 4.7625 mm.
+
+## Presets
+
+| Preset | F camber | F caster | F toe (mm) | R camber | R toe (mm) | Conf. |
+|---|---|---|---|---|---|---|
+| Stock Road | +2 | +3 | −1.59 (1/16″ out) | 0 | +3.18 (1/8″ in) | high |
+| Fast Road | −1 | +3.5 | −1.59 | −0.5 | +1.59 | high |
+| Track Day | −2 | +4.5 | −1.59 | −0.5 | 0 (straight) | medium |
+| Boosted Road | −1 | +4 | 0 (parallel) | −0.5 | +3.18 | medium |
+| Boosted Track | −2.5 | +5 | −1 | −1 | +1.59 | low |
+
+Each preset carries a `rationale` + `sources[]` + `confidence`. The Boosted-Road headline is
+**front toe set parallel** (Wiginton) to cut torque steer; Boosted-Track is the most extrapolated
+(flagged low). Full numbers/rationale/sources live in `data/models/alignment.ts`. Tool shows a
+standing disclaimer: starting points only, verify on a rig, match sides within 0.5°.
+
+## Architecture (mirrors saved gear configs 1:1)
+
+Save/load uses the established pattern: client composable → `/api/*` route with
+`Authorization: Bearer <token>` (from `supabase.auth.getSession()`) → `getServiceClient()`
+server-side with explicit `.eq('user_id', user.id)` → RLS-backed table. (Per the load-bearing
+rule: Supabase session is localStorage, so server routes need the explicit Bearer header.)
+
+### New Supabase table (in `classicminidiy-supabase`, applied to remote)
+
+`saved_alignment_configs`: `id`, `user_id` (FK auth.users, cascade), `name`, `is_public`,
+`front_camber/front_caster/front_toe/rear_camber/rear_toe` (numeric), `wheel_size` (text, null),
+`preset` (text, null — preset it was based on), `notes` (text, null), `journal` (jsonb, default
+`[]` — array of `{ id, date, body }`), `created_at`, `updated_at`. Same 5 RLS policies + public-read
+policy + `set_updated_at` trigger reusing existing `public.handle_updated_at()`. Then regen
+`types/database.ts` in the web repo.
+
+### Web files
+
+- `data/models/alignment.ts` — `ALIGNMENT_PARAMETERS`, `ALIGNMENT_PRESETS`, unit conversions, source list, disclaimer.
+- `app/types/alignment.ts` — `AlignmentValues`, `SavedAlignmentConfig`, `CreateAlignmentConfigInput`, `JournalEntry`.
+- `app/composables/useAlignmentConfigs.ts` — copy of `useGearConfigs.ts` + journal helpers (add/update/delete entry → `updateConfig({ journal })`).
+- `server/api/alignment-configs/{index.post,index.get}.ts`, `[id].{put,delete}.ts`, `public/[userId].get.ts` — copy of gear-configs routes (validate the 5 numerics + name; max 25/user).
+- `app/components/Calculators/AlignmentDiagram.vue` — reactive SVG: top-down plan view (toe, visually exaggerated), front + rear elevation insets (camber), side inset (caster). Brand palette, animated transitions.
+- `app/components/Calculators/Alignment.vue` — 5 sliders + wheel-size + preset selector + readouts + diagram + save/load (anonymous can use everything except save).
+- `app/components/Alignment/AlignmentSaveLoadModal.vue` — load a saved config (mirrors GearboxSaveLoadModal).
+- `app/pages/technical/alignment.vue` — page wrapper (hero/breadcrumb/PageIntro/ClientOnly + Lazy component + SEO/JSON-LD), per gearing.vue.
+- `app/pages/dashboard/alignment-configs.vue` — dashboard tab: list configs, edit values inline, manage the dated journal, public toggle, delete.
+- Register: add card to `ToolboxItems` in `data/models/generic.ts` (+ i18n keys in `technical/index.vue`); add tab to `tabs[]` in `dashboard.vue` (+ i18n).
+
+### Visualization approach
+
+Custom inline SVG (no Highcharts — wrong fit for a plan view; no 3D lib exists). Real toe angles
+are <0.5° so the diagram applies a fixed visual-exaggeration factor for legibility while the numeric
+readout shows the true value. Front toe-out splays the wheels' leading edges apart; rear toe-in
+brings them together; camber leans the wheel tops; caster tilts the steering axis rearward. Smooth
+CSS transitions on transforms give the "real-time" feel as sliders move.
+
+## i18n
+
+Per-component `<i18n lang="json">` blocks, all 10 locales (en es fr de it pt ru ja zh ko), no HTML
+in messages. Build English-complete first, then a translation pass fills the other 9. Add keys to
+`technical/index.vue`, `dashboard.vue`, and the new components/pages.
+
+## Verification
+
+1. `bun run dev`; load `/technical/alignment` — diagram renders, presets populate the sliders,
+   dragging a slider animates the diagram live (preview MCP: snapshot + screenshot + console).
+2. Toe sign sanity: front negative ⇒ wheels splay out (toe-out label); rear positive ⇒ wheels toe in.
+3. Logged in: save a config → appears in `/dashboard/alignment-configs`; add a journal entry; reload
+   into the tool; toggle public; delete. Confirm rows via Supabase.
+4. `bun run build` passes (Nitro). Vitest for `data/models/alignment.ts` conversions/preset integrity.
+
+## Out of scope / follow-ups
+
+- Mobile (iOS/Android) port — tracked on Project #9.
+- Per-wheel (split L/R) alignment entry — tool uses total-toe convention only for now.
+- Wheel size drives the toe°-at-rim readout and per-rim camber guidance (typical range + an aggressive-camber nudge under the camber sliders); *auto-rewriting preset camber numbers* per rim is still out of scope (presets assume ~10″).

--- a/server/api/alignment-configs/[id].delete.ts
+++ b/server/api/alignment-configs/[id].delete.ts
@@ -1,0 +1,21 @@
+import { requireUserAuth } from '../../utils/userAuth';
+import { getServiceClient } from '../../utils/supabase';
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserAuth(event);
+  const id = getRouterParam(event, 'id');
+
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Config ID required' });
+  }
+
+  const supabase = getServiceClient();
+
+  const { error } = await supabase.from('saved_alignment_configs').delete().eq('id', id).eq('user_id', user.id);
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to delete config' });
+  }
+
+  return { success: true };
+});

--- a/server/api/alignment-configs/[id].delete.ts
+++ b/server/api/alignment-configs/[id].delete.ts
@@ -5,8 +5,8 @@ export default defineEventHandler(async (event) => {
   const { user } = await requireUserAuth(event);
   const id = getRouterParam(event, 'id');
 
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Config ID required' });
+  if (!id || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid or missing Config ID' });
   }
 
   const supabase = getServiceClient();

--- a/server/api/alignment-configs/[id].put.ts
+++ b/server/api/alignment-configs/[id].put.ts
@@ -1,5 +1,6 @@
 import { requireUserAuth } from '../../utils/userAuth';
 import { getServiceClient } from '../../utils/supabase';
+import { ALIGNMENT_WHEEL_SIZES } from '../../../data/models/alignment';
 
 const NUMERIC_FIELDS = ['front_camber', 'front_caster', 'front_toe', 'rear_camber', 'rear_toe'] as const;
 
@@ -20,8 +21,8 @@ export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id');
   const body = await readBody(event);
 
-  if (!id) {
-    throw createError({ statusCode: 400, statusMessage: 'Config ID required' });
+  if (!id || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid or missing Config ID' });
   }
 
   if (body.name !== undefined) {
@@ -42,7 +43,12 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  if (body.wheel_size !== undefined) updates.wheel_size = body.wheel_size != null ? String(body.wheel_size) : null;
+  if (body.wheel_size !== undefined) {
+    if (body.wheel_size != null && !ALIGNMENT_WHEEL_SIZES.map(String).includes(String(body.wheel_size))) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid wheel size' });
+    }
+    updates.wheel_size = body.wheel_size != null ? String(body.wheel_size) : null;
+  }
   if (body.preset !== undefined) updates.preset = body.preset != null ? String(body.preset) : null;
   if (body.notes !== undefined) updates.notes = body.notes != null ? String(body.notes).slice(0, 5000) : null;
   if (body.journal !== undefined) updates.journal = sanitizeJournal(body.journal);
@@ -63,6 +69,10 @@ export default defineEventHandler(async (event) => {
     .single();
 
   if (error) {
+    // .single() raises PGRST116 when no row matches (missing id or not the caller's row).
+    if ((error as { code?: string }).code === 'PGRST116') {
+      throw createError({ statusCode: 404, statusMessage: 'Config not found' });
+    }
     throw createError({ statusCode: 500, statusMessage: 'Failed to update config' });
   }
 

--- a/server/api/alignment-configs/[id].put.ts
+++ b/server/api/alignment-configs/[id].put.ts
@@ -1,0 +1,74 @@
+import { requireUserAuth } from '../../utils/userAuth';
+import { getServiceClient } from '../../utils/supabase';
+
+const NUMERIC_FIELDS = ['front_camber', 'front_caster', 'front_toe', 'rear_camber', 'rear_toe'] as const;
+
+function sanitizeJournal(input: unknown): { id: string; date: string; body: string }[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .filter((e) => e && typeof e === 'object')
+    .map((e: any) => ({
+      id: String(e.id ?? `${Date.now()}-${Math.round(Math.random() * 1e6)}`),
+      date: String(e.date ?? new Date().toISOString().slice(0, 10)).slice(0, 10),
+      body: String(e.body ?? '').slice(0, 5000),
+    }))
+    .slice(0, 200);
+}
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserAuth(event);
+  const id = getRouterParam(event, 'id');
+  const body = await readBody(event);
+
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Config ID required' });
+  }
+
+  if (body.name !== undefined) {
+    if (typeof body.name !== 'string' || body.name.trim().length === 0 || body.name.length > 100) {
+      throw createError({ statusCode: 400, statusMessage: 'Name must be 1-100 characters' });
+    }
+  }
+
+  const updates: Record<string, any> = {};
+  if (body.name !== undefined) updates.name = body.name.trim();
+
+  for (const field of NUMERIC_FIELDS) {
+    if (body[field] !== undefined) {
+      if (!Number.isFinite(Number(body[field]))) {
+        throw createError({ statusCode: 400, statusMessage: `Invalid ${field}` });
+      }
+      updates[field] = Number(body[field]);
+    }
+  }
+
+  if (body.wheel_size !== undefined) updates.wheel_size = body.wheel_size != null ? String(body.wheel_size) : null;
+  if (body.preset !== undefined) updates.preset = body.preset != null ? String(body.preset) : null;
+  if (body.notes !== undefined) updates.notes = body.notes != null ? String(body.notes).slice(0, 5000) : null;
+  if (body.journal !== undefined) updates.journal = sanitizeJournal(body.journal);
+  if (body.is_public !== undefined) updates.is_public = body.is_public === true;
+
+  if (Object.keys(updates).length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'No fields to update' });
+  }
+
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from('saved_alignment_configs')
+    .update(updates)
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select()
+    .single();
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to update config' });
+  }
+
+  if (!data) {
+    throw createError({ statusCode: 404, statusMessage: 'Config not found' });
+  }
+
+  return data;
+});

--- a/server/api/alignment-configs/index.get.ts
+++ b/server/api/alignment-configs/index.get.ts
@@ -1,0 +1,19 @@
+import { requireUserAuth } from '../../utils/userAuth';
+import { getServiceClient } from '../../utils/supabase';
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserAuth(event);
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from('saved_alignment_configs')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to fetch configs' });
+  }
+
+  return data;
+});

--- a/server/api/alignment-configs/index.post.ts
+++ b/server/api/alignment-configs/index.post.ts
@@ -1,0 +1,79 @@
+import { requireUserAuth } from '../../utils/userAuth';
+import { getServiceClient } from '../../utils/supabase';
+import { ALIGNMENT_MAX_CONFIGS } from '../../../data/models/alignment';
+
+const NUMERIC_FIELDS = ['front_camber', 'front_caster', 'front_toe', 'rear_camber', 'rear_toe'] as const;
+
+/** Coerce arbitrary input into clean journal entries — never trust the client's JSON shape. */
+function sanitizeJournal(input: unknown): { id: string; date: string; body: string }[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .filter((e) => e && typeof e === 'object')
+    .map((e: any) => ({
+      id: String(e.id ?? `${Date.now()}-${Math.round(Math.random() * 1e6)}`),
+      date: String(e.date ?? new Date().toISOString().slice(0, 10)).slice(0, 10),
+      body: String(e.body ?? '').slice(0, 5000),
+    }))
+    .slice(0, 200);
+}
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserAuth(event);
+  const body = await readBody(event);
+
+  const { name, wheel_size, preset, notes, journal, is_public } = body;
+
+  if (typeof name !== 'string' || name.trim().length === 0 || name.length > 100) {
+    throw createError({ statusCode: 400, statusMessage: 'Name must be 1-100 characters' });
+  }
+
+  for (const field of NUMERIC_FIELDS) {
+    if (!Number.isFinite(Number(body[field]))) {
+      throw createError({ statusCode: 400, statusMessage: `Missing or invalid ${field}` });
+    }
+  }
+
+  const supabase = getServiceClient();
+
+  // Enforce max configs per user
+  const { count, error: countError } = await supabase
+    .from('saved_alignment_configs')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', user.id);
+
+  if (countError) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to check config count' });
+  }
+
+  if ((count ?? 0) >= ALIGNMENT_MAX_CONFIGS) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Maximum of ${ALIGNMENT_MAX_CONFIGS} saved configurations reached`,
+    });
+  }
+
+  const { data, error } = await supabase
+    .from('saved_alignment_configs')
+    .insert({
+      user_id: user.id,
+      name: name.trim(),
+      front_camber: Number(body.front_camber),
+      front_caster: Number(body.front_caster),
+      front_toe: Number(body.front_toe),
+      rear_camber: Number(body.rear_camber),
+      rear_toe: Number(body.rear_toe),
+      wheel_size: wheel_size != null ? String(wheel_size) : null,
+      preset: preset != null ? String(preset) : null,
+      notes: notes != null ? String(notes).slice(0, 5000) : null,
+      journal: sanitizeJournal(journal),
+      is_public: is_public === true,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to create config' });
+  }
+
+  return data;
+});

--- a/server/api/alignment-configs/index.post.ts
+++ b/server/api/alignment-configs/index.post.ts
@@ -1,6 +1,6 @@
 import { requireUserAuth } from '../../utils/userAuth';
 import { getServiceClient } from '../../utils/supabase';
-import { ALIGNMENT_MAX_CONFIGS } from '../../../data/models/alignment';
+import { ALIGNMENT_MAX_CONFIGS, ALIGNMENT_WHEEL_SIZES } from '../../../data/models/alignment';
 
 const NUMERIC_FIELDS = ['front_camber', 'front_caster', 'front_toe', 'rear_camber', 'rear_toe'] as const;
 
@@ -25,6 +25,10 @@ export default defineEventHandler(async (event) => {
 
   if (typeof name !== 'string' || name.trim().length === 0 || name.length > 100) {
     throw createError({ statusCode: 400, statusMessage: 'Name must be 1-100 characters' });
+  }
+
+  if (wheel_size != null && !ALIGNMENT_WHEEL_SIZES.map(String).includes(String(wheel_size))) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid wheel size' });
   }
 
   for (const field of NUMERIC_FIELDS) {

--- a/server/api/alignment-configs/public/[userId].get.ts
+++ b/server/api/alignment-configs/public/[userId].get.ts
@@ -1,0 +1,26 @@
+import { getServiceClient } from '../../../utils/supabase';
+
+export default defineEventHandler(async (event) => {
+  const userId = getRouterParam(event, 'userId');
+
+  if (!userId) {
+    throw createError({ statusCode: 400, statusMessage: 'User ID required' });
+  }
+
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from('saved_alignment_configs')
+    .select(
+      'id, name, front_camber, front_caster, front_toe, rear_camber, rear_toe, wheel_size, preset, notes, journal, created_at'
+    )
+    .eq('user_id', userId)
+    .eq('is_public', true)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to fetch public configs' });
+  }
+
+  return data;
+});

--- a/server/api/alignment-configs/public/[userId].get.ts
+++ b/server/api/alignment-configs/public/[userId].get.ts
@@ -3,8 +3,8 @@ import { getServiceClient } from '../../../utils/supabase';
 export default defineEventHandler(async (event) => {
   const userId = getRouterParam(event, 'userId');
 
-  if (!userId) {
-    throw createError({ statusCode: 400, statusMessage: 'User ID required' });
+  if (!userId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(userId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid or missing User ID' });
   }
 
   const supabase = getServiceClient();

--- a/tests/unit/data/alignment-model.test.ts
+++ b/tests/unit/data/alignment-model.test.ts
@@ -110,6 +110,11 @@ describe('mmToInchFraction', () => {
     expect(mmToInchFraction(-1.5875)).toBe('1/16"');
     expect(mmToInchFraction(0)).toBe('0');
   });
+
+  it('rounds a small sub-1/32" toe to "0" (the readouts must treat this as parallel, not "0 in/out")', () => {
+    expect(mmToInchFraction(0.5)).toBe('0');
+    expect(mmToInchFraction(-0.5)).toBe('0');
+  });
 });
 
 describe('toeMmToDegrees', () => {

--- a/tests/unit/data/alignment-model.test.ts
+++ b/tests/unit/data/alignment-model.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALIGNMENT_PARAMETERS,
+  ALIGNMENT_PRESETS,
+  ALIGNMENT_WHEEL_SIZES,
+  defaultAlignmentValues,
+  getAlignmentPreset,
+  mmToInchFraction,
+  toeMmToDegrees,
+  getCamberGuidance,
+  ALIGNMENT_CAMBER_GUIDANCE,
+  type AlignmentParamId,
+  type AlignmentValues,
+} from '~/data/models/alignment';
+
+const PARAM_IDS: AlignmentParamId[] = ['frontCamber', 'frontCaster', 'frontToe', 'rearCamber', 'rearToe'];
+
+describe('ALIGNMENT_PARAMETERS', () => {
+  it('defines exactly the five expected parameters', () => {
+    expect(ALIGNMENT_PARAMETERS).toHaveLength(5);
+    expect(ALIGNMENT_PARAMETERS.map((p) => p.id).sort()).toEqual([...PARAM_IDS].sort());
+  });
+
+  it('each parameter is internally consistent (min < max, sane step, default in range)', () => {
+    for (const p of ALIGNMENT_PARAMETERS) {
+      expect(p.min).toBeLessThan(p.max);
+      expect(p.step).toBeGreaterThan(0);
+      expect(p.stockDefault).toBeGreaterThanOrEqual(p.min);
+      expect(p.stockDefault).toBeLessThanOrEqual(p.max);
+      expect(['deg', 'mm']).toContain(p.unit);
+      expect(['front', 'rear']).toContain(p.axle);
+      expect(['camber', 'caster', 'toe']).toContain(p.kind);
+    }
+  });
+
+  it('uses degrees for camber/caster and mm for toe', () => {
+    for (const p of ALIGNMENT_PARAMETERS) {
+      expect(p.unit).toBe(p.kind === 'toe' ? 'mm' : 'deg');
+    }
+  });
+});
+
+describe('ALIGNMENT_PRESETS', () => {
+  it('defines the five presets in the expected order', () => {
+    expect(ALIGNMENT_PRESETS.map((p) => p.id)).toEqual([
+      'stockRoad',
+      'fastRoad',
+      'trackDay',
+      'boostedRoad',
+      'boostedTrack',
+    ]);
+  });
+
+  it('every preset value sits within its parameter slider range', () => {
+    for (const preset of ALIGNMENT_PRESETS) {
+      for (const id of PARAM_IDS) {
+        const param = ALIGNMENT_PARAMETERS.find((p) => p.id === id)!;
+        const v = preset.values[id as keyof AlignmentValues];
+        expect(v, `${preset.id}.${id}`).toBeGreaterThanOrEqual(param.min);
+        expect(v, `${preset.id}.${id}`).toBeLessThanOrEqual(param.max);
+      }
+    }
+  });
+
+  it('every preset has a valid confidence and at least one source', () => {
+    for (const preset of ALIGNMENT_PRESETS) {
+      expect(['high', 'medium', 'low']).toContain(preset.confidence);
+      expect(preset.sources.length).toBeGreaterThan(0);
+      for (const src of preset.sources) expect(src).toMatch(/^https?:\/\//);
+    }
+  });
+
+  it('respects the Mini sign conventions: front toe-out, rear toe-in, positive stock front camber', () => {
+    const stock = getAlignmentPreset('stockRoad')!;
+    expect(stock.values.frontToe).toBeLessThan(0); // front runs toe-out
+    expect(stock.values.rearToe).toBeGreaterThan(0); // rear runs toe-in
+    expect(stock.values.frontCamber).toBeGreaterThan(0); // factory front camber is positive
+    expect(stock.values.frontCaster).toBeGreaterThan(0); // caster always positive
+  });
+
+  it('boosted road sets the front toe parallel (the headline torque-steer finding)', () => {
+    expect(getAlignmentPreset('boostedRoad')!.values.frontToe).toBe(0);
+  });
+
+  it('caster is positive across every preset', () => {
+    for (const preset of ALIGNMENT_PRESETS) {
+      expect(preset.values.frontCaster).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('defaultAlignmentValues', () => {
+  it('returns the stock-road geometry as a fresh object', () => {
+    const a = defaultAlignmentValues();
+    expect(a).toEqual(getAlignmentPreset('stockRoad')!.values);
+    a.frontCamber = 99;
+    expect(getAlignmentPreset('stockRoad')!.values.frontCamber).not.toBe(99); // not a shared reference
+  });
+});
+
+describe('mmToInchFraction', () => {
+  it('maps the canonical Mini toe values to imperial fractions', () => {
+    expect(mmToInchFraction(1.5875)).toBe('1/16"');
+    expect(mmToInchFraction(3.175)).toBe('1/8"');
+    expect(mmToInchFraction(4.7625)).toBe('3/16"');
+    expect(mmToInchFraction(25.4)).toBe('1"');
+  });
+
+  it('is sign-agnostic and returns 0 for ~zero', () => {
+    expect(mmToInchFraction(-1.5875)).toBe('1/16"');
+    expect(mmToInchFraction(0)).toBe('0');
+  });
+});
+
+describe('toeMmToDegrees', () => {
+  it('returns 0 for zero toe', () => {
+    expect(toeMmToDegrees(0, 10)).toBe(0);
+  });
+
+  it('computes ~0.72° total for 1/8" toe on 10" wheels', () => {
+    expect(toeMmToDegrees(3.175, 10)).toBeCloseTo(0.716, 2);
+  });
+
+  it('yields a smaller angle on a larger wheel for the same mm', () => {
+    expect(Math.abs(toeMmToDegrees(3.175, 13))).toBeLessThan(Math.abs(toeMmToDegrees(3.175, 10)));
+  });
+
+  it('exposes the supported wheel sizes', () => {
+    expect(ALIGNMENT_WHEEL_SIZES).toContain(10);
+    expect(ALIGNMENT_WHEEL_SIZES).toContain(13);
+  });
+});
+
+describe('getCamberGuidance', () => {
+  it('returns a neutral-to-negative range for every wheel size and axle', () => {
+    for (const size of ALIGNMENT_WHEEL_SIZES) {
+      for (const axle of ['front', 'rear'] as const) {
+        const g = getCamberGuidance(size, axle);
+        expect(g.min, `${size} ${axle}`).toBeLessThanOrEqual(g.max); // min is the more-negative end
+        expect(g.max, `${size} ${axle}`).toBeLessThanOrEqual(0);
+      }
+    }
+  });
+
+  it('recommends more negative camber on smaller rims', () => {
+    expect(getCamberGuidance(10, 'front').min).toBeLessThan(getCamberGuidance(13, 'front').min);
+    expect(getCamberGuidance(10, 'rear').min).toBeLessThan(getCamberGuidance(13, 'rear').min);
+  });
+
+  it('keeps front camber at least as negative as rear for a given rim', () => {
+    for (const size of ALIGNMENT_WHEEL_SIZES) {
+      expect(getCamberGuidance(size, 'front').min).toBeLessThanOrEqual(getCamberGuidance(size, 'rear').min);
+    }
+  });
+
+  it('falls back to the 10" guidance for an unknown wheel size', () => {
+    expect(getCamberGuidance(99, 'front')).toEqual(ALIGNMENT_CAMBER_GUIDANCE[10].front);
+  });
+});

--- a/types/database.ts
+++ b/types/database.ts
@@ -2738,6 +2738,7 @@ export type Database = {
           email_new_comments: boolean | null
           email_new_messages: boolean | null
           email_saved_search_matches: boolean | null
+          email_submission_updates: boolean | null
           email_weekly_digest: boolean | null
           push_new_messages: boolean | null
           updated_at: string | null
@@ -2750,6 +2751,7 @@ export type Database = {
           email_new_comments?: boolean | null
           email_new_messages?: boolean | null
           email_saved_search_matches?: boolean | null
+          email_submission_updates?: boolean | null
           email_weekly_digest?: boolean | null
           push_new_messages?: boolean | null
           updated_at?: string | null
@@ -2762,6 +2764,7 @@ export type Database = {
           email_new_comments?: boolean | null
           email_new_messages?: boolean | null
           email_saved_search_matches?: boolean | null
+          email_submission_updates?: boolean | null
           email_weekly_digest?: boolean | null
           push_new_messages?: boolean | null
           updated_at?: string | null
@@ -3118,6 +3121,60 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      saved_alignment_configs: {
+        Row: {
+          created_at: string
+          front_camber: number
+          front_caster: number
+          front_toe: number
+          id: string
+          is_public: boolean
+          journal: Json
+          name: string
+          notes: string | null
+          preset: string | null
+          rear_camber: number
+          rear_toe: number
+          updated_at: string
+          user_id: string
+          wheel_size: string | null
+        }
+        Insert: {
+          created_at?: string
+          front_camber: number
+          front_caster: number
+          front_toe: number
+          id?: string
+          is_public?: boolean
+          journal?: Json
+          name: string
+          notes?: string | null
+          preset?: string | null
+          rear_camber: number
+          rear_toe: number
+          updated_at?: string
+          user_id: string
+          wheel_size?: string | null
+        }
+        Update: {
+          created_at?: string
+          front_camber?: number
+          front_caster?: number
+          front_toe?: number
+          id?: string
+          is_public?: boolean
+          journal?: Json
+          name?: string
+          notes?: string | null
+          preset?: string | null
+          rear_camber?: number
+          rear_toe?: number
+          updated_at?: string
+          user_id?: string
+          wheel_size?: string | null
+        }
+        Relationships: []
       }
       saved_gear_configs: {
         Row: {
@@ -3954,10 +4011,6 @@ export type Database = {
         Args: { p_city: string; p_country: string; p_state_province: string }
         Returns: string
       }
-      get_auction_fee_by_category: {
-        Args: { p_category: string }
-        Returns: number
-      }
       get_comment_count: { Args: { p_listing_id: string }; Returns: number }
       get_listing_analytics: {
         Args: { p_listing_id: string }
@@ -4151,10 +4204,6 @@ export type Database = {
       moderate_external_model: {
         Args: { p_id: string; p_notes?: string; p_status: string }
         Returns: undefined
-      }
-      place_bid: {
-        Args: { p_amount: number; p_bidder_id: string; p_listing_id: string }
-        Returns: Json
       }
       publish_model_version: {
         Args: { p_version_id: string }


### PR DESCRIPTION
A new technical-toolbox tool at **`/technical/alignment`** to set up and visualize Classic Mini wheel alignment.

## What it does
- Dial in front/rear **camber, caster, and toe**; a custom SVG diagram (top-down plan view for toe + front/rear elevation insets for camber + a caster side view) animates **live** as you adjust.
- **5 research-derived presets** — Stock Road, Fast Road, Track Day, Boosted Road, Boosted Track — each with sourced rationale and a confidence rating (sources: MED, Mini Spares, Calver, The Mini Forum, TurboMinis, Haynes/Rover).
- **Wheel-size-aware camber guidance** (10/12/13″) and a nudge when camber is more negative than typical for the rim; toe shown in mm, imperial fraction, and °-at-rim.
- Surfaces the Mini gotchas explicitly: stock front camber is *positive*; front runs toe-*out*, rear toe-*in*; toe is total-across-both-wheels.

## Save to profile
Logged-in users can save setups with a **dated driving journal**, managed from a new **`/dashboard/alignment-configs`** tab. Mirrors the saved gear-configs pattern: `/api/alignment-configs/*` routes with a Bearer token → service client scoped by `user_id` (max 25/user).

## Notes
- **DB:** requires `saved_alignment_configs` — ClassicMiniDIY/classicminidiy-supabase#46 (already applied to prod, so no migrate-before-deploy ordering). Includes the regenerated `types/database.ts`.
- **No new env vars** (uses the existing Supabase keys).
- All 10 locales; tool card added to the technical toolbox; unit tests for the data model (`bun run test` green); `bun run build` green.
- Design doc: `docs/plans/2026-06-23-alignment-tool.md`.

## Still to verify post-merge
- Real authenticated save → dashboard → journal → load → delete round-trip (not exercisable in the build sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)