### PR TITLE
feat(alignment): preset rework (factory→track), WCAG AA contrast, badge + caster layout

### DIFF
--- a/app/components/Calculators/Alignment.vue
+++ b/app/components/Calculators/Alignment.vue
@@ -438,20 +438,24 @@
 </template>
 
 <style scoped>
-  .confidence-high {
-    background: color-mix(in srgb, #4caf50 22%, transparent);
-    color: #2e7d32;
+  /* Solid, opaque pills with white text. The old translucent-tint + dark-text badges
+     went dark-on-dark in dark mode and on the selected (btn-primary) preset button.
+     Fixed bg + white text clears WCAG AA (5.0–5.2:1) regardless of theme or button state. */
+  .confidence-high,
+  .confidence-medium,
+  .confidence-low {
+    color: #fff;
     border: none;
+    font-weight: 600;
+  }
+  .confidence-high {
+    background: #15803d;
   }
   .confidence-medium {
-    background: color-mix(in srgb, var(--cm-fa-orange, #f3b140) 28%, transparent);
-    color: #8a6d00;
-    border: none;
+    background: #a16207;
   }
   .confidence-low {
-    background: color-mix(in srgb, var(--cm-secondary, #ed7135) 22%, transparent);
-    color: #b34a17;
-    border: none;
+    background: #c2410c;
   }
   /* Aggressive-camber nudge: a deep amber that clears WCAG AA on the white card
      (daisyUI's text-warning #f59e0b is only ~2:1 on white). Lighter amber in dark mode. */

--- a/app/components/Calculators/Alignment.vue
+++ b/app/components/Calculators/Alignment.vue
@@ -248,13 +248,13 @@
                 <span class="text-xs opacity-60 w-6">{{ param.unit === 'deg' ? '°' : 'mm' }}</span>
               </div>
               <p class="text-xs opacity-60 mt-1">{{ t(`params.${param.id}.help`) }}</p>
-              <p v-if="param.kind === 'toe'" class="text-xs opacity-50 mt-0.5">
+              <p v-if="param.kind === 'toe'" class="text-xs opacity-60 mt-0.5">
                 {{ t('approx_total_deg', { deg: toeDegTotal(values[param.id]).toFixed(2) }) }}
               </p>
-              <p v-if="param.kind === 'camber'" class="text-xs opacity-50 mt-0.5">
+              <p v-if="param.kind === 'camber'" class="text-xs opacity-60 mt-0.5">
                 {{ t('camber_guidance', { size: wheelSize, range: camberRangeText(param.axle) }) }}
               </p>
-              <p v-if="param.kind === 'camber' && isCamberAggressive(param.id)" class="text-xs text-warning mt-0.5">
+              <p v-if="param.kind === 'camber' && isCamberAggressive(param.id)" class="text-xs camber-warn mt-0.5">
                 <i class="fas fa-triangle-exclamation"></i> {{ t('camber_aggressive', { size: wheelSize }) }}
               </p>
             </div>
@@ -295,13 +295,13 @@
                 <span class="text-xs opacity-60 w-6">{{ param.unit === 'deg' ? '°' : 'mm' }}</span>
               </div>
               <p class="text-xs opacity-60 mt-1">{{ t(`params.${param.id}.help`) }}</p>
-              <p v-if="param.kind === 'toe'" class="text-xs opacity-50 mt-0.5">
+              <p v-if="param.kind === 'toe'" class="text-xs opacity-60 mt-0.5">
                 {{ t('approx_total_deg', { deg: toeDegTotal(values[param.id]).toFixed(2) }) }}
               </p>
-              <p v-if="param.kind === 'camber'" class="text-xs opacity-50 mt-0.5">
+              <p v-if="param.kind === 'camber'" class="text-xs opacity-60 mt-0.5">
                 {{ t('camber_guidance', { size: wheelSize, range: camberRangeText(param.axle) }) }}
               </p>
-              <p v-if="param.kind === 'camber' && isCamberAggressive(param.id)" class="text-xs text-warning mt-0.5">
+              <p v-if="param.kind === 'camber' && isCamberAggressive(param.id)" class="text-xs camber-warn mt-0.5">
                 <i class="fas fa-triangle-exclamation"></i> {{ t('camber_aggressive', { size: wheelSize }) }}
               </p>
             </div>
@@ -452,6 +452,14 @@
     background: color-mix(in srgb, var(--cm-secondary, #ed7135) 22%, transparent);
     color: #b34a17;
     border: none;
+  }
+  /* Aggressive-camber nudge: a deep amber that clears WCAG AA on the white card
+     (daisyUI's text-warning #f59e0b is only ~2:1 on white). Lighter amber in dark mode. */
+  .camber-warn {
+    color: #92400e;
+  }
+  [data-theme='cmdiy-dark'] .camber-warn {
+    color: #fbbf24;
   }
 </style>
 

--- a/app/components/Calculators/Alignment.vue
+++ b/app/components/Calculators/Alignment.vue
@@ -48,8 +48,8 @@
     Object.assign(values, preset.values);
     track('alignment_preset_selected', { preset: id });
   }
-  function resetStock() {
-    applyPreset('stockRoad');
+  function resetFactory() {
+    applyPreset('factory');
   }
 
   // ---- formatting / readouts ----
@@ -86,7 +86,7 @@
   const warnings = computed<string[]>(() => {
     const w: string[] = [];
     if (values.rearToe < -EPS) w.push('rearToeOut');
-    if (values.frontCaster > 5.5) w.push('casterHigh');
+    if (values.frontCaster > 6.5) w.push('casterHigh');
     if (values.rearCamber > 0.25) w.push('rearCamberPositive');
     if (values.frontCamber > 0.25) w.push('frontCamberPositive');
     return w;
@@ -173,12 +173,13 @@
     <section>
       <h3 class="fancy-font-bold text-lg mb-1">{{ t('presets_title') }}</h3>
       <p class="text-sm opacity-70 mb-3">{{ t('presets_subtitle') }}</p>
-      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2">
+      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2">
         <button
           v-for="preset in ALIGNMENT_PRESETS"
           :key="preset.id"
           class="btn btn-sm h-auto py-2 flex-col gap-1 normal-case"
           :class="matchedPresetId === preset.id ? 'btn-primary' : 'btn-outline'"
+          :aria-pressed="matchedPresetId === preset.id"
           @click="applyPreset(preset.id)"
         >
           <span class="font-semibold">{{ t(`presets.${preset.id}.name`) }}</span>
@@ -204,6 +205,7 @@
               :key="size"
               class="btn btn-sm join-item"
               :class="wheelSize === size ? 'btn-primary' : 'btn-outline'"
+              :aria-pressed="wheelSize === size"
               @click="wheelSize = size"
             >
               {{ size }}"
@@ -220,17 +222,19 @@
           <div class="flex flex-col gap-4">
             <div v-for="param in frontParams" :key="param.id" class="rounded-lg border border-base-300 p-3">
               <div class="flex items-center justify-between gap-2 mb-1">
-                <label class="text-sm font-medium">{{ t(`params.${param.id}.label`) }}</label>
+                <label class="text-sm font-medium" :for="`${param.id}-range`">{{ t(`params.${param.id}.label`) }}</label>
                 <span class="text-sm font-bold tabular-nums">{{ paramReadout(param.id) }}</span>
               </div>
               <div class="flex items-center gap-3">
                 <input
+                  :id="`${param.id}-range`"
                   v-model.number="values[param.id]"
                   type="range"
                   class="range range-primary range-sm grow"
                   :min="param.min"
                   :max="param.max"
                   :step="param.step"
+                  :aria-label="t(`params.${param.id}.label`)"
                 />
                 <input
                   v-model.number="values[param.id]"
@@ -239,6 +243,7 @@
                   :min="param.min"
                   :max="param.max"
                   :step="param.step"
+                  :aria-label="t(`params.${param.id}.label`)"
                 />
                 <span class="text-xs opacity-60 w-6">{{ param.unit === 'deg' ? '°' : 'mm' }}</span>
               </div>
@@ -264,17 +269,19 @@
           <div class="flex flex-col gap-4">
             <div v-for="param in rearParams" :key="param.id" class="rounded-lg border border-base-300 p-3">
               <div class="flex items-center justify-between gap-2 mb-1">
-                <label class="text-sm font-medium">{{ t(`params.${param.id}.label`) }}</label>
+                <label class="text-sm font-medium" :for="`${param.id}-range`">{{ t(`params.${param.id}.label`) }}</label>
                 <span class="text-sm font-bold tabular-nums">{{ paramReadout(param.id) }}</span>
               </div>
               <div class="flex items-center gap-3">
                 <input
+                  :id="`${param.id}-range`"
                   v-model.number="values[param.id]"
                   type="range"
                   class="range range-primary range-sm grow"
                   :min="param.min"
                   :max="param.max"
                   :step="param.step"
+                  :aria-label="t(`params.${param.id}.label`)"
                 />
                 <input
                   v-model.number="values[param.id]"
@@ -283,6 +290,7 @@
                   :min="param.min"
                   :max="param.max"
                   :step="param.step"
+                  :aria-label="t(`params.${param.id}.label`)"
                 />
                 <span class="text-xs opacity-60 w-6">{{ param.unit === 'deg' ? '°' : 'mm' }}</span>
               </div>
@@ -301,7 +309,7 @@
         </div>
 
         <div class="flex flex-wrap gap-2">
-          <button class="btn btn-sm btn-ghost" @click="resetStock">
+          <button class="btn btn-sm btn-ghost" @click="resetFactory">
             <i class="fas fa-rotate-left"></i> {{ t('reset_to_stock') }}
           </button>
         </div>
@@ -475,7 +483,7 @@
       },
       "frontCaster": {
         "label": "Front caster",
-        "help": "Always positive. Set via adjustable tie-bars. Keep both sides within 0.5° and don't exceed ~5.5°."
+        "help": "Always positive. Naturally aspirated road cars run about 3°; forced-induction wants 5–6.5° for stability under boost. Set via adjustable tie-bars and match both sides within 0.5°."
       },
       "frontToe": {
         "label": "Front toe (total)",
@@ -491,25 +499,29 @@
       }
     },
     "presets": {
+      "factory": {
+        "name": "Factory",
+        "rationale": "The factory workshop-manual geometry. Front camber is positive (+2°) and the front toes out slightly — both correct for the Mini, not typos. The rear runs 1/8\" toe-in. A faithful baseline; most modern setups improve on it."
+      },
       "stockRoad": {
         "name": "Stock Road",
-        "rationale": "Factory workshop-manual geometry. Note the front camber is positive (+2°) and the front runs slight toe-out — both are correct for the Mini, not typos. The rear runs 1/8\" toe-in for straight-line stability."
+        "rationale": "Factory geometry tidied up for modern radial tyres: the awkward positive front camber dialled back to a mild -0.5° for a bit more grip and even wear, everything else left near stock. The easy, comfortable daily-driver setup."
       },
-      "fastRoad": {
-        "name": "Fast Road",
-        "rationale": "Sharper turn-in than stock while staying streetable and easy on tyres. Flips front camber negative to keep the loaded tyre flat through body roll, with a touch more caster for self-centring. Keeps mild front toe-out and lighter rear toe-in."
+      "performance": {
+        "name": "Performance",
+        "rationale": "A sharper street setup. More negative front camber keeps the loaded tyre flat through body roll, a touch more caster adds self-centring, and lighter rear toe-in frees the car up. Still road-friendly, with a little more tyre wear."
       },
-      "trackDay": {
-        "name": "Track Day",
-        "rationale": "Maximum cornering grip on road or semi-slick tyres; accepts faster tyre wear. More negative front camber and more caster; rear set straight to let the back rotate on turn-in. The tyre sets the camber ceiling — verify on a rig."
+      "track": {
+        "name": "Track",
+        "rationale": "Maximum cornering grip on road or semi-slick tyres, accepting faster tyre wear. More negative front camber and caster, with the rear set straight to let it rotate on turn-in. The tyre sets the camber ceiling — verify on a rig."
       },
       "boostedRoad": {
         "name": "Boosted Road",
-        "rationale": "Turbo or supercharged street car. The key change is front toe set parallel (zero) to cut torque steer and improve drive off the line, with healthy caster for stability under power and larger rear toe-in for traction."
+        "rationale": "Turbo or supercharged street car. Front toe set parallel (zero) to cut torque steer and put the power down, with high caster (6°) for straight-line stability under boost and a larger rear toe-in for traction."
       },
       "boostedTrack": {
         "name": "Boosted Track",
-        "rationale": "High-power forced-induction circuit car — the most extrapolated preset, so treat it as a starting point only. Aggressive front camber and caster with only a small front toe-out so power still goes down, plus mild rear toe-in for stability under acceleration."
+        "rationale": "High-power forced-induction circuit car. Aggressive front camber with lots of caster (6.5°) for stability and camber gain, a small front toe-out so power still goes down, and mild rear toe-in. A starting point — verify on a rig and corner-weight it."
       }
     },
     "confidence": {
@@ -519,7 +531,7 @@
     },
     "warnings": {
       "rearToeOut": "Rear toe-out can cause snap oversteer — only suitable for experienced drivers on a full-race rotation setup.",
-      "casterHigh": "Caster above 5.5° is beyond the usual practical limit and adds heavy steering effort.",
+      "casterHigh": "Very high caster means heavy low-speed steering. That is normal on a turbo or supercharged Mini (5–6.5°) but a lot for a naturally aspirated car.",
       "rearCamberPositive": "Positive rear camber makes the back nervous — the rear should run neutral to mild negative.",
       "frontCamberPositive": "Positive front camber is the factory figure for skinny crossplies; most modern setups run negative for grip."
     },
@@ -569,7 +581,7 @@
       },
       "frontCaster": {
         "label": "Avance delantero",
-        "help": "Siempre positivo. Se ajusta mediante las barras de tracción ajustables. Mantén ambos lados dentro de 0,5° y no superes los ~5,5°."
+        "help": "Siempre positivo. Los coches de calle atmosféricos llevan unos 3°; la sobrealimentación pide 5–6.5° para estabilidad bajo presión. Ajústalo mediante barras de empuje regulables e iguala ambos lados con una diferencia máxima de 0.5°."
       },
       "frontToe": {
         "label": "Convergencia delantera (total)",
@@ -584,28 +596,6 @@
         "help": "Positiva = convergencia (obligatoria para la estabilidad en carretera). Negativa (divergencia) es solo para competición. Se ajusta mediante suplementos o soportes ajustables."
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "Carretera estándar",
-        "rationale": "Geometría del manual de taller de fábrica. Fíjate en que la caída delantera es positiva (+2°) y el delantero lleva ligera divergencia — ambos son correctos para el Mini, no son errores. El trasero lleva 1/8\" de convergencia para la estabilidad en línea recta."
-      },
-      "fastRoad": {
-        "name": "Carretera rápida",
-        "rationale": "Entrada en curva más afilada que la estándar, pero apta para calle y suave con los neumáticos. Pasa la caída delantera a negativa para mantener plano el neumático cargado durante el balanceo de la carrocería, con algo más de avance para el autocentrado. Conserva una leve divergencia delantera y menos convergencia trasera."
-      },
-      "trackDay": {
-        "name": "Día de circuito",
-        "rationale": "Máximo agarre en curva con neumáticos de calle o semislick; acepta un desgaste más rápido de los neumáticos. Más caída delantera negativa y más avance; el trasero se ajusta recto para dejar que la parte trasera rote en la entrada. El neumático marca el límite de caída — verifícalo en un banco."
-      },
-      "boostedRoad": {
-        "name": "Carretera sobrealimentada",
-        "rationale": "Coche de calle turbo o sobrealimentado. El cambio clave es ajustar la convergencia delantera en paralelo (cero) para reducir el tiro de par y mejorar la salida desde parado, con un buen avance para la estabilidad bajo potencia y más convergencia trasera para la tracción."
-      },
-      "boostedTrack": {
-        "name": "Circuito sobrealimentado",
-        "rationale": "Coche de circuito de alta potencia con sobrealimentación — el preajuste más extrapolado, así que trátalo solo como punto de partida. Caída y avance delanteros agresivos con apenas una pequeña divergencia delantera para que la potencia siga llegando al suelo, más una leve convergencia trasera para la estabilidad bajo aceleración."
-      }
-    },
     "confidence": {
       "high": "Confianza alta",
       "medium": "Media",
@@ -613,9 +603,9 @@
     },
     "warnings": {
       "rearToeOut": "La divergencia trasera puede provocar sobreviraje brusco — solo apta para conductores experimentados en una configuración de rotación de pura competición.",
-      "casterHigh": "Un avance superior a 5,5° está más allá del límite práctico habitual y aumenta mucho el esfuerzo de dirección.",
       "rearCamberPositive": "La caída trasera positiva vuelve nerviosa la parte trasera — el eje trasero debe llevar de neutra a ligeramente negativa.",
-      "frontCamberPositive": "La caída delantera positiva es el valor de fábrica para los neumáticos diagonales estrechos; la mayoría de las configuraciones modernas llevan negativa para mejorar el agarre."
+      "frontCamberPositive": "La caída delantera positiva es el valor de fábrica para los neumáticos diagonales estrechos; la mayoría de las configuraciones modernas llevan negativa para mejorar el agarre.",
+      "casterHigh": "Un avance muy alto significa una dirección pesada a baja velocidad. Eso es normal en un Mini turbo o sobrealimentado (5–6.5°), pero es mucho para un coche atmosférico."
     },
     "save": {
       "button": "Guardar configuración",
@@ -635,7 +625,33 @@
     "load": {
       "button": "Cargar guardada"
     },
-    "disclaimer": "Estos son puntos de partida, no dogmas. Verifica siempre en un banco de alineación adecuado (la convergencia medida a ojo suele estar mal por 1/8\" o más), iguala el avance y la caída entre ambos lados dentro de 0,5° y vuelve a comprobar tras cualquier cambio de altura de marcha. La alineación solo dompta parcialmente el tiro de par en un Mini sobrealimentado."
+    "disclaimer": "Estos son puntos de partida, no dogmas. Verifica siempre en un banco de alineación adecuado (la convergencia medida a ojo suele estar mal por 1/8\" o más), iguala el avance y la caída entre ambos lados dentro de 0,5° y vuelve a comprobar tras cualquier cambio de altura de marcha. La alineación solo dompta parcialmente el tiro de par en un Mini sobrealimentado.",
+    "presets": {
+      "factory": {
+        "name": "De fábrica",
+        "rationale": "La geometría del manual de taller de fábrica. La caída delantera es positiva (+2°) y el tren delantero abre ligeramente en convergencia: ambos valores son correctos para el Mini, no erratas. El tren trasero lleva 1/8\" de convergencia. Una referencia fiel; la mayoría de los reglajes modernos la mejoran."
+      },
+      "stockRoad": {
+        "name": "Calle de serie",
+        "rationale": "Geometría de fábrica afinada para neumáticos radiales modernos: la incómoda caída delantera positiva se reduce a una suave -0.5° para algo más de agarre y un desgaste uniforme, dejando todo lo demás casi de serie. El reglaje fácil y cómodo para uso diario."
+      },
+      "performance": {
+        "name": "Deportivo",
+        "rationale": "Un reglaje de calle más afilado. Más caída negativa delantera mantiene el neumático cargado plano durante el balanceo de la carrocería, algo más de avance añade autocentrado, y una convergencia trasera más ligera suelta el coche. Sigue siendo apto para carretera, con algo más de desgaste de neumáticos."
+      },
+      "track": {
+        "name": "Circuito",
+        "rationale": "Máximo agarre en curva con neumáticos de carretera o semislick, asumiendo un desgaste más rápido. Más caída negativa delantera y más avance, con el tren trasero recto para que rote al entrar en curva. El neumático fija el techo de caída: verifícalo en banco."
+      },
+      "boostedRoad": {
+        "name": "Calle sobrealim.",
+        "rationale": "Coche de calle turbo o sobrealimentado. Convergencia delantera ajustada en paralelo (cero) para reducir el tiro de par y transmitir la potencia, con avance alto (6°) para estabilidad en línea recta bajo sobrealimentación y una mayor convergencia trasera para tracción."
+      },
+      "boostedTrack": {
+        "name": "Circuito sobrealim.",
+        "rationale": "Coche de circuito sobrealimentado de alta potencia. Caída delantera agresiva con mucho avance (6.5°) para estabilidad y ganancia de caída, una ligera apertura delantera para que la potencia siga transmitiéndose, y suave convergencia trasera. Un punto de partida: verifícalo en banco y equilibra los pesos por rueda."
+      }
+    }
   },
   "fr": {
     "presets_title": "Partir d'un préréglage",
@@ -663,7 +679,7 @@
       },
       "frontCaster": {
         "label": "Chasse avant",
-        "help": "Toujours positive. Réglée via des barres de réaction réglables. Gardez les deux côtés à 0,5° près et ne dépassez pas ~5,5°."
+        "help": "Toujours positive. Les voitures de route atmosphériques tournent autour de 3° ; la suralimentation demande 5–6,5° pour la stabilité sous suralimentation. À régler via des barres de poussée réglables et à équilibrer entre les deux côtés à 0,5° près."
       },
       "frontToe": {
         "label": "Parallélisme avant (total)",
@@ -678,28 +694,6 @@
         "help": "Positif = pincement (obligatoire pour la stabilité sur route). Négatif (ouverture) réservé à la compétition. Réglé via des cales ou des supports réglables."
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "Route d'origine",
-        "rationale": "Géométrie du manuel d'atelier d'usine. Notez que le carrossage avant est positif (+2°) et que l'avant roule en légère ouverture — les deux sont corrects pour la Mini, ce ne sont pas des erreurs. L'arrière roule avec 1/8\" de pincement pour la stabilité en ligne droite."
-      },
-      "fastRoad": {
-        "name": "Route sportive",
-        "rationale": "Mise en virage plus incisive que d'origine tout en restant utilisable sur route et indulgent pour les pneus. Passe le carrossage avant en négatif pour garder le pneu chargé à plat dans le roulis, avec un peu plus de chasse pour le rappel. Conserve une légère ouverture à l'avant et un pincement plus léger à l'arrière."
-      },
-      "trackDay": {
-        "name": "Journée circuit",
-        "rationale": "Adhérence maximale en virage sur pneus route ou semi-slicks ; accepte une usure plus rapide des pneus. Carrossage avant plus négatif et plus de chasse ; arrière réglé droit pour laisser l'arrière pivoter en entrée de virage. Le pneu fixe le plafond de carrossage — vérifiez sur un banc."
-      },
-      "boostedRoad": {
-        "name": "Route suralimentée",
-        "rationale": "Voiture de route turbo ou compressée. Le changement clé est le parallélisme avant réglé parallèle (zéro) pour réduire l'effet de couple dans la direction et améliorer la motricité au départ, avec une bonne dose de chasse pour la stabilité en charge et un pincement arrière plus important pour la traction."
-      },
-      "boostedTrack": {
-        "name": "Circuit suralimenté",
-        "rationale": "Voiture de circuit suralimentée à forte puissance — le préréglage le plus extrapolé, à considérer donc uniquement comme un point de départ. Carrossage et chasse avant agressifs avec seulement une petite ouverture avant pour que la puissance passe au sol, plus un léger pincement arrière pour la stabilité à l'accélération."
-      }
-    },
     "confidence": {
       "high": "Confiance élevée",
       "medium": "Moyenne",
@@ -707,9 +701,9 @@
     },
     "warnings": {
       "rearToeOut": "Une ouverture à l'arrière peut provoquer un survirage brutal — réservée aux pilotes expérimentés sur une configuration de pivotement full-race.",
-      "casterHigh": "Une chasse supérieure à 5,5° dépasse la limite pratique habituelle et alourdit fortement la direction.",
       "rearCamberPositive": "Un carrossage arrière positif rend l'arrière nerveux — l'arrière doit rouler de neutre à légèrement négatif.",
-      "frontCamberPositive": "Le carrossage avant positif est la valeur d'usine pour les pneus diagonaux étroits ; la plupart des configurations modernes roulent en négatif pour l'adhérence."
+      "frontCamberPositive": "Le carrossage avant positif est la valeur d'usine pour les pneus diagonaux étroits ; la plupart des configurations modernes roulent en négatif pour l'adhérence.",
+      "casterHigh": "Une chasse très élevée rend la direction lourde à basse vitesse. C'est normal sur une Mini turbo ou compressée (5–6,5°) mais beaucoup pour une voiture atmosphérique."
     },
     "save": {
       "button": "Enregistrer le réglage",
@@ -729,7 +723,33 @@
     "load": {
       "button": "Charger un enregistrement"
     },
-    "disclaimer": "Ce sont des points de départ, pas des vérités absolues. Vérifiez toujours sur un banc de géométrie approprié (le parallélisme estimé à l'œil est souvent faux de 1/8\" ou plus), faites correspondre chasse et carrossage côté à côté à 0,5° près, et revérifiez après tout changement de hauteur de caisse. La géométrie ne maîtrise que partiellement l'effet de couple dans la direction sur une Mini suralimentée."
+    "disclaimer": "Ce sont des points de départ, pas des vérités absolues. Vérifiez toujours sur un banc de géométrie approprié (le parallélisme estimé à l'œil est souvent faux de 1/8\" ou plus), faites correspondre chasse et carrossage côté à côté à 0,5° près, et revérifiez après tout changement de hauteur de caisse. La géométrie ne maîtrise que partiellement l'effet de couple dans la direction sur une Mini suralimentée.",
+    "presets": {
+      "factory": {
+        "name": "Origine",
+        "rationale": "La géométrie d'origine du manuel d'atelier. Le carrossage avant est positif (+2°) et l'avant présente un léger parallélisme ouvert — les deux sont corrects pour la Mini, ce ne sont pas des erreurs. L'arrière tourne avec un parallélisme fermé de 1/8\". Une base fidèle ; la plupart des réglages modernes l'améliorent."
+      },
+      "stockRoad": {
+        "name": "Route d'origine",
+        "rationale": "Géométrie d'origine remise au goût des pneus radiaux modernes : le carrossage avant positif peu commode ramené à un léger -0,5° pour un peu plus d'adhérence et une usure régulière, tout le reste laissé proche de l'origine. Le réglage facile et confortable pour un usage quotidien."
+      },
+      "performance": {
+        "name": "Sport",
+        "rationale": "Un réglage routier plus incisif. Davantage de carrossage avant négatif garde le pneu chargé à plat dans le roulis de caisse, un peu plus de chasse renforce le rappel au centre, et un parallélisme arrière allégé libère la voiture. Reste utilisable sur route, avec une usure des pneus un peu plus marquée."
+      },
+      "track": {
+        "name": "Circuit",
+        "rationale": "Adhérence maximale en virage sur pneus route ou semi-slicks, au prix d'une usure plus rapide. Plus de carrossage avant négatif et de chasse, avec l'arrière réglé droit pour le laisser pivoter à l'inscription en virage. Le pneu fixe la limite de carrossage — à vérifier sur banc."
+      },
+      "boostedRoad": {
+        "name": "Route suralim.",
+        "rationale": "Voiture de route turbo ou compressée. Parallélisme avant réglé parallèle (zéro) pour réduire l'effet de couple dans la direction et faire passer la puissance, avec une chasse élevée (6°) pour la stabilité en ligne droite sous suralimentation et un parallélisme arrière fermé plus marqué pour la motricité."
+      },
+      "boostedTrack": {
+        "name": "Circuit suralim.",
+        "rationale": "Voiture de circuit suralimentée à forte puissance. Carrossage avant agressif avec beaucoup de chasse (6,5°) pour la stabilité et le gain de carrossage, un léger parallélisme avant ouvert pour que la puissance passe toujours, et un parallélisme arrière fermé modéré. Un point de départ — à vérifier sur banc et à équilibrer aux masses par roue."
+      }
+    }
   },
   "de": {
     "presets_title": "Mit einer Voreinstellung beginnen",
@@ -757,7 +777,7 @@
       },
       "frontCaster": {
         "label": "Nachlauf vorne",
-        "help": "Immer positiv. Über verstellbare Zugstreben eingestellt. Beide Seiten auf 0,5° halten und ~5,5° nicht überschreiten."
+        "help": "Immer positiv. Saugmotor-Straßenfahrzeuge laufen etwa 3°; Aufladung verlangt 5–6,5° für Stabilität unter Ladedruck. Über verstellbare Zugstreben einstellen und beide Seiten innerhalb von 0,5° abgleichen."
       },
       "frontToe": {
         "label": "Spur vorne (gesamt)",
@@ -772,28 +792,6 @@
         "help": "Positiv = Vorspur (zwingend erforderlich für Straßenstabilität). Negativ (Nachspur) ist nur für den Rennsport. Über Distanzscheiben oder verstellbare Halterungen eingestellt."
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "Serie Straße",
-        "rationale": "Werksgeometrie aus dem Werkstatthandbuch. Beachte, dass der Sturz vorne positiv ist (+2°) und vorne leichte Nachspur läuft — beides ist beim Mini korrekt, keine Tippfehler. Hinten läuft 1/8\" Vorspur für Geradeauslaufstabilität."
-      },
-      "fastRoad": {
-        "name": "Schnelle Straße",
-        "rationale": "Schärferes Einlenken als Serie, dabei alltagstauglich und reifenschonend. Kippt den Sturz vorne ins Negative, damit der belastete Reifen bei Wankbewegungen flach bleibt, mit etwas mehr Nachlauf für die Selbstzentrierung. Behält milde Nachspur vorne und leichtere Vorspur hinten bei."
-      },
-      "trackDay": {
-        "name": "Trackday",
-        "rationale": "Maximaler Kurvengrip auf Straßen- oder Semislick-Reifen; nimmt schnelleren Reifenverschleiß in Kauf. Mehr negativer Sturz vorne und mehr Nachlauf; hinten auf parallel gestellt, damit das Heck beim Einlenken eindreht. Der Reifen gibt die Sturzobergrenze vor — auf dem Prüfstand verifizieren."
-      },
-      "boostedRoad": {
-        "name": "Aufgeladen Straße",
-        "rationale": "Turbo- oder kompressoraufgeladenes Straßenfahrzeug. Die wichtigste Änderung ist die Spur vorne auf parallel (null), um Antriebseinflüsse auf die Lenkung zu reduzieren und den Vortrieb von der Linie weg zu verbessern, mit ausreichend Nachlauf für Stabilität unter Last und größerer Vorspur hinten für Traktion."
-      },
-      "boostedTrack": {
-        "name": "Aufgeladen Rennstrecke",
-        "rationale": "Hochleistungs-Rennstreckenfahrzeug mit Aufladung — die am weitesten extrapolierte Voreinstellung, daher nur als Ausgangspunkt behandeln. Aggressiver Sturz und Nachlauf vorne mit nur geringer Nachspur vorne, damit die Leistung noch auf die Straße kommt, plus milde Vorspur hinten für Stabilität unter Beschleunigung."
-      }
-    },
     "confidence": {
       "high": "Hohe Verlässlichkeit",
       "medium": "Mittel",
@@ -801,9 +799,9 @@
     },
     "warnings": {
       "rearToeOut": "Nachspur hinten kann zu plötzlichem Übersteuern führen — nur geeignet für erfahrene Fahrer mit einem reinen Renn-Setup auf Eindrehen.",
-      "casterHigh": "Ein Nachlauf über 5,5° liegt jenseits der üblichen praktischen Grenze und erhöht die Lenkkräfte erheblich.",
       "rearCamberPositive": "Positiver Sturz hinten macht das Heck nervös — hinten sollte neutral bis leicht negativ laufen.",
-      "frontCamberPositive": "Positiver Sturz vorne ist der Werkswert für schmale Diagonalreifen; die meisten modernen Setups laufen für den Grip negativ."
+      "frontCamberPositive": "Positiver Sturz vorne ist der Werkswert für schmale Diagonalreifen; die meisten modernen Setups laufen für den Grip negativ.",
+      "casterHigh": "Sehr hoher Nachlauf bedeutet schwergängige Lenkung bei niedrigen Geschwindigkeiten. Das ist bei einem Turbo- oder Kompressor-Mini normal (5–6,5°), aber viel für ein Saugmotor-Fahrzeug."
     },
     "save": {
       "button": "Setup speichern",
@@ -823,7 +821,33 @@
     "load": {
       "button": "Gespeicherte laden"
     },
-    "disclaimer": "Dies sind Ausgangspunkte, kein Dogma. Verifiziere immer auf einem ordentlichen Achsvermessungsstand (per Augenmaß geschätzte Spur liegt häufig um 1/8\" oder mehr daneben), gleiche Nachlauf und Sturz seitenweise auf 0,5° ab und überprüfe nach jeder Änderung der Fahrzeughöhe erneut. Die Achsvermessung zähmt Antriebseinflüsse auf die Lenkung bei einem aufgeladenen Mini nur teilweise."
+    "disclaimer": "Dies sind Ausgangspunkte, kein Dogma. Verifiziere immer auf einem ordentlichen Achsvermessungsstand (per Augenmaß geschätzte Spur liegt häufig um 1/8\" oder mehr daneben), gleiche Nachlauf und Sturz seitenweise auf 0,5° ab und überprüfe nach jeder Änderung der Fahrzeughöhe erneut. Die Achsvermessung zähmt Antriebseinflüsse auf die Lenkung bei einem aufgeladenen Mini nur teilweise.",
+    "presets": {
+      "factory": {
+        "name": "Werkseinstellung",
+        "rationale": "Die Geometrie nach Werkstatthandbuch. Der vordere Sturz ist positiv (+2°) und die Vorderachse hat leichte Vorspur (toe-out) — beides beim Mini korrekt, keine Tippfehler. Hinten läuft 1/8\" Nachspur (toe-in). Eine getreue Ausgangsbasis; die meisten modernen Setups verbessern sie."
+      },
+      "stockRoad": {
+        "name": "Serie Straße",
+        "rationale": "Werksgeometrie aufgeräumt für moderne Radialreifen: der unglückliche positive vordere Sturz auf milde -0,5° zurückgenommen für etwas mehr Grip und gleichmäßigeren Verschleiß, alles andere nah an Serie belassen. Das einfache, komfortable Setup für den Alltag."
+      },
+      "performance": {
+        "name": "Performance",
+        "rationale": "Ein schärferes Straßen-Setup. Mehr negativer vorderer Sturz hält den belasteten Reifen bei Karosserieneigung flach, etwas mehr Nachlauf verbessert die Rückstellung, und leichtere hintere Nachspur macht das Auto agiler. Weiterhin straßentauglich, mit etwas mehr Reifenverschleiß."
+      },
+      "track": {
+        "name": "Rennstrecke",
+        "rationale": "Maximaler Kurvengrip auf Straßen- oder Semislick-Reifen, bei schnellerem Reifenverschleiß. Mehr negativer vorderer Sturz und Nachlauf, hinten auf neutral gestellt, damit das Auto beim Einlenken eindreht. Der Reifen setzt die Sturz-Obergrenze — auf dem Prüfstand verifizieren."
+      },
+      "boostedRoad": {
+        "name": "Aufgeladen Straße",
+        "rationale": "Turbo- oder Kompressor-Straßenfahrzeug. Vorderachse auf parallel (null) gestellt, um Antriebseinflüsse auf die Lenkung zu reduzieren und die Leistung umzusetzen, mit hohem Nachlauf (6°) für Geradeauslaufstabilität unter Ladedruck und größerer hinterer Nachspur für Traktion."
+      },
+      "boostedTrack": {
+        "name": "Aufgeladen Rennstrecke",
+        "rationale": "Leistungsstarkes aufgeladenes Rennstreckenfahrzeug. Aggressiver vorderer Sturz mit viel Nachlauf (6,5°) für Stabilität und Sturzzunahme, leichte vordere Vorspur (toe-out), damit die Leistung dennoch umgesetzt wird, und milde hintere Nachspur. Ein Ausgangspunkt — auf dem Prüfstand verifizieren und Radlasten einstellen."
+      }
+    }
   },
   "it": {
     "presets_title": "Parti da un preset",
@@ -851,7 +875,7 @@
       },
       "frontCaster": {
         "label": "Incidenza anteriore",
-        "help": "Sempre positiva. Si imposta con i tiranti regolabili. Mantieni i due lati entro 0,5° e non superare i ~5,5°."
+        "help": "Sempre positiva. Le vetture stradali aspirate hanno circa 3°; quelle sovralimentate richiedono 5–6,5° per la stabilità sotto sovralimentazione. Si regola tramite tie-bar registrabili e va abbinata su entrambi i lati entro 0,5°."
       },
       "frontToe": {
         "label": "Convergenza anteriore (totale)",
@@ -866,28 +890,6 @@
         "help": "Positiva = convergenza (obbligatoria per la stabilità su strada). Negativa (divergenza) è solo per le competizioni. Si imposta con spessori o staffe regolabili."
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "Strada di serie",
-        "rationale": "Geometria del manuale d'officina di serie. Nota che la campanatura anteriore è positiva (+2°) e l'anteriore lavora in leggera divergenza — entrambi sono corretti per la Mini, non errori. Il posteriore lavora con 1/8\" di convergenza per la stabilità in rettilineo."
-      },
-      "fastRoad": {
-        "name": "Strada sportiva",
-        "rationale": "Inserimento in curva più reattivo rispetto a quello di serie, restando guidabile su strada e poco usurante per gli pneumatici. Rende la campanatura anteriore negativa per mantenere a contatto lo pneumatico carico durante il rollio, con un po' più di incidenza per l'autocentraggio. Mantiene una lieve divergenza anteriore e una convergenza posteriore più leggera."
-      },
-      "trackDay": {
-        "name": "Giornata in pista",
-        "rationale": "Massima aderenza in curva su pneumatici stradali o semi-slick; accetta un'usura più rapida degli pneumatici. Maggiore campanatura anteriore negativa e più incidenza; posteriore impostato dritto per far ruotare il retrotreno in inserimento. Lo pneumatico fissa il limite massimo di campanatura — verifica su un banco."
-      },
-      "boostedRoad": {
-        "name": "Strada sovralimentata",
-        "rationale": "Auto da strada turbo o sovralimentata. La modifica chiave è la convergenza anteriore impostata parallela (zero) per ridurre il torque steer e migliorare la trazione in partenza, con un'incidenza generosa per la stabilità sotto carico e una maggiore convergenza posteriore per la trazione."
-      },
-      "boostedTrack": {
-        "name": "Pista sovralimentata",
-        "rationale": "Auto da circuito a sovralimentazione e alta potenza — il preset più estrapolato, quindi consideralo solo come punto di partenza. Campanatura e incidenza anteriori aggressive con solo una leggera divergenza anteriore per far comunque scaricare la potenza, più una lieve convergenza posteriore per la stabilità in accelerazione."
-      }
-    },
     "confidence": {
       "high": "Affidabilità alta",
       "medium": "Media",
@@ -895,9 +897,9 @@
     },
     "warnings": {
       "rearToeOut": "La divergenza posteriore può causare sovrasterzo improvviso — adatta solo a piloti esperti in un assetto da rotazione full-race.",
-      "casterHigh": "Un'incidenza superiore a 5,5° supera il consueto limite pratico e aumenta notevolmente lo sforzo allo sterzo.",
       "rearCamberPositive": "Una campanatura posteriore positiva rende il retrotreno nervoso — il posteriore dovrebbe lavorare da neutro a lievemente negativo.",
-      "frontCamberPositive": "La campanatura anteriore positiva è il valore di serie per gli stretti pneumatici crossply; la maggior parte degli assetti moderni usa valori negativi per l'aderenza."
+      "frontCamberPositive": "La campanatura anteriore positiva è il valore di serie per gli stretti pneumatici crossply; la maggior parte degli assetti moderni usa valori negativi per l'aderenza.",
+      "casterHigh": "Un'incidenza molto elevata comporta uno sterzo pesante a bassa velocità. È normale su una Mini turbo o con compressore volumetrico (5–6,5°) ma è molto per una vettura aspirata."
     },
     "save": {
       "button": "Salva configurazione",
@@ -917,7 +919,33 @@
     "load": {
       "button": "Carica salvati"
     },
-    "disclaimer": "Questi sono punti di partenza, non verità assolute. Verifica sempre su un banco di allineamento adeguato (la convergenza valutata a occhio è spesso sbagliata di 1/8\" o più), allinea incidenza e campanatura tra i due lati entro 0,5° e ricontrolla dopo ogni modifica dell'altezza da terra. L'allineamento attenua solo in parte il torque steer su una Mini sovralimentata."
+    "disclaimer": "Questi sono punti di partenza, non verità assolute. Verifica sempre su un banco di allineamento adeguato (la convergenza valutata a occhio è spesso sbagliata di 1/8\" o più), allinea incidenza e campanatura tra i due lati entro 0,5° e ricontrolla dopo ogni modifica dell'altezza da terra. L'allineamento attenua solo in parte il torque steer su una Mini sovralimentata.",
+    "presets": {
+      "factory": {
+        "name": "Originale",
+        "rationale": "La geometria del manuale d'officina originale. Il campanatura anteriore è positiva (+2°) e l'anteriore ha una leggera convergenza negativa (toe-out) — entrambi corretti per la Mini, non errori. Il posteriore ha 1/8\" di convergenza positiva (toe-in). Una base fedele all'originale; la maggior parte degli assetti moderni la migliora."
+      },
+      "stockRoad": {
+        "name": "Strada Standard",
+        "rationale": "Geometria originale rivista per i moderni pneumatici radiali: la scomoda campanatura anteriore positiva ridotta a un lieve -0,5° per un po' più di aderenza e un'usura più uniforme, tutto il resto lasciato vicino all'originale. L'assetto facile e confortevole per l'uso quotidiano."
+      },
+      "performance": {
+        "name": "Sportivo",
+        "rationale": "Un assetto stradale più incisivo. Una campanatura anteriore più negativa mantiene piatto lo pneumatico sotto carico durante il rollio, un po' più di incidenza aumenta l'autoallineamento, e una convergenza posteriore più leggera rende la vettura più libera. Ancora adatto alla strada, con un'usura degli pneumatici leggermente maggiore."
+      },
+      "track": {
+        "name": "Pista",
+        "rationale": "Massima aderenza in curva su pneumatici stradali o semi-slick, accettando un'usura più rapida degli pneumatici. Campanatura e incidenza anteriori più negative, con il posteriore impostato dritto per favorire la rotazione in inserimento. Lo pneumatico determina il limite di campanatura — verificare al banco."
+      },
+      "boostedRoad": {
+        "name": "Strada Sovralimentata",
+        "rationale": "Vettura stradale turbo o con compressore volumetrico. Convergenza anteriore impostata parallela (zero) per ridurre il torque steer e scaricare a terra la potenza, con incidenza elevata (6°) per la stabilità in rettilineo sotto sovralimentazione e una maggiore convergenza positiva al posteriore per la trazione."
+      },
+      "boostedTrack": {
+        "name": "Pista Sovralimentata",
+        "rationale": "Vettura da circuito ad alta potenza sovralimentata. Campanatura anteriore aggressiva con molta incidenza (6,5°) per stabilità e recupero di campanatura, una leggera convergenza negativa all'anteriore così la potenza arriva comunque a terra, e una lieve convergenza positiva al posteriore. Un punto di partenza — verificare al banco e bilanciare i pesi alle ruote."
+      }
+    }
   },
   "pt": {
     "presets_title": "Comece a partir de uma predefinição",
@@ -945,7 +973,7 @@
       },
       "frontCaster": {
         "label": "Cáster dianteiro",
-        "help": "Sempre positivo. Definido através de barras de ligação ajustáveis. Mantenha ambos os lados dentro de 0,5° e não exceda ~5,5°."
+        "help": "Sempre positivo. Os carros de estrada atmosféricos têm cerca de 3°; a sobrealimentação pede 5–6.5° para estabilidade sob pressão de admissão. Ajuste através das barras tensoras reguláveis e iguale ambos os lados a menos de 0.5°."
       },
       "frontToe": {
         "label": "Convergência dianteira (total)",
@@ -960,28 +988,6 @@
         "help": "Positiva = convergência (obrigatória para estabilidade em estrada). Negativa (divergência) é só para competição. Definida através de calços ou suportes ajustáveis."
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "Estrada de Série",
-        "rationale": "Geometria do manual de oficina de fábrica. Repare que a cambagem dianteira é positiva (+2°) e o dianteiro corre com ligeira divergência — ambos estão corretos para o Mini, não são erros. A traseira corre com 1/8\" de convergência para estabilidade em linha reta."
-      },
-      "fastRoad": {
-        "name": "Estrada Rápida",
-        "rationale": "Entrada em curva mais incisiva do que a de série, mantendo-se utilizável na estrada e suave para os pneus. Inverte a cambagem dianteira para negativa de modo a manter o pneu carregado plano durante a inclinação da carroçaria, com um pouco mais de cáster para autocentragem. Mantém ligeira divergência dianteira e convergência traseira mais leve."
-      },
-      "trackDay": {
-        "name": "Dia de Pista",
-        "rationale": "Aderência máxima em curva com pneus de estrada ou semi-slick; aceita um desgaste mais rápido dos pneus. Mais cambagem dianteira negativa e mais cáster; a traseira definida a direito para deixar a parte de trás rodar na entrada da curva. O pneu define o limite máximo de cambagem — verifique numa bancada."
-      },
-      "boostedRoad": {
-        "name": "Estrada Turbo",
-        "rationale": "Carro de rua turbo ou sobrealimentado. A alteração-chave é a convergência dianteira definida paralela (zero) para reduzir o efeito de torque na direção e melhorar a tração na arrancada, com cáster saudável para estabilidade sob potência e maior convergência traseira para tração."
-      },
-      "boostedTrack": {
-        "name": "Pista Turbo",
-        "rationale": "Carro de circuito de indução forçada de alta potência — a predefinição mais extrapolada, por isso trate-a apenas como ponto de partida. Cambagem e cáster dianteiros agressivos com apenas uma pequena divergência dianteira para a potência ainda ir ao chão, mais ligeira convergência traseira para estabilidade sob aceleração."
-      }
-    },
     "confidence": {
       "high": "Confiança alta",
       "medium": "Média",
@@ -989,9 +995,9 @@
     },
     "warnings": {
       "rearToeOut": "A divergência traseira pode causar sobreviragem brusca — só adequada para condutores experientes numa configuração de rotação de competição total.",
-      "casterHigh": "Cáster acima de 5,5° está além do limite prático habitual e acrescenta um esforço de direção pesado.",
       "rearCamberPositive": "A cambagem traseira positiva torna a traseira nervosa — a traseira deve correr entre neutra e ligeiramente negativa.",
-      "frontCamberPositive": "A cambagem dianteira positiva é o valor de fábrica para os pneus diagonais estreitos; a maioria das configurações modernas corre negativa para aderência."
+      "frontCamberPositive": "A cambagem dianteira positiva é o valor de fábrica para os pneus diagonais estreitos; a maioria das configurações modernas corre negativa para aderência.",
+      "casterHigh": "Um avance muito elevado significa uma direção pesada a baixa velocidade. Isso é normal num Mini turbo ou sobrealimentado (5–6.5°), mas é muito para um carro atmosférico."
     },
     "save": {
       "button": "Guardar configuração",
@@ -1011,7 +1017,33 @@
     "load": {
       "button": "Carregar guardada"
     },
-    "disclaimer": "Estes são pontos de partida, não dogmas. Verifique sempre numa bancada de alinhamento adequada (a convergência avaliada a olho está frequentemente errada em 1/8\" ou mais), iguale o cáster e a cambagem de lado a lado dentro de 0,5°, e volte a verificar após qualquer alteração da altura de rodagem. O alinhamento só dompta parcialmente o efeito de torque na direção num Mini turbo."
+    "disclaimer": "Estes são pontos de partida, não dogmas. Verifique sempre numa bancada de alinhamento adequada (a convergência avaliada a olho está frequentemente errada em 1/8\" ou mais), iguale o cáster e a cambagem de lado a lado dentro de 0,5°, e volte a verificar após qualquer alteração da altura de rodagem. O alinhamento só dompta parcialmente o efeito de torque na direção num Mini turbo.",
+    "presets": {
+      "factory": {
+        "name": "Fábrica",
+        "rationale": "A geometria do manual de oficina de fábrica. A caída dianteira é positiva (+2°) e a dianteira tem uma ligeira convergência negativa (toe-out) — ambas corretas para o Mini, não são erros. A traseira tem 1/8\" de convergência positiva (toe-in). Uma base fiel; a maioria das configurações modernas melhora-a."
+      },
+      "stockRoad": {
+        "name": "Estrada Original",
+        "rationale": "Geometria de fábrica acertada para pneus radiais modernos: a desajeitada caída dianteira positiva reduzida para uns suaves -0.5° para um pouco mais de aderência e desgaste uniforme, deixando todo o resto próximo do original. A configuração fácil e confortável para uso diário."
+      },
+      "performance": {
+        "name": "Desportivo",
+        "rationale": "Uma configuração de estrada mais incisiva. Mais caída dianteira negativa mantém o pneu carregado plano durante o rolamento da carroçaria, um pouco mais de avance acrescenta auto-centragem, e uma convergência positiva traseira mais ligeira solta o carro. Ainda adequado para a estrada, com um pouco mais de desgaste dos pneus."
+      },
+      "track": {
+        "name": "Pista",
+        "rationale": "Aderência máxima em curva com pneus de estrada ou semi-slick, aceitando um desgaste mais rápido dos pneus. Mais caída dianteira negativa e avance, com a traseira ajustada a direito para deixá-la rodar na entrada da curva. O pneu define o limite da caída — verifique num alinhador."
+      },
+      "boostedRoad": {
+        "name": "Estrada Turbo",
+        "rationale": "Carro de estrada turbo ou sobrealimentado. Convergência dianteira ajustada paralela (zero) para reduzir o torque steer e transmitir a potência ao solo, com avance elevado (6°) para estabilidade em linha reta sob pressão de admissão e uma maior convergência positiva traseira para tração."
+      },
+      "boostedTrack": {
+        "name": "Pista Turbo",
+        "rationale": "Carro de circuito de sobrealimentação de alta potência. Caída dianteira agressiva com bastante avance (6.5°) para estabilidade e ganho de caída, uma pequena convergência negativa dianteira (toe-out) para a potência continuar a chegar ao solo, e uma convergência positiva traseira suave. Um ponto de partida — verifique num alinhador e faça o corner-weight."
+      }
+    }
   },
   "ru": {
     "presets_title": "Начните с пресета",
@@ -1039,7 +1071,7 @@
       },
       "frontCaster": {
         "label": "Передний кастер",
-        "help": "Всегда положительный. Регулируется через регулируемые продольные тяги. Держите обе стороны в пределах 0,5° и не превышайте ~5.5°."
+        "help": "Всегда положительный. Атмосферные дорожные автомобили работают примерно на 3°; для наддувных нужно 5–6.5° для устойчивости под наддувом. Настраивается регулируемыми тягами; разница между сторонами не более 0.5°."
       },
       "frontToe": {
         "label": "Переднее схождение (всего)",
@@ -1054,28 +1086,6 @@
         "help": "Положительное = схождение (обязательно для устойчивости на дороге). Отрицательное (расхождение) только для гонок. Регулируется прокладками или регулируемыми кронштейнами."
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "Сток дорога",
-        "rationale": "Геометрия из заводского руководства. Обратите внимание: передний развал положительный (+2°), а спереди задано небольшое расхождение — для Mini это правильно, а не опечатки. Сзади задано схождение 1/8\" для устойчивости по прямой."
-      },
-      "fastRoad": {
-        "name": "Спорт дорога",
-        "rationale": "Более острый вход в поворот, чем у стока, при этом пригоден для улицы и щадит шины. Делает передний развал отрицательным, чтобы нагруженная шина оставалась плоской при кренах кузова, с чуть большим кастером для самовозврата руля. Сохраняет умеренное переднее расхождение и меньшее заднее схождение."
-      },
-      "trackDay": {
-        "name": "Трек-день",
-        "rationale": "Максимальное сцепление в поворотах на дорожных или полуслик-шинах; за это платите ускоренным износом шин. Больше отрицательного переднего развала и больше кастера; сзади задано прямо, чтобы корма доворачивалась при входе в поворот. Предел развала задаёт шина — проверяйте на стенде."
-      },
-      "boostedRoad": {
-        "name": "Наддув дорога",
-        "rationale": "Уличный автомобиль с турбонаддувом или компрессором. Ключевое изменение — переднее схождение выставлено параллельно (ноль), чтобы убрать рулевой увод от тяги и улучшить разгон со старта, со здоровым кастером для устойчивости под нагрузкой и большим задним схождением для сцепления."
-      },
-      "boostedTrack": {
-        "name": "Наддув трек",
-        "rationale": "Мощный трековый автомобиль с наддувом — самый экстраполированный пресет, поэтому относитесь к нему лишь как к отправной точке. Агрессивные передний развал и кастер с лишь небольшим передним расхождением, чтобы мощность всё же доходила до колёс, плюс умеренное заднее схождение для устойчивости при разгоне."
-      }
-    },
     "confidence": {
       "high": "Высокая достоверность",
       "medium": "Средняя",
@@ -1083,9 +1093,9 @@
     },
     "warnings": {
       "rearToeOut": "Заднее расхождение может вызвать резкую избыточную поворачиваемость — подходит только опытным водителям при чисто гоночной настройке на доворот.",
-      "casterHigh": "Кастер выше 5.5° выходит за обычный практический предел и сильно утяжеляет руль.",
       "rearCamberPositive": "Положительный задний развал делает корму нервной — сзади развал должен быть нейтральным или слегка отрицательным.",
-      "frontCamberPositive": "Положительный передний развал — заводское значение для узких диагональных шин; большинство современных настроек используют отрицательный развал ради сцепления."
+      "frontCamberPositive": "Положительный передний развал — заводское значение для узких диагональных шин; большинство современных настроек используют отрицательный развал ради сцепления.",
+      "casterHigh": "Очень высокий кастор означает тяжёлый руль на малых скоростях. Это нормально для Mini с турбонаддувом или нагнетателем (5–6.5°), но многовато для атмосферного автомобиля."
     },
     "save": {
       "button": "Сохранить настройку",
@@ -1105,7 +1115,33 @@
     "load": {
       "button": "Загрузить сохранённое"
     },
-    "disclaimer": "Это отправные точки, а не истина в последней инстанции. Всегда проверяйте на нормальном стенде развал-схождения (схождение на глаз часто ошибочно на 1/8\" и более), согласуйте кастер и развал по сторонам в пределах 0,5° и перепроверяйте после любого изменения дорожного просвета. Регулировка лишь частично укрощает рулевой увод от тяги на Mini с наддувом."
+    "disclaimer": "Это отправные точки, а не истина в последней инстанции. Всегда проверяйте на нормальном стенде развал-схождения (схождение на глаз часто ошибочно на 1/8\" и более), согласуйте кастер и развал по сторонам в пределах 0,5° и перепроверяйте после любого изменения дорожного просвета. Регулировка лишь частично укрощает рулевой увод от тяги на Mini с наддувом.",
+    "presets": {
+      "factory": {
+        "name": "Заводская",
+        "rationale": "Геометрия из заводского руководства по ремонту. Передний развал положительный (+2°), а спереди небольшая расходимость колёс — для Mini это правильно, а не опечатки. Сзади заданы 1/8\" схождения. Достоверная отправная точка; большинство современных настроек её улучшают."
+      },
+      "stockRoad": {
+        "name": "Сток дорога",
+        "rationale": "Заводская геометрия, приведённая в порядок под современные радиальные шины: неудобный положительный передний развал уменьшен до мягких -0.5° для чуть большего сцепления и равномерного износа, остальное оставлено близко к стоку. Простая, комфортная настройка для повседневной езды."
+      },
+      "performance": {
+        "name": "Спорт",
+        "rationale": "Более острая дорожная настройка. Больше отрицательного переднего развала держит нагруженную шину плоской при кренах кузова, чуть больше кастора добавляет самоцентрирование, а уменьшенное заднее схождение раскрепощает автомобиль. Всё ещё пригодно для дорог, но с чуть большим износом шин."
+      },
+      "track": {
+        "name": "Трек",
+        "rationale": "Максимальное сцепление в поворотах на дорожных или полуслик-шинах ценой ускоренного износа. Больше отрицательного переднего развала и кастора, а зад выставлен прямо, чтобы машина поворачивала на входе. Шина задаёт предел развала — проверьте на стенде."
+      },
+      "boostedRoad": {
+        "name": "Над. дорога",
+        "rationale": "Дорожный автомобиль с турбонаддувом или нагнетателем. Переднее схождение выставлено параллельно (ноль), чтобы убрать рывки руля под тягой и реализовать мощность, с высоким кастором (6°) для прямолинейной устойчивости под наддувом и увеличенным задним схождением для тяги."
+      },
+      "boostedTrack": {
+        "name": "Над. трек",
+        "rationale": "Мощный кольцевой автомобиль с наддувом. Агрессивный передний развал с большим кастором (6.5°) для устойчивости и прироста развала, небольшая передняя расходимость, чтобы мощность всё же реализовывалась, и мягкое заднее схождение. Это отправная точка — проверьте на стенде и сделайте развесовку по колёсам."
+      }
+    }
   },
   "ja": {
     "presets_title": "プリセットから始める",
@@ -1133,7 +1169,7 @@
       },
       "frontCaster": {
         "label": "フロントキャスター",
-        "help": "常にプラス。調整式タイバーで設定します。左右を0.5°以内に揃え、約5.5°を超えないようにしてください。"
+        "help": "常にポジティブ。自然吸気のロードカーはおよそ3°、過給車は過給時の安定性のために5–6.5°が望ましいです。調整式タイバーで設定し、左右を0.5°以内で合わせてください。"
       },
       "frontToe": {
         "label": "フロントトー（合計）",
@@ -1148,28 +1184,6 @@
         "help": "プラス＝トーイン（路上での安定性に必須）。マイナス（トーアウト）はレース専用です。シムまたは調整式ブラケットで設定します。"
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "ノーマル公道",
-        "rationale": "純正ワークショップマニュアルのジオメトリー。フロントキャンバーがプラス（+2°）で、フロントが軽いトーアウトであることに注目してください。どちらもMiniにとって正しい値で、誤記ではありません。リアは直進安定性のために1/8\"のトーインです。"
-      },
-      "fastRoad": {
-        "name": "ファストロード",
-        "rationale": "ノーマルより鋭いターンインを実現しつつ、街乗りに対応しタイヤにも優しい設定。フロントキャンバーをマイナスに反転させ、ロール時に荷重のかかったタイヤを路面にフラットに保ち、セルフセンタリングのためにキャスターをやや増やします。フロントは軽いトーアウト、リアは控えめなトーインを維持します。"
-      },
-      "trackDay": {
-        "name": "トラックデー",
-        "rationale": "公道用またはセミスリックタイヤでのコーナリンググリップを最大化。タイヤの摩耗が早まることを許容します。フロントキャンバーをよりマイナスに、キャスターをより多くし、リアはストレートに設定してターンインで後輪を回頭させます。タイヤがキャンバーの上限を決めます。測定機で確認してください。"
-      },
-      "boostedRoad": {
-        "name": "過給公道",
-        "rationale": "ターボまたはスーパーチャージャー付きのストリートカー。重要な変更点はフロントトーを平行（ゼロ）に設定してトルクステアを抑え、発進時の駆動力を改善することです。パワー下での安定性のために十分なキャスターを確保し、トラクションのためにリアトーインを大きめにします。"
-      },
-      "boostedTrack": {
-        "name": "過給サーキット",
-        "rationale": "ハイパワーの過給サーキットカー。最も外挿の度合いが大きいプリセットなので、あくまで出発点として扱ってください。アグレッシブなフロントキャンバーとキャスターに、パワーをしっかり路面に伝えるための小さなフロントトーアウトのみを組み合わせ、加速時の安定性のために控えめなリアトーインを加えます。"
-      }
-    },
     "confidence": {
       "high": "信頼度：高",
       "medium": "中",
@@ -1177,9 +1191,9 @@
     },
     "warnings": {
       "rearToeOut": "リアのトーアウトは急なオーバーステアを引き起こす可能性があります。フルレースの回頭セットアップに慣れた経験豊富なドライバーにのみ適しています。",
-      "casterHigh": "5.5°を超えるキャスターは通常の実用的な限界を超えており、ステアリングが重くなります。",
       "rearCamberPositive": "リアのプラスキャンバーは後輪を神経質にします。リアはニュートラルから軽いマイナスにすべきです。",
-      "frontCamberPositive": "フロントのプラスキャンバーは細身のクロスプライタイヤ向けの純正値です。現代の多くのセットアップではグリップのためにマイナスにします。"
+      "frontCamberPositive": "フロントのプラスキャンバーは細身のクロスプライタイヤ向けの純正値です。現代の多くのセットアップではグリップのためにマイナスにします。",
+      "casterHigh": "非常に高いキャスターは、低速時のステアリングを重くします。ターボやスーパーチャージャー付きのMiniでは正常な範囲（5–6.5°）ですが、自然吸気車には大きすぎます。"
     },
     "save": {
       "button": "セットアップを保存",
@@ -1199,7 +1213,33 @@
     "load": {
       "button": "保存済みを読み込む"
     },
-    "disclaimer": "これらは出発点であり、絶対的なものではありません。必ず適切なアライメント測定機で確認し（目視によるトー測定は1/8\"以上ずれていることがよくあります）、キャスターとキャンバーを左右0.5°以内で揃え、車高を変更した後は再確認してください。過給したMiniでは、アライメントはトルクステアを部分的にしか抑えられません。"
+    "disclaimer": "これらは出発点であり、絶対的なものではありません。必ず適切なアライメント測定機で確認し（目視によるトー測定は1/8\"以上ずれていることがよくあります）、キャスターとキャンバーを左右0.5°以内で揃え、車高を変更した後は再確認してください。過給したMiniでは、アライメントはトルクステアを部分的にしか抑えられません。",
+    "presets": {
+      "factory": {
+        "name": "ファクトリー",
+        "rationale": "工場マニュアル準拠のジオメトリ。フロントのキャンバーはポジティブ（+2°）で、フロントはわずかにトーアウト――どちらもMiniにとっては正しい設定で、誤記ではありません。リアは1/8\"のトーインです。忠実なベースラインですが、最近のセットアップの多くはこれを改善しています。"
+      },
+      "stockRoad": {
+        "name": "ストックロード",
+        "rationale": "現代のラジアルタイヤ向けに整えた工場ジオメトリ。扱いにくいポジティブなフロントキャンバーを、グリップとタイヤの均一な摩耗のために控えめな-0.5°へ戻し、それ以外はほぼ標準のまま。気軽で快適な日常使い向けセットアップです。"
+      },
+      "performance": {
+        "name": "パフォーマンス",
+        "rationale": "よりシャープなストリート向けセットアップ。フロントのネガティブキャンバーを増やしてロール時も荷重のかかったタイヤを路面に対してフラットに保ち、キャスターを少し増やしてセルフセンタリングを高め、リアのトーインを軽くしてクルマの動きを軽快にします。ストリートでも扱いやすく、タイヤ摩耗はやや増えます。"
+      },
+      "track": {
+        "name": "トラック",
+        "rationale": "ロードまたはセミスリックタイヤでのコーナリンググリップを最大化し、タイヤ摩耗の速さは許容します。フロントのネガティブキャンバーとキャスターを増やし、リアはストレートにしてターンイン時の回頭性を引き出します。キャンバーの上限はタイヤが決めるので、アライメント測定機で確認してください。"
+      },
+      "boostedRoad": {
+        "name": "過給ロード",
+        "rationale": "ターボまたはスーパーチャージャー付きのストリートカー。フロントトーをパラレル（ゼロ）にしてトルクステアを抑えパワーを路面に伝え、高めのキャスター（6°）で過給時の直進安定性を確保し、リアは大きめのトーインでトラクションを得ます。"
+      },
+      "boostedTrack": {
+        "name": "過給トラック",
+        "rationale": "ハイパワーな過給サーキットカー。アグレッシブなフロントキャンバーに多めのキャスター（6.5°）を組み合わせて安定性とキャンバーゲインを得て、フロントは小さめのトーアウトでパワーを路面に伝え、リアは控えめのトーインにします。あくまで出発点――アライメント測定機で確認し、コーナーウェイトを取ってください。"
+      }
+    }
   },
   "zh": {
     "presets_title": "从预设开始",
@@ -1227,7 +1267,7 @@
       },
       "frontCaster": {
         "label": "前轮主销后倾角",
-        "help": "始终为正值。通过可调式拉杆设定。两侧保持在 0.5° 范围内，且不要超过 ~5.5°。"
+        "help": "始终为正值。自然进气的道路车约为 3°；强制进气则需要 5–6.5° 以在增压下保持稳定。通过可调拉杆设定，并使两侧偏差控制在 0.5° 以内。"
       },
       "frontToe": {
         "label": "前轮前束（总计）",
@@ -1242,28 +1282,6 @@
         "help": "正值=内束（道路稳定性必需）。负值（外束）仅适用于赛道。通过垫片或可调支架设定。"
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "原厂街道",
-        "rationale": "原厂维修手册几何参数。请注意前轮外倾角为正值（+2°），且前轮采用轻微外束——这两点对 Mini 而言都是正确的，并非笔误。后轮采用 1/8\" 内束以保证直线行驶稳定性。"
-      },
-      "fastRoad": {
-        "name": "高性能街道",
-        "rationale": "比原厂更敏锐的入弯响应，同时保持街道适用性且对轮胎友好。将前轮外倾角翻转为负值，使受载轮胎在车身侧倾时保持平整，并略微增加主销后倾角以增强回正力。保持轻微的前轮外束和较小的后轮内束。"
-      },
-      "trackDay": {
-        "name": "赛道日",
-        "rationale": "在公路或半热熔轮胎上获得最大过弯抓地力；可接受较快的轮胎磨损。更大的前轮负外倾角和更大的主销后倾角；后轮设为平直以便后部在入弯时转动。轮胎决定外倾角上限——务必在调校台上验证。"
-      },
-      "boostedRoad": {
-        "name": "增压街道",
-        "rationale": "涡轮增压或机械增压街车。关键变化是将前轮前束设为平行（零），以减少扭矩转向并改善起步动力，配合充足的主销后倾角以保证动力下的稳定性，并加大后轮内束以提升牵引力。"
-      },
-      "boostedTrack": {
-        "name": "增压赛道",
-        "rationale": "大功率强制进气赛道车——这是外推程度最高的预设，因此仅应作为起始点对待。激进的前轮外倾角和主销后倾角，仅配合少量前轮外束以便动力仍能落地，外加轻微的后轮内束以保证加速时的稳定性。"
-      }
-    },
     "confidence": {
       "high": "高可信度",
       "medium": "中等",
@@ -1271,9 +1289,9 @@
     },
     "warnings": {
       "rearToeOut": "后轮外束可能导致突发性转向过度——仅适合经验丰富的驾驶者在全赛车转动设置下使用。",
-      "casterHigh": "主销后倾角超过 5.5° 已超出常规实用极限，并会大幅增加转向力度。",
       "rearCamberPositive": "后轮正外倾角会使后部变得不安定——后轮应采用中性至轻微负值。",
-      "frontCamberPositive": "前轮正外倾角是针对窄胎面斜交胎的原厂数值；大多数现代设置采用负值以获得抓地力。"
+      "frontCamberPositive": "前轮正外倾角是针对窄胎面斜交胎的原厂数值；大多数现代设置采用负值以获得抓地力。",
+      "casterHigh": "极大的后倾角意味着低速转向沉重。这在涡轮增压或机械增压的 Mini 上属正常（5–6.5°），但对自然进气车型而言偏大。"
     },
     "save": {
       "button": "保存设置",
@@ -1293,7 +1311,33 @@
     "load": {
       "button": "加载已保存"
     },
-    "disclaimer": "这些只是起始参数，并非金科玉律。请始终在专业的四轮定位调校台上验证（目测的前束经常会有 1/8\" 甚至更大的偏差），将主销后倾角和外倾角左右两侧匹配在 0.5° 范围内，并在任何车身高度变更后重新检查。在增压 Mini 上，四轮定位只能部分抑制扭矩转向。"
+    "disclaimer": "这些只是起始参数，并非金科玉律。请始终在专业的四轮定位调校台上验证（目测的前束经常会有 1/8\" 甚至更大的偏差），将主销后倾角和外倾角左右两侧匹配在 0.5° 范围内，并在任何车身高度变更后重新检查。在增压 Mini 上，四轮定位只能部分抑制扭矩转向。",
+    "presets": {
+      "factory": {
+        "name": "原厂",
+        "rationale": "原厂维修手册定义的几何参数。前轮外倾为正值（+2°），前轮略带前张（外八），这两项对 Mini 而言都是正确的，并非笔误。后轮采用 1/8\" 前束（内八）。这是忠于原厂的基准设定，多数现代设定都在此基础上加以改进。"
+      },
+      "stockRoad": {
+        "name": "街道原厂",
+        "rationale": "为现代子午线轮胎优化过的原厂几何：将别扭的前轮正外倾回调到温和的 -0.5°，以获得更多抓地力并使磨损更均匀，其余基本保持原厂状态。轻松舒适、适合日常代步的设定。"
+      },
+      "performance": {
+        "name": "运动",
+        "rationale": "更犀利的街道设定。更大的前轮负外倾让承载侧轮胎在车身侧倾中保持贴地，略增的后倾角提升回正性，更轻的后轮前束让车尾更灵活。仍适合道路使用，但轮胎磨损会稍快。"
+      },
+      "track": {
+        "name": "赛道",
+        "rationale": "在道路胎或半热熔胎上追求极致过弯抓地力，代价是轮胎磨损更快。更大的前轮负外倾与后倾角，后轮设为零前束（直行），以便转向时车尾能顺势转动。轮胎决定了外倾角的上限，请在四轮定位仪上核对。"
+      },
+      "boostedRoad": {
+        "name": "增压街道",
+        "rationale": "涡轮增压或机械增压的街车。前轮前束设为平行（零），以减少扭矩转向并更好地输出动力，配合较大的后倾角（6°）在增压下保持直线稳定性，后轮采用更大的前束以增强牵引力。"
+      },
+      "boostedTrack": {
+        "name": "增压赛道",
+        "rationale": "大马力强制进气的赛道车。激进的前轮外倾配合大量后倾角（6.5°）以获得稳定性与外倾增益，前轮略带前张（外八）以保证动力仍能输出，后轮采用温和前束。这只是一个起点，请在四轮定位仪上核对并做四轮称重配重。"
+      }
+    }
   },
   "ko": {
     "presets_title": "프리셋에서 시작하기",
@@ -1321,7 +1365,7 @@
       },
       "frontCaster": {
         "label": "앞 캐스터",
-        "help": "항상 양(+)입니다. 조절식 타이바로 설정합니다. 양쪽을 0.5° 이내로 맞추고 약 5.5°를 넘지 마세요."
+        "help": "항상 양의 값입니다. 자연흡기 도로용 차량은 약 3°로, 과급 차량은 부스트 상황의 안정성을 위해 5–6.5°를 원합니다. 조절식 타이바로 설정하고 양쪽을 0.5° 이내로 맞추세요."
       },
       "frontToe": {
         "label": "앞 토(합계)",
@@ -1336,28 +1380,6 @@
         "help": "양(+) = 토인(도로 안정성을 위해 필수). 음(-)(토아웃)은 레이스 전용입니다. 심이나 조절식 브래킷으로 설정합니다."
       }
     },
