### PR TITLE
fix(models): surface "already listed" message on duplicate external model fetch

### DIFF
--- a/app/components/models/ExternalModelSubmitForm.vue
+++ b/app/components/models/ExternalModelSubmitForm.vue
@@ -106,10 +106,11 @@
         </div>
 
         <!-- Already listed (from preview dedupe check) -->
-        <div v-if="f.alreadyListed.value && !f.preview.value" class="alert alert-info">
+        <div v-if="f.alreadyListed.value" class="alert alert-info">
           <i class="fas fa-circle-info"></i>
           <div>
             <p class="font-semibold">{{ t('step1.alreadyListedTitle') }}</p>
+            <p class="text-sm opacity-80">{{ t('step1.alreadyListedBody') }}</p>
             <NuxtLink
               :to="`/models/external/${f.alreadyListed.value.slug}`"
               class="link link-primary text-sm"
@@ -283,6 +284,7 @@
       "detectedLabel": "Detected site:",
       "sitesHint": "Works best with {sites}. Any other URL is also accepted as a generic listing.",
       "alreadyListedTitle": "This model is already in the library.",
+      "alreadyListedBody": "Someone has already added this model, so there's nothing more to submit.",
       "alreadyListedLink": "View the existing listing"
     },
     "step2": {
@@ -319,6 +321,7 @@
       "detectedLabel": "Sitio detectado:",
       "sitesHint": "Funciona mejor con {sites}. Cualquier otra URL también se acepta como listado genérico.",
       "alreadyListedTitle": "Este modelo ya está en la biblioteca.",
+      "alreadyListedBody": "Alguien ya añadió este modelo, así que no hay nada más que enviar.",
       "alreadyListedLink": "Ver el listado existente"
     },
     "step2": {
@@ -355,6 +358,7 @@
       "detectedLabel": "Site détecté :",
       "sitesHint": "Fonctionne mieux avec {sites}. Toute autre URL est aussi acceptée comme listage générique.",
       "alreadyListedTitle": "Ce modèle est déjà dans la bibliothèque.",
+      "alreadyListedBody": "Quelqu'un a déjà ajouté ce modèle, il n'y a donc rien de plus à soumettre.",
       "alreadyListedLink": "Voir le listage existant"
     },
     "step2": {
@@ -391,6 +395,7 @@
       "detectedLabel": "Erkannte Seite:",
       "sitesHint": "Funktioniert am besten mit {sites}. Jede andere URL wird auch als generisches Listing akzeptiert.",
       "alreadyListedTitle": "Dieses Modell ist bereits in der Bibliothek.",
+      "alreadyListedBody": "Jemand hat dieses Modell bereits hinzugefügt, es gibt also nichts mehr einzureichen.",
       "alreadyListedLink": "Vorhandenes Listing ansehen"
     },
     "step2": {
@@ -427,6 +432,7 @@
       "detectedLabel": "Sito rilevato:",
       "sitesHint": "Funziona meglio con {sites}. Qualsiasi altro URL è accettato come listato generico.",
       "alreadyListedTitle": "Questo modello è già nella libreria.",
+      "alreadyListedBody": "Qualcuno ha già aggiunto questo modello, quindi non c'è altro da inviare.",
       "alreadyListedLink": "Visualizza il listato esistente"
     },
     "step2": {
@@ -463,6 +469,7 @@
       "detectedLabel": "Site detectado:",
       "sitesHint": "Funciona melhor com {sites}. Qualquer outro URL também é aceito como listagem genérica.",
       "alreadyListedTitle": "Este modelo já está na biblioteca.",
+      "alreadyListedBody": "Alguém já adicionou este modelo, então não há mais nada a enviar.",
       "alreadyListedLink": "Ver a listagem existente"
     },
     "step2": {
@@ -499,6 +506,7 @@
       "detectedLabel": "Обнаруженный сайт:",
       "sitesHint": "Лучше всего работает с {sites}. Любой другой URL принимается как общий листинг.",
       "alreadyListedTitle": "Эта модель уже есть в библиотеке.",
+      "alreadyListedBody": "Кто-то уже добавил эту модель, так что отправлять больше нечего.",
       "alreadyListedLink": "Посмотреть существующий листинг"
     },
     "step2": {
@@ -535,6 +543,7 @@
       "detectedLabel": "検出されたサイト：",
       "sitesHint": "{sites}で最もよく機能します。その他のURLも汎用リストとして受け付けられます。",
       "alreadyListedTitle": "このモデルはすでにライブラリにあります。",
+      "alreadyListedBody": "このモデルはすでに誰かが追加しているため、提出するものはありません。",
       "alreadyListedLink": "既存のリストを見る"
     },
     "step2": {
@@ -571,6 +580,7 @@
       "detectedLabel": "检测到的网站：",
       "sitesHint": "最适合 {sites}。其他链接也可作为通用列表接受。",
       "alreadyListedTitle": "此模型已在库中。",
+      "alreadyListedBody": "已有人添加了此模型，因此无需再提交。",
       "alreadyListedLink": "查看现有列表"
     },
     "step2": {
@@ -607,6 +617,7 @@
       "detectedLabel": "감지된 사이트:",
       "sitesHint": "{sites}에서 가장 잘 작동합니다. 다른 URL도 일반 목록으로 허용됩니다.",
       "alreadyListedTitle": "이 모델은 이미 라이브러리에 있습니다.",
+      "alreadyListedBody": "이미 다른 사용자가 이 모델을 추가했으므로 제출할 항목이 없습니다.",
       "alreadyListedLink": "기존 목록 보기"
     },
     "step2": {

--- a/tests/unit/components/models/external-submit-form.test.ts
+++ b/tests/unit/components/models/external-submit-form.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+/**
+ * ExternalModelSubmitForm (app/components/models/ExternalModelSubmitForm.vue).
+ *
+ * Regression for Brian's report (June 2026): pasting the URL of a model that
+ * is already in the library and clicking "Fetch details" silently did nothing.
+ * Root cause — /api/models/external/fetch returns the FULL preview object with
+ * `alreadyListed` set, but the template gated the "already listed" alert on
+ * `alreadyListed && !preview`, while step 2 was gated on `preview && !alreadyListed`.
+ * With both refs set, neither branch rendered. These tests pin the fix: the
+ * alert renders whenever `alreadyListed` is set (preview present or not), and
+ * step 2 stays hidden in that case.
+ *
+ * The i18n mock returns translation keys verbatim, so assertions match keys.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref, computed, defineComponent, h, Suspense } from 'vue';
+import ExternalModelSubmitForm from '~/app/components/models/ExternalModelSubmitForm.vue';
+
+/** A preview object with just enough shape for the template to render step 2. */
+function makePreview(overrides: Record<string, any> = {}) {
+  return {
+    sourceSite: 'printables',
+    sourceUrl: 'https://www.printables.com/model/123-brake-duct',
+    externalId: '123',
+    title: 'Brake Duct',
+    description: 'A printable brake cooling duct',
+    summary: null,
+    authorName: 'Brian',
+    authorUrl: 'https://www.printables.com/@brian',
+    license: 'CC-BY',
+    remixesAllowed: true,
+    commercialUseAllowed: false,
+    tags: ['brake', 'cooling'],
+    printSettings: null,
+    images: [{ url: 'https://img.test/1.jpg', isPrimary: true }],
+    alreadyListed: null,
+    ...overrides,
+  };
+}
+
+/** Build the composable stub the component consumes via useExternalModelSubmit(). */
+function makeFormStub(overrides: Record<string, any> = {}) {
+  const stub = {
+    url: ref(''),
+    isValidUrl: computed(() => true),
+    detectedSite: ref(null),
+    fetching: ref(false),
+    preview: ref<any>(null),
+    fetchError: ref<string | null>(null),
+    alreadyListed: ref<{ slug: string } | null>(null),
+    fetchPreview: vi.fn(),
+    title: ref(''),
+    description: ref(''),
+    categorySlug: ref(''),
+    tags: ref<string[]>([]),
+    submitting: ref(false),
+    submitError: ref<string | null>(null),
+    submittedSlug: ref<string | null>(null),
+    submit: vi.fn(),
+    reset: vi.fn(),
+  };
+  Object.assign(stub, overrides);
+  return stub;
+}
+
+const mountStubs = {
+  ModelsSourceBadge: { name: 'ModelsSourceBadge', template: '<span class="mock-source-badge" />', props: ['site', 'size'] },
+  NuxtLink: { name: 'NuxtLink', template: '<a :href="to"><slot /></a>', props: ['to'] },
+};
+
+// The component uses top-level `await useFetch()`, so it has async setup and
+// only resolves inside a Suspense boundary. Wrap it so html() is populated
+// after flushPromises.
+const SuspenseWrapper = defineComponent({
+  render() {
+    return h(Suspense, null, { default: () => h(ExternalModelSubmitForm), fallback: () => h('div') });
+  },
+});
+
+async function mountForm(form: ReturnType<typeof makeFormStub>) {
+  vi.stubGlobal('useExternalModelSubmit', () => form);
+  vi.stubGlobal('useFetch', vi.fn().mockResolvedValue({ data: ref({ categories: [{ slug: 'cooling', name: 'Cooling' }] }) }));
+  const wrapper = mount(SuspenseWrapper, { global: { stubs: mountStubs } });
+  await flushPromises();
+  return wrapper;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('ExternalModelSubmitForm — already-listed feedback', () => {
+  it('renders the "already in the library" alert when a preview comes back already listed', async () => {
+    // Mirrors the real fetch response: full preview AND alreadyListed both set.
+    const form = makeFormStub({
+      preview: ref(makePreview({ alreadyListed: { slug: 'brake-duct' } })),
+      alreadyListed: ref({ slug: 'brake-duct' }),
+    });
+    const wrapper = await mountForm(form);
+
+    const html = wrapper.html();
+    // The user now gets an explicit message (title + body) — not a silent exit.
+    expect(html).toContain('step1.alreadyListedTitle');
+    expect(html).toContain('step1.alreadyListedBody');
+    // ...with a link to the existing listing.
+    expect(wrapper.find('a[href="/models/external/brake-duct"]').exists()).toBe(true);
+  });
+
+  it('does not render step 2 (the edit/submit form) when the model is already listed', async () => {
+    const form = makeFormStub({
+      preview: ref(makePreview({ alreadyListed: { slug: 'brake-duct' } })),
+      alreadyListed: ref({ slug: 'brake-duct' }),
+    });
+    const wrapper = await mountForm(form);
+
+    // Step 2 heading / submit button must stay hidden — there is nothing to submit.
+    expect(wrapper.html()).not.toContain('step2.heading');
+    expect(wrapper.html()).not.toContain('step2.submitBtn');
+  });
+});
+
+describe('ExternalModelSubmitForm — normal preview path', () => {
+  it('renders step 2 with the submit button when a fresh (not-listed) preview loads', async () => {
+    const form = makeFormStub({ preview: ref(makePreview()) });
+    const wrapper = await mountForm(form);
+
+    expect(wrapper.html()).toContain('step2.heading');
+    expect(wrapper.html()).toContain('step2.submitBtn');
+    // No already-listed alert on the happy path.
+    expect(wrapper.html()).not.toContain('step1.alreadyListedTitle');
+  });
+
+  it('shows the success state once a slug is submitted, hiding both steps', async () => {
+    const form = makeFormStub({
+      preview: ref(makePreview()),
+      submittedSlug: ref('brake-duct'),
+    });
+    const wrapper = await mountForm(form);
+
+    expect(wrapper.html()).toContain('success.title');
+    expect(wrapper.html()).not.toContain('step1.heading');
+    expect(wrapper.html()).not.toContain('step2.heading');
+  });
+});


### PR DESCRIPTION
## Problem

Reported by a user (Brian): when adding a Printables model via **Link an External Model**, pasting a URL and clicking **Fetch details** did nothing — no error, no step 2, just a stopped spinner. The cause turned out to be that two of his models had already been submitted by someone else, and the duplicate case had no user-facing feedback.

## Root cause

`/api/models/external/fetch` returns the **full preview object** with `alreadyListed` set when the source URL is already in `external_models`. But the template gated:

- the "already in the library" alert on `alreadyListed && !preview`
- step 2 (edit/submit) on `preview && !alreadyListed`

With both refs set, **neither branch rendered** — a silent exit.

## Fix

- Drop the `&& !preview` guard on the alert in [`ExternalModelSubmitForm.vue`](app/components/models/ExternalModelSubmitForm.vue) so it shows whenever the dedupe check matches. `showStep2` already excludes `alreadyListed`, so there's no double-render.
- Add an `alreadyListedBody` explanation ("Someone has already added this model, so there's nothing more to submit.") across all 10 locales, above the existing "View the existing listing" link.

## Tests

New component test (`tests/unit/components/models/external-submit-form.test.ts`) covering:
- duplicate fetch (preview **and** `alreadyListed` both set) renders the alert + link — verified to **fail** against the old gate
- step 2 stays hidden when already listed
- normal preview still renders step 2
- success state hides both steps

All 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)