-    "presets": {
-      "stockRoad": {
-        "name": "순정 도로",
-        "rationale": "공장 정비 매뉴얼 지오메트리입니다. 앞 캠버가 양(+2°)이고 앞이 약간의 토아웃으로 세팅된 점에 유의하세요 — 둘 다 오타가 아니라 Mini에 맞는 정상값입니다. 뒤는 직진 안정성을 위해 1/8\" 토인으로 세팅됩니다."
-      },
-      "fastRoad": {
-        "name": "패스트 로드",
-        "rationale": "도로 주행에 적합하고 타이어에 무리가 없으면서도 순정보다 날카로운 턴인을 제공합니다. 차체 롤 시 하중이 실린 타이어를 평평하게 유지하기 위해 앞 캠버를 음(-)으로 바꾸고, 셀프 센터링을 위해 캐스터를 약간 더 줍니다. 가벼운 앞 토아웃과 약한 뒤 토인을 유지합니다."
-      },
-      "trackDay": {
-        "name": "트랙 데이",
-        "rationale": "도로용 또는 세미슬릭 타이어에서 최대 코너링 그립을 냅니다; 더 빠른 타이어 마모를 감수합니다. 앞 캠버를 더 음(-)으로, 캐스터를 더 많이 주며; 턴인 시 뒤가 회전하도록 뒤는 일직선으로 세팅합니다. 캠버 한계는 타이어가 결정합니다 — 정비 장비로 확인하세요."
-      },
-      "boostedRoad": {
-        "name": "부스트 도로",
-        "rationale": "터보 또는 슈퍼차저 도로용 차량입니다. 핵심 변경점은 토크 스티어를 줄이고 출발 가속을 개선하기 위해 앞 토를 평행(0)으로 세팅하는 것이며, 출력 하에서의 안정성을 위한 충분한 캐스터와 접지력을 위한 더 큰 뒤 토인을 함께 적용합니다."
-      },
-      "boostedTrack": {
-        "name": "부스트 트랙",
-        "rationale": "고출력 강제 흡기 서킷 차량 — 가장 추정에 의존한 프리셋이므로 출발점으로만 취급하세요. 공격적인 앞 캠버와 캐스터에 출력 전달을 유지하도록 작은 앞 토아웃만 주고, 가속 시 안정성을 위해 약한 뒤 토인을 더합니다."
-      }
-    },
     "confidence": {
       "high": "높은 신뢰도",
       "medium": "보통",
@@ -1365,9 +1387,9 @@
     },
     "warnings": {
       "rearToeOut": "뒤 토아웃은 급격한 오버스티어를 유발할 수 있습니다 — 풀레이스 회전 세팅에서 숙련된 운전자에게만 적합합니다.",
-      "casterHigh": "5.5°를 넘는 캐스터는 통상적인 실용 한계를 벗어나며 조향이 매우 무거워집니다.",
       "rearCamberPositive": "뒤 캠버가 양(+)이면 후미가 불안정해집니다 — 뒤는 중립에서 약한 음(-)으로 세팅해야 합니다.",
-      "frontCamberPositive": "앞 캠버 양(+)은 가는 크로스플라이 타이어용 공장 수치입니다; 대부분의 현대적 세팅은 그립을 위해 음(-)으로 갑니다."
+      "frontCamberPositive": "앞 캠버 양(+)은 가는 크로스플라이 타이어용 공장 수치입니다; 대부분의 현대적 세팅은 그립을 위해 음(-)으로 갑니다.",
+      "casterHigh": "매우 높은 캐스터는 저속에서 조향을 무겁게 만듭니다. 터보나 슈퍼차저 Mini(5–6.5°)에서는 정상이지만 자연흡기 차량에는 과한 값입니다."
     },
     "save": {
       "button": "세팅 저장",
@@ -1387,7 +1409,33 @@
     "load": {
       "button": "저장 항목 불러오기"
     },
-    "disclaimer": "이는 출발점일 뿐 절대적인 정답이 아닙니다. 항상 제대로 된 얼라인먼트 장비로 확인하고(눈대중 토는 1/8\" 이상 틀린 경우가 흔합니다), 캐스터와 캠버 좌우를 0.5° 이내로 맞추며, 차고 변경 후에는 다시 점검하세요. 얼라인먼트는 부스트 Mini의 토크 스티어를 부분적으로만 완화합니다."
+    "disclaimer": "이는 출발점일 뿐 절대적인 정답이 아닙니다. 항상 제대로 된 얼라인먼트 장비로 확인하고(눈대중 토는 1/8\" 이상 틀린 경우가 흔합니다), 캐스터와 캠버 좌우를 0.5° 이내로 맞추며, 차고 변경 후에는 다시 점검하세요. 얼라인먼트는 부스트 Mini의 토크 스티어를 부분적으로만 완화합니다.",
+    "presets": {
+      "factory": {
+        "name": "공장 사양",
+        "rationale": "공장 정비 매뉴얼 기준 지오메트리입니다. 전륜 캠버는 양의 값(+2°)이고 전륜은 약간 토아웃으로 설정되는데, 둘 다 Mini에서는 정상이며 오타가 아닙니다. 후륜은 1/8\" 토인으로 설정됩니다. 충실한 기준점이지만 대부분의 현대식 세팅은 이를 개선합니다."
+      },
+      "stockRoad": {
+        "name": "기본 도로",
+        "rationale": "현대식 레이디얼 타이어에 맞춰 정리한 공장 지오메트리입니다. 어색한 양의 전륜 캠버를 완만한 -0.5°로 되돌려 접지력과 균일한 마모를 약간 개선하고, 나머지는 거의 기본값에 가깝게 둡니다. 편안하고 무난한 일상 주행용 세팅입니다."
+      },
+      "performance": {
+        "name": "퍼포먼스",
+        "rationale": "보다 날카로운 도로용 세팅입니다. 더 많은 음의 전륜 캠버가 차체 롤 중에도 하중이 걸린 타이어를 평평하게 유지하고, 약간 더 큰 캐스터가 셀프 센터링을 더하며, 가벼운 후륜 토인이 차의 거동을 자유롭게 합니다. 타이어 마모가 조금 더 늘지만 여전히 도로 주행에 적합합니다."
+      },
+      "track": {
+        "name": "트랙",
+        "rationale": "도로용 또는 세미슬릭 타이어에서 최대 코너링 접지력을 얻되 더 빠른 타이어 마모를 감수하는 세팅입니다. 더 많은 음의 전륜 캠버와 캐스터를 적용하고, 후륜은 직진으로 설정해 턴인 시 차체가 회전하도록 합니다. 캠버 한계는 타이어가 결정하므로 정렬기에서 검증하세요."
+      },
+      "boostedRoad": {
+        "name": "부스트 도로",
+        "rationale": "터보 또는 슈퍼차저를 장착한 도로용 차량입니다. 전륜 토를 평행(0)으로 설정해 토크 스티어를 줄이고 출력을 노면에 전달하며, 부스트 상황에서의 직진 안정성을 위해 높은 캐스터(6°)를, 접지력을 위해 더 큰 후륜 토인을 적용합니다."
+      },
+      "boostedTrack": {
+        "name": "부스트 트랙",
+        "rationale": "고출력 과급 서킷용 차량입니다. 공격적인 전륜 캠버에 안정성과 캠버 게인을 위한 충분한 캐스터(6.5°), 출력이 여전히 노면에 전달되도록 약간의 전륜 토아웃, 그리고 완만한 후륜 토인을 적용합니다. 출발점일 뿐이니 정렬기에서 검증하고 코너 웨이트를 잡으세요."
+      }
+    }
   }
 }
 </i18n>

--- a/app/components/Calculators/AlignmentDiagram.vue
+++ b/app/components/Calculators/AlignmentDiagram.vue
@@ -134,7 +134,7 @@
       </figure>
 
       <!-- caster (side view) -->
-      <figure class="align-diagram__panel">
+      <figure class="align-diagram__panel align-diagram__panel--caster">
         <svg viewBox="0 0 200 132" role="img" :aria-label="t('aria.caster')">
           <line x1="16" y1="112" x2="184" y2="112" class="ad-ground" />
           <circle cx="100" cy="76" r="36" class="ad-wheel-side" />
@@ -179,8 +179,17 @@
   }
   .align-diagram__insets {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     gap: 0.75rem;
+  }
+  /* Caster spans the full width beneath the two camber cards. */
+  .align-diagram__panel--caster {
+    grid-column: 1 / -1;
+  }
+  .align-diagram__panel--caster svg {
+    max-width: 300px;
+    margin-inline: auto;
+    display: block;
   }
   @media (max-width: 520px) {
     .align-diagram__insets {

--- a/app/components/Calculators/AlignmentDiagram.vue
+++ b/app/components/Calculators/AlignmentDiagram.vue
@@ -208,7 +208,8 @@
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--fg-3, #76767c);
+    /* fg-2 (not fg-3): fg-3 on the panel bg is 4.06:1, just under the WCAG AA 4.5:1 floor. */
+    color: var(--fg-2, #4a4a4f);
     font-weight: 600;
   }
   .ad-cap-val {
@@ -268,7 +269,7 @@
   }
   .ad-end-label,
   .ad-side-hint {
-    fill: var(--fg-3, #76767c);
+    fill: var(--fg-2, #4a4a4f);
     font-size: 13px;
     font-weight: 700;
     text-anchor: middle;

--- a/app/pages/dashboard/alignment-configs.vue
+++ b/app/pages/dashboard/alignment-configs.vue
@@ -99,10 +99,11 @@
                   type="checkbox"
                   class="toggle toggle-primary toggle-sm"
                   :checked="config.is_public"
+                  :aria-label="t('public')"
                   @change="togglePublic(config)"
                 />
               </div>
-              <button class="btn btn-ghost btn-sm btn-square text-error" :title="t('delete')" @click="handleDelete(config.id)">
+              <button class="btn btn-ghost btn-sm btn-square text-error" :title="t('delete')" :aria-label="t('delete')" @click="handleDelete(config.id)">
                 <i class="fas fa-trash"></i>
               </button>
             </div>
@@ -110,7 +111,11 @@
 
           <!-- Journal -->
           <div class="mt-3 border-t border-base-300 pt-3">
-            <button class="btn btn-ghost btn-xs gap-2" @click="expanded[config.id] = !expanded[config.id]">
+            <button
+              class="btn btn-ghost btn-xs gap-2"
+              :aria-expanded="!!expanded[config.id]"
+              @click="expanded[config.id] = !expanded[config.id]"
+            >
               <i class="fas" :class="expanded[config.id] ? 'fa-chevron-down' : 'fa-chevron-right'"></i>
               {{ t('journal') }}
               <span class="badge badge-xs">{{ config.journal?.length || 0 }}</span>
@@ -123,6 +128,7 @@
                   type="text"
                   class="input input-bordered input-sm grow"
                   :placeholder="t('note_placeholder')"
+                  :aria-label="t('note_placeholder')"
                   @keyup.enter="handleAddNote(config.id)"
                 />
                 <button class="btn btn-sm btn-primary" @click="handleAddNote(config.id)">
@@ -144,6 +150,7 @@
                   <button
                     class="btn btn-ghost btn-xs btn-square text-error shrink-0"
                     :title="t('delete_note')"
+                    :aria-label="t('delete_note')"
                     @click="handleDeleteNote(config.id, entry.id)"
                   >
                     <i class="fas fa-xmark"></i>

--- a/app/pages/dashboard/alignment-configs.vue
+++ b/app/pages/dashboard/alignment-configs.vue
@@ -136,7 +136,7 @@
                 </button>
               </div>
 
-              <div v-if="!config.journal?.length" class="text-xs opacity-50">{{ t('no_notes') }}</div>
+              <div v-if="!config.journal?.length" class="text-xs opacity-60">{{ t('no_notes') }}</div>
               <ul v-else class="space-y-2">
                 <li
                   v-for="entry in config.journal"
@@ -144,7 +144,7 @@
                   class="flex items-start justify-between gap-3 text-sm rounded bg-base-200 px-3 py-2"
                 >
                   <div class="min-w-0">
-                    <span class="text-xs opacity-50 mr-2">{{ entry.date }}</span>
+                    <span class="text-xs opacity-60 mr-2">{{ entry.date }}</span>
                     <span>{{ entry.body }}</span>
                   </div>
                   <button

--- a/app/pages/technical/alignment.vue
+++ b/app/pages/technical/alignment.vue
@@ -120,11 +120,11 @@
     "hero_title": "Alignment Calculator",
     "breadcrumb_title": "Alignment Calculator",
     "og_title": "Classic Mini Alignment Calculator",
-    "og_description": "Dial in camber, caster, and toe with a live top-down diagram and proven presets for stock, fast road, track, and boosted Minis. Save your setups and keep a driving journal.",
+    "og_description": "Dial in camber, caster, and toe with a live top-down diagram and proven presets — from factory through performance and track to boosted. Save your setups and keep a driving journal.",
     "twitter_title": "Classic Mini Alignment Calculator",
     "twitter_description": "Dial in camber, caster, and toe with a live diagram and proven presets. Save your setups and keep a driving journal.",
     "main_heading": "Alignment Calculator",
-    "description_text": "Visualize and plan your Classic Mini's wheel alignment in real time. Start from a research-derived preset (stock, fast road, track, or boosted), fine-tune camber, caster, and toe, and watch the top-down diagram update live. Sign in to save setups and keep a dated driving journal for each one.",
+    "description_text": "Visualize and plan your Classic Mini's wheel alignment in real time. Start from a preset (factory, stock road, performance, track, or boosted), fine-tune camber, caster, and toe, and watch the top-down diagram update live. Sign in to save setups and keep a dated driving journal for each one.",
     "eyebrow": "CALCULATOR",
     "support_section": "Support",
     "ui": {
@@ -138,7 +138,7 @@
       "steps": {
         "preset": {
           "name": "Pick a preset",
-          "text": "Choose a starting point — stock, fast road, track day, or boosted."
+          "text": "Choose a starting point — factory, stock road, performance, track, or boosted."
         },
         "adjust": {
           "name": "Adjust the angles",
@@ -162,11 +162,9 @@
     "hero_title": "Calculadora de alineación",
     "breadcrumb_title": "Calculadora de alineación",
     "og_title": "Calculadora de alineación Classic Mini",
-    "og_description": "Ajusta caída, avance y convergencia con un diagrama cenital en vivo y preajustes probados para Minis estándar, de carretera rápida, de circuito y sobrealimentados. Guarda tus configuraciones y mantén un diario de conducción.",
     "twitter_title": "Calculadora de alineación Classic Mini",
     "twitter_description": "Ajusta caída, avance y convergencia con un diagrama en vivo y preajustes probados. Guarda tus configuraciones y mantén un diario de conducción.",
     "main_heading": "Calculadora de alineación",
-    "description_text": "Visualiza y planifica la alineación de las ruedas de tu Classic Mini en tiempo real. Empieza desde un preajuste basado en investigación (estándar, carretera rápida, circuito o sobrealimentado), ajusta con precisión la caída, el avance y la convergencia, y observa cómo el diagrama cenital se actualiza en vivo. Inicia sesión para guardar configuraciones y mantener un diario de conducción fechado para cada una.",
     "eyebrow": "CALCULADORA",
     "support_section": "Apoyo",
     "ui": {
@@ -180,7 +178,7 @@
       "steps": {
         "preset": {
           "name": "Elige un preajuste",
-          "text": "Elige un punto de partida — estándar, carretera rápida, día de circuito o sobrealimentado."
+          "text": "Elige un punto de partida: de fábrica, calle de serie, deportivo, circuito o sobrealimentado."
         },
         "adjust": {
           "name": "Ajusta los ángulos",
@@ -195,7 +193,9 @@
           "text": "Inicia sesión para guardar la configuración y mantener un diario de conducción fechado."
         }
       }
-    }
+    },
+    "description_text": "Visualiza y planifica la alineación de las ruedas de tu Classic Mini en tiempo real. Parte de un reglaje predefinido (de fábrica, calle de serie, deportivo, circuito o sobrealimentado), ajusta con precisión la caída, el avance y la convergencia, y observa cómo el diagrama en planta se actualiza en vivo. Inicia sesión para guardar reglajes y llevar un diario de conducción fechado para cada uno.",
+    "og_description": "Afina la caída, el avance y la convergencia con un diagrama en planta en vivo y reglajes predefinidos probados: desde el de fábrica, pasando por deportivo y circuito, hasta sobrealimentado. Guarda tus reglajes y lleva un diario de conducción."
   },
   "fr": {
     "title": "Tech - Calculateur de géométrie",
@@ -204,11 +204,9 @@
     "hero_title": "Calculateur de géométrie",
     "breadcrumb_title": "Calculateur de géométrie",
     "og_title": "Calculateur de géométrie Classic Mini",
-    "og_description": "Réglez carrossage, chasse et parallélisme avec un schéma en vue de dessus en direct et des préréglages éprouvés pour les Mini d'origine, route sportive, circuit et suralimentées. Enregistrez vos réglages et tenez un journal de conduite.",
     "twitter_title": "Calculateur de géométrie Classic Mini",
     "twitter_description": "Réglez carrossage, chasse et parallélisme avec un schéma en direct et des préréglages éprouvés. Enregistrez vos réglages et tenez un journal de conduite.",
     "main_heading": "Calculateur de géométrie",
-    "description_text": "Visualisez et planifiez en temps réel la géométrie des roues de votre Classic Mini. Partez d'un préréglage issu de recherches (origine, route sportive, circuit ou suralimentée), affinez carrossage, chasse et parallélisme, et regardez le schéma en vue de dessus se mettre à jour en direct. Connectez-vous pour enregistrer vos réglages et tenir un journal de conduite daté pour chacun.",
     "eyebrow": "CALCULATEUR",
     "support_section": "Soutien",
     "ui": {
@@ -222,7 +220,7 @@
       "steps": {
         "preset": {
           "name": "Choisissez un préréglage",
-          "text": "Choisissez un point de départ — origine, route sportive, journée circuit ou suralimentée."
+          "text": "Choisissez un point de départ — origine, route d'origine, sport, circuit ou suralimenté."
         },
         "adjust": {
           "name": "Ajustez les angles",
@@ -237,7 +235,9 @@
           "text": "Connectez-vous pour enregistrer la configuration et tenir un journal de conduite daté."
         }
       }
-    }
+    },
+    "description_text": "Visualisez et planifiez la géométrie des roues de votre Classic Mini en temps réel. Partez d'un préréglage (origine, route d'origine, sport, circuit ou suralimenté), ajustez finement le carrossage, la chasse et le parallélisme, et regardez le schéma vu de dessus se mettre à jour en direct. Connectez-vous pour enregistrer vos réglages et tenir un journal de conduite daté pour chacun.",
+    "og_description": "Réglez le carrossage, la chasse et le parallélisme avec un schéma vu de dessus en direct et des préréglages éprouvés — de l'origine au sport et au circuit en passant par le suralimenté. Enregistrez vos réglages et tenez un journal de conduite."
   },
   "de": {
     "title": "Technik - Achsvermessungsrechner",
@@ -246,11 +246,9 @@
     "hero_title": "Achsvermessungsrechner",
     "breadcrumb_title": "Achsvermessungsrechner",
     "og_title": "Classic Mini Achsvermessungsrechner",
-    "og_description": "Stelle Sturz, Nachlauf und Spur mit einer Live-Draufsicht und bewährten Voreinstellungen für Serie, schnelle Straße, Rennstrecke und aufgeladene Minis ein. Speichere deine Setups und führe ein Fahrtenjournal.",
     "twitter_title": "Classic Mini Achsvermessungsrechner",
     "twitter_description": "Stelle Sturz, Nachlauf und Spur mit einem Live-Diagramm und bewährten Voreinstellungen ein. Speichere deine Setups und führe ein Fahrtenjournal.",
     "main_heading": "Achsvermessungsrechner",
-    "description_text": "Visualisiere und plane die Achseinstellung deines Classic Mini in Echtzeit. Beginne mit einer recherchierten Voreinstellung (Serie, schnelle Straße, Rennstrecke oder aufgeladen), feine Sturz, Nachlauf und Spur ab und beobachte, wie sich die Draufsicht live aktualisiert. Melde dich an, um Setups zu speichern und für jedes ein datiertes Fahrtenjournal zu führen.",
     "eyebrow": "RECHNER",
     "support_section": "Unterstützung",
     "ui": {
@@ -264,7 +262,7 @@
       "steps": {
         "preset": {
           "name": "Eine Voreinstellung wählen",
-          "text": "Wähle einen Ausgangspunkt — Serie, schnelle Straße, Trackday oder aufgeladen."
+          "text": "Wähle einen Ausgangspunkt — Werkseinstellung, Serie Straße, Performance, Rennstrecke oder aufgeladen."
         },
         "adjust": {
           "name": "Die Winkel anpassen",
@@ -279,7 +277,9 @@
           "text": "Melde dich an, um die Konfiguration zu speichern und ein datiertes Fahrtenjournal zu führen."
         }
       }
-    }
+    },
+    "description_text": "Visualisiere und plane die Achsvermessung deines Classic Mini in Echtzeit. Starte von einer Voreinstellung (Werkseinstellung, Serie Straße, Performance, Rennstrecke oder aufgeladen), justiere Sturz, Nachlauf und Spur fein und beobachte, wie sich das Draufsicht-Diagramm live aktualisiert. Melde dich an, um Setups zu speichern und für jedes ein datiertes Fahrtenbuch zu führen.",
+    "og_description": "Stelle Sturz, Nachlauf und Spur mit einem Live-Draufsicht-Diagramm und bewährten Voreinstellungen ein — von Werkseinstellung über Performance und Rennstrecke bis aufgeladen. Speichere deine Setups und führe ein Fahrtenbuch."
   },
   "it": {
     "title": "Tech - Calcolatore di allineamento",
@@ -288,11 +288,9 @@
     "hero_title": "Calcolatore di allineamento",
     "breadcrumb_title": "Calcolatore di allineamento",
     "og_title": "Calcolatore di allineamento Classic Mini",
-    "og_description": "Regola campanatura, incidenza e convergenza con un diagramma dall'alto in tempo reale e preset collaudati per Mini di serie, strada sportiva, pista e sovralimentate. Salva le tue configurazioni e tieni un diario di guida.",
     "twitter_title": "Calcolatore di allineamento Classic Mini",
     "twitter_description": "Regola campanatura, incidenza e convergenza con un diagramma in tempo reale e preset collaudati. Salva le tue configurazioni e tieni un diario di guida.",
     "main_heading": "Calcolatore di allineamento",
-    "description_text": "Visualizza e pianifica in tempo reale l'allineamento delle ruote della tua Classic Mini. Parti da un preset derivato da ricerche (di serie, strada sportiva, pista o sovralimentata), affina campanatura, incidenza e convergenza, e guarda il diagramma dall'alto aggiornarsi dal vivo. Accedi per salvare le configurazioni e tenere un diario di guida datato per ciascuna.",
     "eyebrow": "CALCOLATORE",
     "support_section": "Supporto",
     "ui": {
@@ -306,7 +304,7 @@
       "steps": {
         "preset": {
           "name": "Scegli un preset",
-          "text": "Scegli un punto di partenza — di serie, strada sportiva, giornata in pista o sovralimentata."
+          "text": "Scegli un punto di partenza — originale, strada standard, sportivo, pista o sovralimentato."
         },
         "adjust": {
           "name": "Regola gli angoli",
@@ -321,7 +319,9 @@
           "text": "Accedi per salvare la configurazione e tenere un diario di guida datato."
         }
       }
-    }
+    },
+    "description_text": "Visualizza e pianifica l'assetto delle ruote della tua Classic Mini in tempo reale. Parti da un preset (originale, strada standard, sportivo, pista o sovralimentato), regola con precisione campanatura, incidenza e convergenza, e guarda lo schema dall'alto aggiornarsi dal vivo. Accedi per salvare gli assetti e tenere un diario di guida datato per ciascuno.",
+    "og_description": "Metti a punto campanatura, incidenza e convergenza con uno schema dall'alto dal vivo e preset collaudati — dall'originale allo sportivo e alla pista fino al sovralimentato. Salva i tuoi assetti e tieni un diario di guida."
   },
   "pt": {
     "title": "Técnico - Calculadora de Alinhamento",
@@ -330,11 +330,9 @@
     "hero_title": "Calculadora de Alinhamento",
     "breadcrumb_title": "Calculadora de Alinhamento",
     "og_title": "Calculadora de Alinhamento do Classic Mini",
-    "og_description": "Acerte a cambagem, o cáster e a convergência com um diagrama de cima ao vivo e predefinições comprovadas para Minis de série, estrada rápida, pista e turbo. Guarde as suas configurações e mantenha um diário de condução.",
     "twitter_title": "Calculadora de Alinhamento do Classic Mini",
     "twitter_description": "Acerte a cambagem, o cáster e a convergência com um diagrama ao vivo e predefinições comprovadas. Guarde as suas configurações e mantenha um diário de condução.",
     "main_heading": "Calculadora de Alinhamento",
-    "description_text": "Visualize e planeie o alinhamento das rodas do seu Classic Mini em tempo real. Comece a partir de uma predefinição derivada de pesquisa (série, estrada rápida, pista ou turbo), afine a cambagem, o cáster e a convergência, e veja o diagrama de cima atualizar-se ao vivo. Inicie sessão para guardar configurações e manter um diário de condução datado para cada uma.",
     "eyebrow": "CALCULADORA",
     "support_section": "Apoio",
     "ui": {
@@ -348,7 +346,7 @@
       "steps": {
         "preset": {
           "name": "Escolha uma predefinição",
-          "text": "Escolha um ponto de partida — série, estrada rápida, dia de pista ou turbo."
+          "text": "Escolha um ponto de partida — fábrica, estrada original, desportivo, pista ou turbo."
         },
         "adjust": {
           "name": "Ajuste os ângulos",
@@ -363,7 +361,9 @@
           "text": "Inicie sessão para guardar a configuração e manter um diário de condução datado."
         }
       }
-    }
+    },
+    "description_text": "Visualize e planeie o alinhamento das rodas do seu Classic Mini em tempo real. Comece a partir de uma predefinição (fábrica, estrada original, desportivo, pista ou turbo), afine a caída, o avance e a convergência, e veja o diagrama de vista superior atualizar-se ao vivo. Inicie sessão para guardar configurações e manter um diário de condução datado para cada uma.",
+    "og_description": "Acerte a caída, o avance e a convergência com um diagrama de vista superior ao vivo e predefinições comprovadas — de fábrica, passando por desportivo e pista, até turbo. Guarde as suas configurações e mantenha um diário de condução."
   },
   "ru": {
     "title": "Техника — Калькулятор развал-схождения",
@@ -372,11 +372,9 @@
     "hero_title": "Калькулятор развал-схождения",
     "breadcrumb_title": "Калькулятор развал-схождения",
     "og_title": "Калькулятор развал-схождения Classic Mini",
-    "og_description": "Настройте развал, кастер и схождение с живой схемой вида сверху и проверенными пресетами для стокового, спортивного, трекового Mini и Mini с наддувом. Сохраняйте свои настройки и ведите журнал поездок.",
     "twitter_title": "Калькулятор развал-схождения Classic Mini",
     "twitter_description": "Настройте развал, кастер и схождение с живой схемой и проверенными пресетами. Сохраняйте свои настройки и ведите журнал поездок.",
     "main_heading": "Калькулятор развал-схождения",
-    "description_text": "Визуализируйте и планируйте развал-схождение вашего Classic Mini в реальном времени. Начните с пресета на основе исследований (сток, спорт-дорога, трек или наддув), точно подстройте развал, кастер и схождение и наблюдайте, как схема вида сверху обновляется вживую. Войдите, чтобы сохранять настройки и вести датированный журнал поездок для каждой из них.",
     "eyebrow": "КАЛЬКУЛЯТОР",
     "support_section": "Поддержка",
     "ui": {
@@ -390,7 +388,7 @@
       "steps": {
         "preset": {
           "name": "Выберите пресет",
-          "text": "Выберите отправную точку — сток, спорт-дорога, трек-день или наддув."
+          "text": "Выберите отправную точку — заводская, сток дорога, спорт, трек или наддувная."
         },
         "adjust": {
           "name": "Отрегулируйте углы",
@@ -405,7 +403,9 @@
           "text": "Войдите, чтобы сохранить конфигурацию и вести датированный журнал поездок."
         }
       }
-    }
+    },
+    "description_text": "Визуализируйте и планируйте развал-схождение вашего Classic Mini в реальном времени. Начните с пресета (заводская, сток дорога, спорт, трек или наддувный), точно настройте развал, кастор и схождение и наблюдайте, как схема вида сверху обновляется вживую. Войдите, чтобы сохранять настройки и вести датированный журнал поездок для каждой из них.",
+    "og_description": "Настройте развал, кастор и схождение с живой схемой вида сверху и проверенными пресетами — от заводской через спорт и трек до наддувной. Сохраняйте настройки и ведите журнал поездок."
   },
   "ja": {
     "title": "テック - アライメント計算機",
@@ -414,11 +414,9 @@
     "hero_title": "アライメント計算機",
     "breadcrumb_title": "アライメント計算機",
     "og_title": "Classic Mini アライメント計算機",
-    "og_description": "ライブの上面図と、ノーマル・ファストロード・トラック・過給のMini向けに実証されたプリセットで、キャンバー、キャスター、トーを設定。セットアップを保存してドライビングジャーナルを記録できます。",
     "twitter_title": "Classic Mini アライメント計算機",
     "twitter_description": "ライブ図と実証済みプリセットで、キャンバー、キャスター、トーを設定。セットアップを保存してドライビングジャーナルを記録できます。",
     "main_heading": "アライメント計算機",
-    "description_text": "Classic Miniのホイールアライメントをリアルタイムで可視化・計画します。調査に基づくプリセット（ノーマル、ファストロード、トラック、過給）から始め、キャンバー、キャスター、トーを微調整し、上面図がライブで更新される様子を確認できます。サインインするとセットアップを保存し、それぞれに日付付きのドライビングジャーナルを記録できます。",
     "eyebrow": "計算機",
     "support_section": "サポート",
     "ui": {
@@ -432,7 +430,7 @@
       "steps": {
         "preset": {
           "name": "プリセットを選ぶ",
-          "text": "出発点を選びます — ノーマル、ファストロード、トラックデー、または過給。"
+          "text": "出発点を選びましょう――ファクトリー、ストックロード、パフォーマンス、トラック、または過給。"
         },
         "adjust": {
           "name": "角度を調整する",
@@ -447,7 +445,9 @@
           "text": "サインインして設定を保存し、日付付きのドライビングジャーナルを記録します。"
         }
       }
-    }
+    },
+    "description_text": "Classic Miniのホイールアライメントをリアルタイムで可視化し、プランニングできます。プリセット（ファクトリー、ストックロード、パフォーマンス、トラック、過給）から始め、キャンバー・キャスター・トーを微調整しながら、上面図のダイアグラムがライブで更新される様子を確認できます。サインインすればセットアップを保存し、それぞれに日付付きのドライビングジャーナルを残せます。",
+    "og_description": "ライブの上面図ダイアグラムと実証済みのプリセット――ファクトリーからパフォーマンス、トラック、そして過給まで――でキャンバー・キャスター・トーを追い込めます。セットアップを保存し、ドライビングジャーナルを残しましょう。"
   },
   "zh": {
     "title": "技术 - 四轮定位计算器",
@@ -456,11 +456,9 @@
     "hero_title": "四轮定位计算器",
     "breadcrumb_title": "四轮定位计算器",
     "og_title": "Classic Mini 四轮定位计算器",
-    "og_description": "通过实时俯视图以及针对原厂、高性能街道、赛道和增压 Mini 的成熟预设，精准调校外倾角、主销后倾角和前束。保存您的设置并记录驾驶日志。",
     "twitter_title": "Classic Mini 四轮定位计算器",
     "twitter_description": "通过实时图示和成熟预设精准调校外倾角、主销后倾角和前束。保存您的设置并记录驾驶日志。",
     "main_heading": "四轮定位计算器",
-    "description_text": "实时可视化并规划您的 Classic Mini 四轮定位。从研究得出的预设（原厂、高性能街道、赛道或增压）开始，微调外倾角、主销后倾角和前束，并实时观看俯视图更新。登录即可保存设置，并为每个设置记录带日期的驾驶日志。",
     "eyebrow": "计算器",
     "support_section": "支持",
     "ui": {
@@ -474,7 +472,7 @@
       "steps": {
         "preset": {
           "name": "选择预设",
-          "text": "选择一个起始点——原厂、高性能街道、赛道日或增压。"
+          "text": "选择一个起点——原厂、街道原厂、运动、赛道或增压。"
         },
         "adjust": {
           "name": "调整角度",
@@ -489,7 +487,9 @@
           "text": "登录以保存配置并记录带日期的驾驶日志。"
         }
       }
-    }
+    },
+    "description_text": "实时可视化并规划你的 Classic Mini 四轮定位。从预设方案入手（原厂、街道原厂、运动、赛道或增压），微调外倾角、后倾角与前束，看着俯视示意图实时更新。登录即可保存设定，并为每套设定保留带日期的驾驶日志。",
+    "og_description": "借助实时俯视示意图与久经验证的预设方案，精准调校外倾角、后倾角与前束——从原厂、运动、赛道到增压一应俱全。保存你的设定并记录驾驶日志。"
   },
   "ko": {
     "title": "기술 - 얼라인먼트 계산기",
@@ -498,11 +498,9 @@
     "hero_title": "얼라인먼트 계산기",
     "breadcrumb_title": "얼라인먼트 계산기",
     "og_title": "Classic Mini 얼라인먼트 계산기",
-    "og_description": "실시간 평면도와 순정, 패스트 로드, 트랙, 부스트 Mini용 검증된 프리셋으로 캠버, 캐스터, 토를 세팅하세요. 세팅을 저장하고 주행 저널을 기록하세요.",
     "twitter_title": "Classic Mini 얼라인먼트 계산기",
     "twitter_description": "실시간 다이어그램과 검증된 프리셋으로 캠버, 캐스터, 토를 세팅하세요. 세팅을 저장하고 주행 저널을 기록하세요.",
     "main_heading": "얼라인먼트 계산기",
-    "description_text": "Classic Mini의 휠 얼라인먼트를 실시간으로 시각화하고 계획하세요. 연구 기반 프리셋(순정, 패스트 로드, 트랙, 부스트)에서 시작해 캠버, 캐스터, 토를 미세 조정하고 평면도가 실시간으로 갱신되는 모습을 확인하세요. 로그인하면 세팅을 저장하고 각각에 대해 날짜가 기록된 주행 저널을 남길 수 있습니다.",
     "eyebrow": "계산기",
     "support_section": "후원",
     "ui": {
@@ -516,7 +514,7 @@
       "steps": {
         "preset": {
           "name": "프리셋 선택",
-          "text": "출발점을 선택하세요 — 순정, 패스트 로드, 트랙 데이, 또는 부스트."
+          "text": "시작점을 선택하세요 — 공장 사양, 기본 도로, 퍼포먼스, 트랙, 부스트."
         },
         "adjust": {
           "name": "각도 조정",
@@ -531,7 +529,9 @@
           "text": "로그인하여 구성을 저장하고 날짜가 기록된 주행 저널을 남기세요."
         }
       }
-    }
+    },
+    "description_text": "Classic Mini의 휠 얼라인먼트를 실시간으로 시각화하고 계획하세요. 프리셋(공장 사양, 기본 도로, 퍼포먼스, 트랙, 부스트)에서 시작해 캠버, 캐스터, 토를 미세 조정하고 위에서 본 도면이 실시간으로 갱신되는 모습을 확인하세요. 로그인하면 세팅을 저장하고 각 세팅마다 날짜별 주행 일지를 기록할 수 있습니다.",
+    "og_description": "실시간 위에서 본 도면과 검증된 프리셋으로 캠버, 캐스터, 토를 세팅하세요 — 공장 사양부터 퍼포먼스와 트랙, 부스트까지. 세팅을 저장하고 주행 일지를 기록하세요."
   }
 }
 </i18n>

--- a/app/pages/technical/alignment.vue
+++ b/app/pages/technical/alignment.vue
@@ -77,7 +77,7 @@
 
 <template>
   <hero :navigation="true" :title="t('hero_title')" :heroType="HERO_TYPES.TECH" />
-  <div class="container mx-auto px-4">
+  <div class="container mx-auto px-4 pb-15">
     <div class="grid grid-cols-12 gap-6">
       <div class="col-span-12">
         <breadcrumb class="my-6" :version="BREADCRUMB_VERSIONS.TECH" :page="t('breadcrumb_title')"></breadcrumb>

--- a/app/pages/technical/index.vue
+++ b/app/pages/technical/index.vue
@@ -157,7 +157,7 @@
       "needle_configurator_desc": "Compare SU HS2/HS4/HIF44 needle profiles side-by-side with chart overlays.",
       "gearbox_calculator_desc": "Final-drive math across SPi, MPi, and pre-Verto cars.",
       "compression_calculator_desc": "CR for any combo of bore, stroke, head cc and deck height.",
-      "alignment_calculator_desc": "Visualize camber, caster, and toe live, with presets for stock, fast road, track, and boosted.",
+      "alignment_calculator_desc": "Visualize camber, caster, and toe live — presets from factory to track, plus boosted.",
       "parts_equivalency_desc": "Cross-reference part numbers across vendors and brands.",
       "common_clearances_desc": "Tappet gaps, bearing tolerances, and assembly clearances."
     }

--- a/data/models/alignment.ts
+++ b/data/models/alignment.ts
@@ -14,7 +14,7 @@
 export type AlignmentAxle = 'front' | 'rear';
 export type AlignmentParamKind = 'camber' | 'caster' | 'toe';
 export type AlignmentParamId = 'frontCamber' | 'frontCaster' | 'frontToe' | 'rearCamber' | 'rearToe';
-export type AlignmentPresetId = 'stockRoad' | 'fastRoad' | 'trackDay' | 'boostedRoad' | 'boostedTrack';
+export type AlignmentPresetId = 'factory' | 'stockRoad' | 'performance' | 'track' | 'boostedRoad' | 'boostedTrack';
 export type AlignmentConfidence = 'high' | 'medium' | 'low';
 
 export interface AlignmentValues {
@@ -81,17 +81,20 @@ export function getCamberGuidance(wheelSize: number, axle: AlignmentAxle): Cambe
 
 export const ALIGNMENT_PARAMETERS: AlignmentParameter[] = [
   { id: 'frontCamber', axle: 'front', kind: 'camber', unit: 'deg', min: -3, max: 2.5, step: 0.25, stockDefault: 2 },
-  { id: 'frontCaster', axle: 'front', kind: 'caster', unit: 'deg', min: 1, max: 6, step: 0.25, stockDefault: 3 },
+  { id: 'frontCaster', axle: 'front', kind: 'caster', unit: 'deg', min: 1, max: 7, step: 0.25, stockDefault: 3 },
   { id: 'frontToe', axle: 'front', kind: 'toe', unit: 'mm', min: -4, max: 3, step: 0.25, stockDefault: -1.59 },
   { id: 'rearCamber', axle: 'rear', kind: 'camber', unit: 'deg', min: -2, max: 1, step: 0.25, stockDefault: 0 },
   { id: 'rearToe', axle: 'rear', kind: 'toe', unit: 'mm', min: -1, max: 5, step: 0.25, stockDefault: 3.18 },
 ];
 
-/** Five research-derived starting points. Numeric values + sources only; display name,
- *  summary, and rationale are localized via i18n keys (`presets.<id>.*`) in the component. */
+/** Six starting points, ordered from mildest to most aggressive (then the two boosted setups).
+ *  Numeric values + sources only; display name, summary, and rationale are localized via i18n
+ *  keys (`presets.<id>.*`) in the component. Boosted caster (6° / 6.5°) reflects practitioner
+ *  input from forced-induction Mini builders, who run far more caster than an N/A car. */
 export const ALIGNMENT_PRESETS: AlignmentPreset[] = [
   {
-    id: 'stockRoad',
+    // Pure Haynes / workshop-manual geometry — the faithful baseline (positive front camber).
+    id: 'factory',
     confidence: 'high',
     values: { frontCamber: 2, frontCaster: 3, frontToe: -1.59, rearCamber: 0, rearToe: 3.18 },
     sources: [
@@ -101,7 +104,19 @@ export const ALIGNMENT_PRESETS: AlignmentPreset[] = [
     ],
   },
   {
-    id: 'fastRoad',
+    // Factory geometry gently corrected for modern radials: mild negative front camber, rest near stock.
+    id: 'stockRoad',
+    confidence: 'high',
+    values: { frontCamber: -0.5, frontCaster: 3, frontToe: -1.59, rearCamber: 0, rearToe: 3.18 },
+    sources: [
+      'https://www.calverst.com/technical-info/suspension-basic-set-up-method/',
+      'https://www.med-engineering.co.uk/blogs/news/classic-mini-suspension-geometry-setup-guide',
+      'https://www.theminiforum.co.uk/forums/topic/353453-camber-caster-toe-tracking-figures/page-2',
+    ],
+  },
+  {
+    // Sharper road setup (formerly "fast road").
+    id: 'performance',
     confidence: 'high',
     values: { frontCamber: -1, frontCaster: 3.5, frontToe: -1.59, rearCamber: -0.5, rearToe: 1.59 },
     sources: [
@@ -111,7 +126,7 @@ export const ALIGNMENT_PRESETS: AlignmentPreset[] = [
     ],
   },
   {
-    id: 'trackDay',
+    id: 'track',
     confidence: 'medium',
     values: { frontCamber: -2, frontCaster: 4.5, frontToe: -1.59, rearCamber: -0.5, rearToe: 0 },
     sources: [
@@ -123,7 +138,7 @@ export const ALIGNMENT_PRESETS: AlignmentPreset[] = [
   {
     id: 'boostedRoad',
     confidence: 'medium',
-    values: { frontCamber: -1, frontCaster: 4, frontToe: 0, rearCamber: -0.5, rearToe: 3.18 },
+    values: { frontCamber: -1, frontCaster: 6, frontToe: 0, rearCamber: -0.5, rearToe: 3.18 },
     sources: [
       'https://www.turbominis.co.uk/forums/index.php?p=vt&tid=593349',
       'https://www.med-engineering.co.uk/blogs/news/classic-mini-suspension-geometry-setup-guide',
@@ -133,7 +148,7 @@ export const ALIGNMENT_PRESETS: AlignmentPreset[] = [
   {
     id: 'boostedTrack',
     confidence: 'low',
-    values: { frontCamber: -2.5, frontCaster: 5, frontToe: -1, rearCamber: -1, rearToe: 1.59 },
+    values: { frontCamber: -2.5, frontCaster: 6.5, frontToe: -1, rearCamber: -1, rearToe: 1.59 },
     sources: [
       'https://www.turbominis.co.uk/forums/index.php?p=vt&tid=345429',
       'https://www.turbominis.co.uk/forums/index.php?p=vt&tid=593349',
@@ -146,9 +161,9 @@ export function getAlignmentPreset(id: AlignmentPresetId): AlignmentPreset | und
   return ALIGNMENT_PRESETS.find((p) => p.id === id);
 }
 
-/** Default tool state = factory/stock geometry. */
+/** Default tool state = factory (Haynes) geometry. */
 export function defaultAlignmentValues(): AlignmentValues {
-  return { ...(getAlignmentPreset('stockRoad') as AlignmentPreset).values };
+  return { ...(getAlignmentPreset('factory') as AlignmentPreset).values };
 }
 
 /**

--- a/docs/plans/2026-06-23-alignment-tool.md
+++ b/docs/plans/2026-06-23-alignment-tool.md
@@ -32,7 +32,7 @@ Web first; the data model + presets are intended to cascade to the iOS/Android t
 | Param | Unit | Sign convention | Min | Max | Step | Stock default |
 |---|---|---|---|---|---|---|
 | Front camber | ° | + = top leans OUT, − = top leans IN (stock is **positive**) | −3 | 2.5 | 0.25 | +2 |
-| Front caster | ° | always **positive** (validate ≥0) | 1 | 6 | 0.25 | +3 |
+| Front caster | ° | always **positive** | 1 | 7 | 0.25 | +3 |
 | Front toe (total) | mm | − = toe-**OUT**, + = toe-IN (front runs **toe-out**) | −4 | 3 | 0.25 | −1.59 |
 | Rear camber | ° | + = out, − = in | −2 | 1 | 0.25 | 0 |
 | Rear toe (total) | mm | + = toe-**IN**, − = toe-OUT (rear runs **toe-in**) | −1 | 5 | 0.25 | +3.18 |
@@ -45,18 +45,25 @@ in the UI. Key conversions: 1/16″ = 1.5875 mm, 1/8″ = 3.175 mm, 3/16″ = 4.
 
 ## Presets
 
+A clear ladder from mildest to most aggressive, plus the two boosted setups. (Renamed 2026-06-25
+per user/community feedback — "fast road" dropped; Factory split out from a gently-improved Stock
+Road; boosted caster raised to match real forced-induction practice.)
+
 | Preset | F camber | F caster | F toe (mm) | R camber | R toe (mm) | Conf. |
 |---|---|---|---|---|---|---|
-| Stock Road | +2 | +3 | −1.59 (1/16″ out) | 0 | +3.18 (1/8″ in) | high |
-| Fast Road | −1 | +3.5 | −1.59 | −0.5 | +1.59 | high |
-| Track Day | −2 | +4.5 | −1.59 | −0.5 | 0 (straight) | medium |
-| Boosted Road | −1 | +4 | 0 (parallel) | −0.5 | +3.18 | medium |
-| Boosted Track | −2.5 | +5 | −1 | −1 | +1.59 | low |
+| Factory | +2 | +3 | −1.59 (1/16″ out) | 0 | +3.18 (1/8″ in) | high |
+| Stock Road | −0.5 | +3 | −1.59 | 0 | +3.18 | high |
+| Performance | −1 | +3.5 | −1.59 | −0.5 | +1.59 | high |
+| Track | −2 | +4.5 | −1.59 | −0.5 | 0 (straight) | medium |
+| Boosted Road | −1 | +6 | 0 (parallel) | −0.5 | +3.18 | medium |
+| Boosted Track | −2.5 | +6.5 | −1 | −1 | +1.59 | low |
 
-Each preset carries a `rationale` + `sources[]` + `confidence`. The Boosted-Road headline is
-**front toe set parallel** (Wiginton) to cut torque steer; Boosted-Track is the most extrapolated
-(flagged low). Full numbers/rationale/sources live in `data/models/alignment.ts`. Tool shows a
-standing disclaimer: starting points only, verify on a rig, match sides within 0.5°.
+Factory = pure Haynes geometry; Stock Road = factory gently corrected for modern radials (mild
+negative front camber). Each preset carries a `rationale` + `sources[]` + `confidence`. The
+Boosted-Road headline is **front toe set parallel** (Wiginton) to cut torque steer; the high
+boosted caster (6° / 6.5°) reflects practitioner input (turbo Minis run far more caster than N/A).
+Full numbers/rationale/sources live in `data/models/alignment.ts`. Standing disclaimer in the tool:
+starting points only, verify on a rig, match sides within 0.5°.
 
 ## Architecture (mirrors saved gear configs 1:1)
 

--- a/tests/unit/data/alignment-model.test.ts
+++ b/tests/unit/data/alignment-model.test.ts
@@ -41,11 +41,12 @@ describe('ALIGNMENT_PARAMETERS', () => {
 });
 
 describe('ALIGNMENT_PRESETS', () => {
-  it('defines the five presets in the expected order', () => {
+  it('defines the six presets in the expected ladder order', () => {
     expect(ALIGNMENT_PRESETS.map((p) => p.id)).toEqual([
+      'factory',
       'stockRoad',
-      'fastRoad',
-      'trackDay',
+      'performance',
+      'track',
       'boostedRoad',
       'boostedTrack',
     ]);
@@ -70,12 +71,26 @@ describe('ALIGNMENT_PRESETS', () => {
     }
   });
 
-  it('respects the Mini sign conventions: front toe-out, rear toe-in, positive stock front camber', () => {
-    const stock = getAlignmentPreset('stockRoad')!;
-    expect(stock.values.frontToe).toBeLessThan(0); // front runs toe-out
-    expect(stock.values.rearToe).toBeGreaterThan(0); // rear runs toe-in
-    expect(stock.values.frontCamber).toBeGreaterThan(0); // factory front camber is positive
-    expect(stock.values.frontCaster).toBeGreaterThan(0); // caster always positive
+  it('respects the Mini sign conventions: front toe-out, rear toe-in, positive factory front camber', () => {
+    const factory = getAlignmentPreset('factory')!;
+    expect(factory.values.frontToe).toBeLessThan(0); // front runs toe-out
+    expect(factory.values.rearToe).toBeGreaterThan(0); // rear runs toe-in
+    expect(factory.values.frontCamber).toBeGreaterThan(0); // factory front camber is positive
+    expect(factory.values.frontCaster).toBeGreaterThan(0); // caster always positive
+  });
+
+  it('stock road softens factory: mild negative front camber, otherwise near stock', () => {
+    const factory = getAlignmentPreset('factory')!.values;
+    const stock = getAlignmentPreset('stockRoad')!.values;
+    expect(stock.frontCamber).toBeLessThan(0); // corrected off the factory positive
+    expect(stock.frontCamber).toBeGreaterThan(-1.5); // but mild
+    expect(stock.frontCaster).toBe(factory.frontCaster);
+    expect(stock.rearToe).toBe(factory.rearToe); // keeps factory rear toe-in for comfort
+  });
+
+  it('boosted presets run high caster (≥6°) per forced-induction practitioner input', () => {
+    expect(getAlignmentPreset('boostedRoad')!.values.frontCaster).toBeGreaterThanOrEqual(6);
+    expect(getAlignmentPreset('boostedTrack')!.values.frontCaster).toBeGreaterThanOrEqual(6);
   });
 
   it('boosted road sets the front toe parallel (the headline torque-steer finding)', () => {
@@ -90,11 +105,11 @@ describe('ALIGNMENT_PRESETS', () => {
 });
 
 describe('defaultAlignmentValues', () => {
-  it('returns the stock-road geometry as a fresh object', () => {
+  it('returns the factory geometry as a fresh object', () => {
     const a = defaultAlignmentValues();
-    expect(a).toEqual(getAlignmentPreset('stockRoad')!.values);
+    expect(a).toEqual(getAlignmentPreset('factory')!.values);
     a.frontCamber = 99;
-    expect(getAlignmentPreset('stockRoad')!.values.frontCamber).not.toBe(99); // not a shared reference
+    expect(getAlignmentPreset('factory')!.values.frontCamber).not.toBe(99); // not a shared reference
   });
 });
 


### PR DESCRIPTION
Follow-up to the merged alignment tool (#633) — these four changes were authored after that PR was squash-merged, so they need their own PR.

### Preset ladder rework (community feedback)
Dropped the disliked "fast road" naming. New ladder: **Factory → Stock Road → Performance → Track**, plus **Boosted Road / Boosted Track**.
- **Factory** = pure Haynes geometry (positive front camber); **Stock Road** = factory gently corrected for radials (−0.5° front camber) — resolves the "is "factory" just "fast road"?" confusion.
- Boosted caster raised to **6° (road) / 6.5° (track)** per forced-induction builders ("turbos need shitloads of caster"; "4° isn't enough"). Front-caster slider max raised to 7°.
- Default tool state is now **Factory**.

### Accessibility (axe-core / a11y MCP audit)
- Muted helper/readout text `opacity-50 → opacity-60`; diagram caption + SVG labels `--fg-3 → --fg-2` (both were ~4:1, now ≥5.7:1).
- Aggressive-camber nudge off daisyUI `text-warning` (#f59e0b ≈ 2:1 on white) to a scoped deep-amber (#92400e light / #fbbf24 dark).
- **Confidence badges** redesigned: were translucent tint + dark text (dark-on-dark in dark mode / on the selected preset button) → solid pills with white text (green/amber/orange, 5.0–5.2:1), theme- and state-independent.

### Layout
- Diagram insets reflowed to 2 columns: front + rear camber on top, **caster spanning full width beneath them** next to the car.
- Added bottom padding so the support section no longer touches the footer.

Verified: `bun run build` green; 23 unit tests pass; axe shows no remaining contrast issues in the tool (the only site-wide axe finding is the shared `.eyebrow` brand-orange, tracked separately). No schema/env changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)