### PR TITLE
feat(exchange): read pages — finds/wanted/sold + full browse (3/10)

### DIFF
--- a/app/components/exchange/finds/FindCard.vue
+++ b/app/components/exchange/finds/FindCard.vue
@@ -1,0 +1,166 @@
+<template>
+  <NuxtLink
+    :to="`/exchange/finds/${find.slug}`"
+    class="card bg-base-100 shadow-sm hover:shadow-lg transition-all duration-200 cursor-pointer h-full"
+  >
+    <!-- Image -->
+    <figure class="relative">
+      <div class="aspect-video bg-linear-to-br from-base-200 to-base-300 w-full">
+        <img
+          v-if="find.og_image_url && !imageError"
+          :src="find.og_image_url"
+          :alt="find.title"
+          class="w-full h-full object-cover"
+          loading="lazy"
+          @error="imageError = true"
+        />
+        <div v-else class="w-full h-full flex items-center justify-center">
+          <i class="fas fa-link text-5xl text-base-content/30"></i>
+        </div>
+      </div>
+
+      <!-- Source site badge -->
+      <ExchangeFindsSourceSiteBadge :site="find.source_site" class="absolute top-2 left-2 shadow-sm" />
+
+      <!-- Editor's Pick badge -->
+      <span v-if="find.is_editors_pick" class="badge badge-sm badge-accent absolute top-2 right-2 gap-1">
+        <i class="fas fa-star"></i>
+        {{ t('editorsPick') }}
+      </span>
+    </figure>
+
+    <!-- Card Body -->
+    <div class="card-body p-4">
+      <!-- Title -->
+      <h3 class="card-title text-base font-bold line-clamp-2">{{ find.title }}</h3>
+
+      <!-- Year / Model -->
+      <p v-if="find.year || find.model" class="text-sm text-base-content/70">
+        {{ [find.year, find.model].filter(Boolean).join(' ') }}
+      </p>
+
+      <!-- Price -->
+      <div v-if="find.price != null" class="text-lg font-bold text-primary">
+        {{ find.price_label || formatPrice(find.price) }}
+      </div>
+      <div v-else-if="find.price_label" class="text-lg font-bold text-primary">
+        {{ find.price_label }}
+      </div>
+
+      <!-- Auction countdown -->
+      <div
+        v-if="auctionLabel"
+        class="flex items-center gap-1 text-sm"
+        :class="auctionEnded ? 'text-base-content/50' : 'text-warning'"
+      >
+        <i :class="auctionEnded ? 'fas fa-clock' : 'fas fa-fire'"></i>
+        {{ auctionLabel }}
+      </div>
+
+      <!-- Description snippet -->
+      <p v-if="find.description" class="text-sm text-base-content/60 line-clamp-2">
+        {{ find.description }}
+      </p>
+
+      <!-- Tags -->
+      <div v-if="find.tags && find.tags.length > 0" class="flex flex-wrap gap-1 mt-1">
+        <span v-for="tag in displayTags" :key="tag" class="badge badge-xs badge-outline">
+          {{ tag }}
+        </span>
+        <span v-if="find.tags.length > 3" class="badge badge-xs badge-ghost"> +{{ find.tags.length - 3 }} </span>
+      </div>
+
+      <!-- Footer row -->
+      <div class="flex items-center justify-between text-xs text-base-content/50 mt-auto pt-2">
+        <div class="flex items-center gap-3">
+          <span class="flex items-center gap-1">
+            <i class="fas fa-heart"></i>
+            {{ find.like_count }}
+          </span>
+          <span class="flex items-center gap-1">
+            <i class="fas fa-comment"></i>
+            {{ find.comment_count }}
+          </span>
+        </div>
+        <ExchangeFindsSourceSiteBadge :site="find.source_site" icon-only />
+      </div>
+    </div>
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+  import type { ExternalListing } from '~/composables/useExternalListings';
+
+  const { t } = useI18n();
+
+  interface Props {
+    find: ExternalListing;
+  }
+
+  const props = defineProps<Props>();
+
+  const imageError = ref(false);
+
+  // Format price as currency
+  const formatPrice = (price: number): string => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(price);
+  };
+
+  // Only show first 3 tags
+  const displayTags = computed(() => {
+    return props.find.tags?.slice(0, 3) || [];
+  });
+
+  // Don't show auction countdown if the listing is already sold
+  const isSold = computed(() => {
+    return props.find.price_label ? /sold/i.test(props.find.price_label) : false;
+  });
+
+  // Auction countdown logic
+  const auctionEnded = computed(() => {
+    if (!props.find.auction_end_time || isSold.value) return false;
+    return new Date(props.find.auction_end_time) <= new Date();
+  });
+
+  const auctionLabel = computed(() => {
+    if (!props.find.auction_end_time || isSold.value) return null;
+
+    const endTime = new Date(props.find.auction_end_time);
+    const now = new Date();
+
+    if (endTime <= now) {
+      return t('ended');
+    }
+
+    const diffMs = endTime.getTime() - now.getTime();
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+    const diffDays = Math.floor(diffHours / 24);
+    const remainingHours = diffHours % 24;
+
+    if (diffDays > 0) {
+      return t('endsInDays', { days: diffDays, hours: remainingHours });
+    }
+    return t('endsInHours', { hours: diffHours, minutes: diffMinutes });
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": { "editorsPick": "Editor's Pick", "ended": "Ended", "endsInDays": "Ends in {days}d {hours}h", "endsInHours": "Ends in {hours}h {minutes}m" },
+  "es": { "editorsPick": "Selección del editor", "ended": "Finalizada", "endsInDays": "Termina en {days}d {hours}h", "endsInHours": "Termina en {hours}h {minutes}m" },
+  "fr": { "editorsPick": "Choix de la rédaction", "ended": "Terminée", "endsInDays": "Se termine dans {days}j {hours}h", "endsInHours": "Se termine dans {hours}h {minutes}m" },
+  "de": { "editorsPick": "Redaktionstipp", "ended": "Beendet", "endsInDays": "Endet in {days}T {hours}Std", "endsInHours": "Endet in {hours}Std {minutes}Min" },
+  "it": { "editorsPick": "Scelta della redazione", "ended": "Terminata", "endsInDays": "Termina tra {days}g {hours}h", "endsInHours": "Termina tra {hours}h {minutes}min" },
+  "pt": { "editorsPick": "Escolha do editor", "ended": "Encerrada", "endsInDays": "Termina em {days}d {hours}h", "endsInHours": "Termina em {hours}h {minutes}min" },
+  "ru": { "editorsPick": "Выбор редакции", "ended": "Завершено", "endsInDays": "Завершится через {days}д {hours}ч", "endsInHours": "Завершится через {hours}ч {minutes}м" },
+  "ja": { "editorsPick": "編集者のおすすめ", "ended": "終了", "endsInDays": "残り {days}日 {hours}時間", "endsInHours": "残り {hours}時間 {minutes}分" },
+  "zh": { "editorsPick": "编辑精选", "ended": "已结束", "endsInDays": "{days}天 {hours}小时后结束", "endsInHours": "{hours}小时 {minutes}分钟后结束" },
+  "ko": { "editorsPick": "편집자 추천", "ended": "종료됨", "endsInDays": "{days}일 {hours}시간 후 종료", "endsInHours": "{hours}시간 {minutes}분 후 종료" }
+}
+</i18n>

--- a/app/components/exchange/finds/FindCard.vue
+++ b/app/components/exchange/finds/FindCard.vue
@@ -47,15 +47,17 @@
         {{ find.price_label }}
       </div>
 
-      <!-- Auction countdown -->
-      <div
-        v-if="auctionLabel"
-        class="flex items-center gap-1 text-sm"
-        :class="auctionEnded ? 'text-base-content/50' : 'text-warning'"
-      >
-        <i :class="auctionEnded ? 'fas fa-clock' : 'fas fa-fire'"></i>
-        {{ auctionLabel }}
-      </div>
+      <!-- Auction countdown — client-only: now-based label drifts vs server (hydration mismatch) -->
+      <ClientOnly>
+        <div
+          v-if="auctionLabel"
+          class="flex items-center gap-1 text-sm"
+          :class="auctionEnded ? 'text-base-content/50' : 'text-warning'"
+        >
+          <i :class="auctionEnded ? 'fas fa-clock' : 'fas fa-fire'"></i>
+          {{ auctionLabel }}
+        </div>
+      </ClientOnly>
 
       <!-- Description snippet -->
       <p v-if="find.description" class="text-sm text-base-content/60 line-clamp-2">

--- a/app/components/exchange/finds/FindFilters.vue
+++ b/app/components/exchange/finds/FindFilters.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="flex flex-wrap items-end gap-3">
+    <!-- Source Site -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend text-xs">{{ t('source.label') }}</legend>
+      <select
+        :value="modelValue.sourceSite || ''"
+        class="select select-bordered select-sm"
+        @change="updateFilter('sourceSite', ($event.target as HTMLSelectElement).value || undefined)"
+      >
+        <option value="">{{ t('source.all') }}</option>
+        <option value="bat">{{ t('source.bat') }}</option>
+        <option value="carsandbids">{{ t('source.carsandbids') }}</option>
+        <option value="copart">{{ t('source.copart') }}</option>
+        <option value="craigslist">{{ t('source.craigslist') }}</option>
+        <option value="facebook">{{ t('source.facebook') }}</option>
+        <option value="ebay">{{ t('source.ebay') }}</option>
+        <option value="other">{{ t('source.other') }}</option>
+      </select>
+    </fieldset>
+
+    <!-- Category -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend text-xs">{{ t('category.label') }}</legend>
+      <select
+        :value="modelValue.category || ''"
+        class="select select-bordered select-sm"
+        @change="updateFilter('category', ($event.target as HTMLSelectElement).value || undefined)"
+      >
+        <option value="">{{ t('category.all') }}</option>
+        <option value="vehicle">{{ t('category.vehicle') }}</option>
+        <option value="engine">{{ t('category.engine') }}</option>
+        <option value="parts">{{ t('category.parts') }}</option>
+      </select>
+    </fieldset>
+
+    <!-- Sort -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend text-xs">{{ t('sort.label') }}</legend>
+      <select
+        :value="currentSort"
+        class="select select-bordered select-sm"
+        @change="updateSort(($event.target as HTMLSelectElement).value)"
+      >
+        <option value="newest">{{ t('sort.newest') }}</option>
+        <option value="most_liked">{{ t('sort.mostLiked') }}</option>
+        <option value="ending_soon">{{ t('sort.endingSoon') }}</option>
+      </select>
+    </fieldset>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { FindFilters } from '~/composables/useExternalListings';
+
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    modelValue: FindFilters;
+  }>();
+
+  const emit = defineEmits<{
+    'update:modelValue': [value: FindFilters];
+  }>();
+
+  const currentSort = computed(() => props.modelValue.sort || 'newest');
+
+  /**
+   * Update a single filter key and emit the full filters object.
+   */
+  const updateFilter = (key: keyof FindFilters, value: any) => {
+    emit('update:modelValue', {
+      ...props.modelValue,
+      [key]: value,
+      page: 1,
+    });
+  };
+
+  const updateSort = (value: string) => {
+    emit('update:modelValue', {
+      ...props.modelValue,
+      sort: value as FindFilters['sort'],
+      page: 1,
+    });
+  };
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "source": { "label": "Source", "all": "All Sources", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "Other" },
+    "category": { "label": "Category", "all": "All Categories", "vehicle": "Vehicle", "engine": "Engine", "parts": "Parts" },
+    "sort": { "label": "Sort", "newest": "Newest", "mostLiked": "Most Liked", "endingSoon": "Ending Soon" }
+  },
+  "es": {
+    "source": { "label": "Origen", "all": "Todos los orígenes", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "Otro" },
+    "category": { "label": "Categoría", "all": "Todas las categorías", "vehicle": "Vehículo", "engine": "Motor", "parts": "Piezas" },
+    "sort": { "label": "Ordenar", "newest": "Más recientes", "mostLiked": "Más populares", "endingSoon": "Terminan pronto" }
+  },
+  "fr": {
+    "source": { "label": "Source", "all": "Toutes les sources", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "Autre" },
+    "category": { "label": "Catégorie", "all": "Toutes les catégories", "vehicle": "Véhicule", "engine": "Moteur", "parts": "Pièces" },
+    "sort": { "label": "Trier", "newest": "Plus récentes", "mostLiked": "Plus aimées", "endingSoon": "Se terminent bientôt" }
+  },
+  "de": {
+    "source": { "label": "Quelle", "all": "Alle Quellen", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "Sonstige" },
+    "category": { "label": "Kategorie", "all": "Alle Kategorien", "vehicle": "Fahrzeug", "engine": "Motor", "parts": "Teile" },
+    "sort": { "label": "Sortieren", "newest": "Neueste", "mostLiked": "Beliebteste", "endingSoon": "Endet bald" }
+  },
+  "it": {
+    "source": { "label": "Fonte", "all": "Tutte le fonti", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "Altro" },
+    "category": { "label": "Categoria", "all": "Tutte le categorie", "vehicle": "Veicolo", "engine": "Motore", "parts": "Ricambi" },
+    "sort": { "label": "Ordina", "newest": "Più recenti", "mostLiked": "Più apprezzate", "endingSoon": "In scadenza" }
+  },
+  "pt": {
+    "source": { "label": "Origem", "all": "Todas as origens", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "Outro" },
+    "category": { "label": "Categoria", "all": "Todas as categorias", "vehicle": "Veículo", "engine": "Motor", "parts": "Peças" },
+    "sort": { "label": "Ordenar", "newest": "Mais recentes", "mostLiked": "Mais curtidas", "endingSoon": "Terminando em breve" }
+  },
+  "ru": {
+    "source": { "label": "Источник", "all": "Все источники", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "Другое" },
+    "category": { "label": "Категория", "all": "Все категории", "vehicle": "Автомобиль", "engine": "Двигатель", "parts": "Запчасти" },
+    "sort": { "label": "Сортировка", "newest": "Новые", "mostLiked": "Популярные", "endingSoon": "Скоро завершатся" }
+  },
+  "ja": {
+    "source": { "label": "ソース", "all": "すべてのソース", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "その他" },
+    "category": { "label": "カテゴリー", "all": "すべてのカテゴリー", "vehicle": "車両", "engine": "エンジン", "parts": "パーツ" },
+    "sort": { "label": "並び替え", "newest": "新着順", "mostLiked": "人気順", "endingSoon": "まもなく終了" }
+  },
+  "zh": {
+    "source": { "label": "来源", "all": "所有来源", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "其他" },
+    "category": { "label": "类别", "all": "所有类别", "vehicle": "整车", "engine": "发动机", "parts": "配件" },
+    "sort": { "label": "排序", "newest": "最新", "mostLiked": "最受欢迎", "endingSoon": "即将结束" }
+  },
+  "ko": {
+    "source": { "label": "출처", "all": "모든 출처", "bat": "Bring a Trailer", "carsandbids": "Cars & Bids", "copart": "Copart", "craigslist": "Craigslist", "facebook": "Facebook", "ebay": "eBay", "other": "기타" },
+    "category": { "label": "카테고리", "all": "모든 카테고리", "vehicle": "차량", "engine": "엔진", "parts": "부품" },
+    "sort": { "label": "정렬", "newest": "최신순", "mostLiked": "인기순", "endingSoon": "마감 임박" }
+  }
+}
+</i18n>

--- a/app/components/exchange/finds/LikeButton.vue
+++ b/app/components/exchange/finds/LikeButton.vue
@@ -1,0 +1,40 @@
+<template>
+  <button
+    class="btn btn-ghost btn-sm gap-1"
+    :title="isLiked ? t('unlike') : t('like')"
+    :aria-label="isLiked ? t('unlikeFind') : t('likeFind')"
+    @click.prevent="$emit('toggle')"
+  >
+    <i :class="[isLiked ? 'fas fa-heart text-error' : 'far fa-heart']"></i>
+    <span class="text-sm">{{ likeCount }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  defineProps<{
+    findId: string;
+    likeCount: number;
+    isLiked: boolean;
+  }>();
+
+  defineEmits<{
+    toggle: [];
+  }>();
+</script>
+
+<i18n lang="json">
+{
+  "en": { "like": "Like", "unlike": "Unlike", "likeFind": "Like this find", "unlikeFind": "Unlike this find" },
+  "es": { "like": "Me gusta", "unlike": "Ya no me gusta", "likeFind": "Me gusta este hallazgo", "unlikeFind": "Ya no me gusta este hallazgo" },
+  "fr": { "like": "J'aime", "unlike": "Je n'aime plus", "likeFind": "J'aime cette trouvaille", "unlikeFind": "Je n'aime plus cette trouvaille" },
+  "de": { "like": "Gefällt mir", "unlike": "Gefällt mir nicht mehr", "likeFind": "Diesen Fund liken", "unlikeFind": "Like für diesen Fund entfernen" },
+  "it": { "like": "Mi piace", "unlike": "Non mi piace più", "likeFind": "Aggiungi mi piace a questa scoperta", "unlikeFind": "Rimuovi mi piace da questa scoperta" },
+  "pt": { "like": "Curtir", "unlike": "Descurtir", "likeFind": "Curtir este achado", "unlikeFind": "Descurtir este achado" },
+  "ru": { "like": "Нравится", "unlike": "Не нравится", "likeFind": "Нравится эта находка", "unlikeFind": "Убрать отметку «Нравится» с этой находки" },
+  "ja": { "like": "いいね", "unlike": "いいねを取り消す", "likeFind": "この出品にいいね", "unlikeFind": "この出品のいいねを取り消す" },
+  "zh": { "like": "点赞", "unlike": "取消点赞", "likeFind": "为这个发现点赞", "unlikeFind": "取消为这个发现点赞" },
+  "ko": { "like": "좋아요", "unlike": "좋아요 취소", "likeFind": "이 발견에 좋아요", "unlikeFind": "이 발견 좋아요 취소" }
+}
+</i18n>

--- a/app/components/exchange/finds/SourceSiteBadge.vue
+++ b/app/components/exchange/finds/SourceSiteBadge.vue
@@ -1,0 +1,48 @@
+<template>
+  <span
+    class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-bold leading-none whitespace-nowrap"
+    :class="sizeClass"
+    :style="{ backgroundColor: brand.bg, color: brand.text }"
+  >
+    <img v-if="brand.logo" :src="brand.logo" :alt="brand.label" :class="iconClass" class="rounded-sm object-contain" />
+    <i v-else class="fas fa-link" :class="iconClass"></i>
+
+    <span v-if="!iconOnly">{{ brand.label }}</span>
+  </span>
+</template>
+
+<script setup lang="ts">
+  interface Props {
+    site: string;
+    size?: 'sm' | 'md';
+    iconOnly?: boolean;
+  }
+
+  const props = withDefaults(defineProps<Props>(), {
+    size: 'sm',
+    iconOnly: false,
+  });
+
+  interface BrandConfig {
+    bg: string;
+    text: string;
+    label: string;
+    logo: string | null;
+  }
+
+  const brandMap: Record<string, BrandConfig> = {
+    bat: { bg: '#B12024', text: '#ffffff', label: 'Bring a Trailer', logo: '/logos/sources/bat.png' },
+    carsandbids: { bg: '#0D9488', text: '#ffffff', label: 'Cars & Bids', logo: '/logos/sources/carsandbids.png' },
+    copart: { bg: '#003B71', text: '#ffffff', label: 'Copart', logo: '/logos/sources/copart.png' },
+    craigslist: { bg: '#5B2C82', text: '#ffffff', label: 'Craigslist', logo: '/logos/sources/craigslist.png' },
+    facebook: { bg: '#1877F2', text: '#ffffff', label: 'Marketplace', logo: '/logos/sources/facebook.png' },
+    ebay: { bg: '#E53238', text: '#ffffff', label: 'eBay', logo: '/logos/sources/ebay.png' },
+    other: { bg: '#6B7280', text: '#ffffff', label: 'Other', logo: null },
+  };
+
+  const defaultBrand: BrandConfig = { bg: '#6B7280', text: '#ffffff', label: 'Other', logo: null };
+  const brand = computed((): BrandConfig => brandMap[props.site] ?? defaultBrand);
+
+  const sizeClass = computed(() => (props.size === 'md' ? 'text-sm px-2.5 py-1.5' : ''));
+  const iconClass = computed(() => (props.size === 'md' ? 'w-4 h-4' : 'w-3.5 h-3.5'));
+</script>

--- a/app/components/exchange/listings/FilterSidebar.vue
+++ b/app/components/exchange/listings/FilterSidebar.vue
@@ -1,0 +1,987 @@
+<template>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body p-4">
+      <div class="flex items-center justify-between mb-2">
+        <h3 class="card-title text-lg">{{ t('filters') }}</h3>
+        <button v-if="hasActiveFilters" class="btn btn-ghost btn-sm" @click="onClearFilters">
+          <i class="fas fa-xmark text-xl"></i>
+          {{ t('clearAll') }}
+        </button>
+      </div>
+
+      <!-- Category Filter -->
+      <div class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('category') }}</label>
+        <select v-model="selectedCategory" class="select select-sm w-full">
+          <option value="">{{ t('allCategories') }}</option>
+          <option value="vehicle">{{ t('categoryVehicles') }}</option>
+          <option value="engine">{{ t('categoryEngines') }}</option>
+          <option value="parts">{{ t('categoryParts') }}</option>
+        </select>
+      </div>
+
+      <!-- Parts Subcategory Filter (shown when Parts is selected) -->
+      <div v-if="selectedCategory === 'parts'" class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('partType') }}</label>
+        <select v-model="selectedPartsSubcategory" class="select select-sm w-full">
+          <option value="">{{ t('allPartTypes') }}</option>
+          <option value="body_exterior">{{ t('partBodyExterior') }}</option>
+          <option value="interior">{{ t('partInterior') }}</option>
+          <option value="wheels_tires">{{ t('partWheelsTires') }}</option>
+          <option value="engine_internals">{{ t('partEngineInternals') }}</option>
+          <option value="suspension">{{ t('partSuspension') }}</option>
+          <option value="electrical">{{ t('partElectrical') }}</option>
+          <option value="other">{{ t('partOther') }}</option>
+        </select>
+      </div>
+
+      <div class="divider my-0"></div>
+
+      <!-- Year Range Filter -->
+      <div class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('year') }}</label>
+        <select v-model="selectedYearRange" class="select select-sm w-full">
+          <option value="">{{ t('allYears') }}</option>
+          <option value="1960s">1959-1969</option>
+          <option value="1970s">1970-1979</option>
+          <option value="1980s">1980-1989</option>
+          <option value="1990s">1990-2000</option>
+        </select>
+      </div>
+
+      <div class="divider my-0"></div>
+
+      <!-- Manufacturer Filter (Vehicles only) -->
+      <div v-if="!selectedCategory || selectedCategory === 'vehicle'" class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('manufacturer') }}</label>
+        <select v-model="selectedManufacturer" class="select select-sm w-full">
+          <option value="">{{ t('allManufacturers') }}</option>
+          <option value="morris">Morris</option>
+          <option value="austin">Austin</option>
+          <option value="rover">Rover</option>
+          <option value="leyland">Leyland</option>
+          <option value="innocenti">Innocenti</option>
+          <option value="wolseley">Wolseley</option>
+          <option value="riley">Riley</option>
+          <option value="other">{{ t('manufacturerOther') }}</option>
+        </select>
+      </div>
+
+      <div class="divider my-0"></div>
+
+      <!-- Model Filter -->
+      <div class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('model') }}</label>
+        <select v-model="selectedModel" class="select select-sm w-full">
+          <option value="">{{ t('allModels') }}</option>
+          <option value="Mini">Mini</option>
+          <option value="Seven">Seven</option>
+          <option value="Mini-Minor">Mini-Minor</option>
+          <option value="Cooper">Cooper</option>
+          <option value="Cooper S">Cooper S</option>
+          <option value="Clubman">Clubman</option>
+          <option value="Clubman Estate">Clubman Estate</option>
+          <option value="Mini 1000">Mini 1000</option>
+          <option value="1275 GT">1275 GT</option>
+          <option value="Elf">Elf</option>
+          <option value="Hornet">Hornet</option>
+          <option value="Moke">Moke</option>
+          <option value="Countryman">Countryman</option>
+          <option value="Traveller">Traveller</option>
+          <option value="Van">Van</option>
+          <option value="Pickup">Pickup</option>
+          <option value="Other">{{ t('modelOther') }}</option>
+        </select>
+      </div>
+
+      <div class="divider my-0"></div>
+
+      <!-- Condition Filter -->
+      <div class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('condition') }}</label>
+        <select v-model="selectedCondition" class="select select-sm w-full">
+          <option value="">{{ t('allConditions') }}</option>
+          <option value="excellent">{{ t('conditionExcellent') }}</option>
+          <option value="good">{{ t('conditionGood') }}</option>
+          <option value="fair">{{ t('conditionFair') }}</option>
+          <option value="project">{{ t('conditionProject') }}</option>
+        </select>
+      </div>
+
+      <div class="divider my-0"></div>
+
+      <!-- Price Range Filter -->
+      <div class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('priceRange') }}</label>
+        <select v-model="selectedPriceRange" class="select select-sm w-full">
+          <option value="">{{ t('allPrices') }}</option>
+          <option value="free">{{ t('priceFree') }}</option>
+          <option value="under-10k">{{ t('priceUnder10k') }}</option>
+          <option value="10k-20k">$10,000 - $20,000</option>
+          <option value="20k-30k">$20,000 - $30,000</option>
+          <option value="30k-50k">$30,000 - $50,000</option>
+          <option value="over-50k">{{ t('priceOver50k') }}</option>
+        </select>
+      </div>
+
+      <div class="divider my-0"></div>
+
+      <!-- Transmission Filter -->
+      <div class="mb-3">
+        <label class="text-sm font-medium mb-1 block">{{ t('transmission') }}</label>
+        <select v-model="selectedTransmission" class="select select-sm w-full">
+          <option value="">{{ t('allTransmissions') }}</option>
+          <option value="magic_wand">Magic Wand</option>
+          <option value="3_synchro_remote">3-Synchro Remote</option>
+          <option value="4_synchro_remote">4-Synchro Remote</option>
+          <option value="rod_change">Rod Change</option>
+          <option value="automatic">{{ t('transmissionAutomatic') }}</option>
+        </select>
+      </div>
+
+      <div class="divider my-0"></div>
+
+      <!-- Location Filter -->
+      <div class="mb-2">
+        <label class="text-sm font-medium mb-1 block">{{ t('location') }}</label>
+        <label class="input input-sm flex items-center gap-2">
+          <i class="fas fa-location-dot text-base-content/50"></i>
+          <input v-model="selectedLocation" type="text" :placeholder="t('locationPlaceholder')" class="grow" />
+        </label>
+
+        <!-- Distance Filter (shown when location is entered) -->
+        <div v-if="selectedLocation" class="mt-2">
+          <label class="text-xs text-base-content/70 mb-1 block">{{ t('distance') }}</label>
+          <select v-model="selectedDistance" class="select select-sm w-full">
+            <option value="25">{{ t('distanceWithin', { miles: 25 }) }}</option>
+            <option value="50">{{ t('distanceWithin', { miles: 50 }) }}</option>
+            <option value="100">{{ t('distanceWithin', { miles: 100 }) }}</option>
+            <option value="250">{{ t('distanceWithin', { miles: 250 }) }}</option>
+            <option value="500">{{ t('distanceWithin', { miles: 500 }) }}</option>
+            <option value="">{{ t('distanceAny') }}</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Active Filter Badges -->
+      <div v-if="hasActiveFilters" class="mt-3 pt-3 border-t border-base-300">
+        <p class="text-xs text-base-content/70 mb-2">{{ t('activeFilters') }}</p>
+        <div class="flex flex-wrap gap-2">
+          <div v-if="selectedCategory" class="badge badge-ghost gap-2">
+            {{ getCategoryLabel(selectedCategory) }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedCategory = ''"
+              :aria-label="t('removeCategoryFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedPartsSubcategory" class="badge badge-ghost gap-2">
+            {{ getPartsSubcategoryLabel(selectedPartsSubcategory) }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedPartsSubcategory = ''"
+              :aria-label="t('removePartsSubcategoryFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedYearRange" class="badge badge-ghost gap-2">
+            {{ getYearRangeLabel(selectedYearRange) }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedYearRange = ''"
+              :aria-label="t('removeYearFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedManufacturer" class="badge badge-ghost gap-2">
+            {{ getManufacturerLabel(selectedManufacturer) }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedManufacturer = ''"
+              :aria-label="t('removeManufacturerFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedModel" class="badge badge-ghost gap-2">
+            {{ selectedModel }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedModel = ''"
+              :aria-label="t('removeModelFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedCondition" class="badge badge-ghost gap-2">
+            {{ selectedCondition }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedCondition = ''"
+              :aria-label="t('removeConditionFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedPriceRange" class="badge badge-ghost gap-2">
+            {{ getPriceRangeLabel(selectedPriceRange) }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedPriceRange = ''"
+              :aria-label="t('removePriceFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedTransmission" class="badge badge-ghost gap-2">
+            {{ getTransmissionLabel(selectedTransmission) }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="selectedTransmission = ''"
+              :aria-label="t('removeTransmissionFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+          <div v-if="selectedLocation" class="badge badge-ghost gap-2">
+            {{ selectedLocation }}{{ selectedDistance ? ` (${selectedDistance} mi)` : '' }}
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              @click="clearLocationFilter"
+              :aria-label="t('removeLocationFilter')"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Save Search Button -->
+      <ExchangeListingsSaveSearchButton
+        v-if="hasActiveFilters"
+        :filters="currentFilters"
+        :filter-summary="filterSummaryText"
+        class="mt-3"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { useDebounceFn } from '@vueuse/core';
+  import {
+    getCategoryLabel,
+    getPartsSubcategoryLabel,
+    getYearRangeLabel,
+    getPriceRangeLabel,
+    getTransmissionLabel,
+    getManufacturerLabel,
+  } from '~/utils/filterLabels';
+
+  const { t } = useI18n();
+  const { capture } = usePostHog();
+
+  const props = defineProps<{
+    resultsCount?: number;
+  }>();
+
+  const selectedCategory = defineModel<string>('category', { required: true });
+  const selectedPartsSubcategory = defineModel<string>('partsSubcategory', { required: true });
+  const selectedYearRange = defineModel<string>('yearRange', { required: true });
+  const selectedManufacturer = defineModel<string>('manufacturer', { required: true });
+  const selectedModel = defineModel<string>('model', { required: true });
+  const selectedCondition = defineModel<string>('condition', { required: true });
+  const selectedPriceRange = defineModel<string>('priceRange', { required: true });
+  const selectedTransmission = defineModel<string>('transmission', { required: true });
+  const selectedLocation = defineModel<string>('location', { required: true });
+  const selectedDistance = defineModel<string>('distance', { required: true });
+
+  // Track filter application
+  const trackFilterApplied = (
+    filterType: 'category' | 'year' | 'price' | 'condition' | 'transmission' | 'location' | 'model',
+    value: string | number | [number, number]
+  ) => {
+    if (value) {
+      capture('filter_applied', {
+        filter_type: filterType,
+        filter_value: value,
+        results_count: props.resultsCount ?? 0,
+      });
+    }
+  };
+
+  // Watch for filter changes and track analytics
+  watch(selectedCategory, (newValue) => {
+    trackFilterApplied('category', newValue);
+  });
+
+  watch(selectedYearRange, (newValue) => {
+    trackFilterApplied('year', newValue);
+  });
+
+  watch(selectedModel, (newValue) => {
+    trackFilterApplied('model', newValue);
+  });
+
+  watch(selectedCondition, (newValue) => {
+    trackFilterApplied('condition', newValue);
+  });
+
+  watch(selectedPriceRange, (newValue) => {
+    trackFilterApplied('price', newValue);
+  });
+
+  watch(selectedTransmission, (newValue) => {
+    trackFilterApplied('transmission', newValue);
+  });
+
+  // Debounced location tracking to avoid tracking every keystroke
+  const debouncedLocationTrack = useDebounceFn((value: string) => {
+    trackFilterApplied('location', value);
+  }, 1000);
+
+  watch(selectedLocation, (newValue) => {
+    if (newValue) {
+      debouncedLocationTrack(newValue);
+    }
+  });
+
+  // Clear parts subcategory when category changes from parts
+  watch(selectedCategory, (newCategory) => {
+    if (newCategory !== 'parts') {
+      selectedPartsSubcategory.value = '';
+    }
+  });
+
+  // Clear distance when location is cleared
+  watch(selectedLocation, (newLocation) => {
+    if (!newLocation) {
+      selectedDistance.value = '';
+    }
+  });
+
+  // Helper to clear both location and distance
+  const clearLocationFilter = () => {
+    selectedLocation.value = '';
+    selectedDistance.value = '';
+  };
+
+  const emit = defineEmits<{
+    clearFilters: [];
+  }>();
+
+  const hasActiveFilters = computed(
+    () =>
+      !!(
+        selectedCategory.value ||
+        selectedPartsSubcategory.value ||
+        selectedYearRange.value ||
+        selectedManufacturer.value ||
+        selectedModel.value ||
+        selectedCondition.value ||
+        selectedPriceRange.value ||
+        selectedTransmission.value ||
+        selectedLocation.value ||
+        selectedDistance.value
+      )
+  );
+
+  const onClearFilters = () => {
+    emit('clearFilters');
+  };
+
+  // Computed filter state for SaveSearchButton
+  const currentFilters = computed(() => {
+    const f: Record<string, string> = {};
+    if (selectedCategory.value) f.listing_category = selectedCategory.value;
+    if (selectedPartsSubcategory.value) f.parts_subcategory = selectedPartsSubcategory.value;
+    if (selectedYearRange.value) f.year_range = selectedYearRange.value;
+    if (selectedManufacturer.value) f.manufacturer = selectedManufacturer.value;
+    if (selectedModel.value) f.model = selectedModel.value;
+    if (selectedCondition.value) f.condition = selectedCondition.value;
+    if (selectedPriceRange.value) f.price_range = selectedPriceRange.value;
+    if (selectedTransmission.value) f.transmission = selectedTransmission.value;
+    if (selectedLocation.value) f.location = selectedLocation.value;
+    return f;
+  });
+
+  const filterSummaryText = computed(() => {
+    const parts: string[] = [];
+    if (selectedCategory.value) parts.push(getCategoryLabel(selectedCategory.value));
+    if (selectedModel.value) parts.push(selectedModel.value);
+    if (selectedYearRange.value) parts.push(getYearRangeLabel(selectedYearRange.value));
+    if (selectedPriceRange.value) parts.push(getPriceRangeLabel(selectedPriceRange.value));
+    if (selectedCondition.value) parts.push(selectedCondition.value);
+    if (selectedTransmission.value) parts.push(getTransmissionLabel(selectedTransmission.value));
+    if (selectedLocation.value) parts.push(selectedLocation.value);
+    return parts.join(', ');
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "filters": "Filters",
+    "clearAll": "Clear All",
+    "category": "Category",
+    "allCategories": "All Categories",
+    "categoryVehicles": "Vehicles",
+    "categoryEngines": "Engines",
+    "categoryParts": "Parts",
+    "partType": "Part Type",
+    "allPartTypes": "All Part Types",
+    "partBodyExterior": "Body & Exterior",
+    "partInterior": "Interior",
+    "partWheelsTires": "Wheels & Tires",
+    "partEngineInternals": "Engine Internals",
+    "partSuspension": "Suspension",
+    "partElectrical": "Electrical",
+    "partOther": "Other",
+    "year": "Year",
+    "allYears": "All Years",
+    "manufacturer": "Manufacturer",
+    "allManufacturers": "All Manufacturers",
+    "manufacturerOther": "Other",
+    "model": "Model",
+    "allModels": "All Models",
+    "modelOther": "Other",
+    "condition": "Condition",
+    "allConditions": "All Conditions",
+    "conditionExcellent": "Excellent",
+    "conditionGood": "Good",
+    "conditionFair": "Fair",
+    "conditionProject": "Project",
+    "priceRange": "Price Range",
+    "allPrices": "All Prices",
+    "priceFree": "Free",
+    "priceUnder10k": "Under $10,000",
+    "priceOver50k": "Over $50,000",
+    "transmission": "Transmission",
+    "allTransmissions": "All Transmissions",
+    "transmissionAutomatic": "Automatic",
+    "location": "Location",
+    "locationPlaceholder": "City, State, or Zip",
+    "distance": "Distance",
+    "distanceWithin": "Within {miles} miles",
+    "distanceAny": "Any distance",
+    "activeFilters": "Active Filters:",
+    "removeCategoryFilter": "Remove category filter",
+    "removePartsSubcategoryFilter": "Remove parts subcategory filter",
+    "removeYearFilter": "Remove year filter",
+    "removeManufacturerFilter": "Remove manufacturer filter",
+    "removeModelFilter": "Remove model filter",
+    "removeConditionFilter": "Remove condition filter",
+    "removePriceFilter": "Remove price filter",
+    "removeTransmissionFilter": "Remove transmission filter",
+    "removeLocationFilter": "Remove location filter"
+  },
+  "es": {
+    "filters": "Filtros",
+    "clearAll": "Borrar todo",
+    "category": "Categoría",
+    "allCategories": "Todas las categorías",
+    "categoryVehicles": "Vehículos",
+    "categoryEngines": "Motores",
+    "categoryParts": "Piezas",
+    "partType": "Tipo de pieza",
+    "allPartTypes": "Todos los tipos de piezas",
+    "partBodyExterior": "Carrocería y exterior",
+    "partInterior": "Interior",
+    "partWheelsTires": "Ruedas y neumáticos",
+    "partEngineInternals": "Internos del motor",
+    "partSuspension": "Suspensión",
+    "partElectrical": "Eléctrico",
+    "partOther": "Otro",
+    "year": "Año",
+    "allYears": "Todos los años",
+    "manufacturer": "Fabricante",
+    "allManufacturers": "Todos los fabricantes",
+    "manufacturerOther": "Otro",
+    "model": "Modelo",
+    "allModels": "Todos los modelos",
+    "modelOther": "Otro",
+    "condition": "Estado",
+    "allConditions": "Todos los estados",
+    "conditionExcellent": "Excelente",
+    "conditionGood": "Bueno",
+    "conditionFair": "Aceptable",
+    "conditionProject": "Proyecto",
+    "priceRange": "Rango de precios",
+    "allPrices": "Todos los precios",
+    "priceFree": "Gratis",
+    "priceUnder10k": "Menos de $10,000",
+    "priceOver50k": "Más de $50,000",
+    "transmission": "Transmisión",
+    "allTransmissions": "Todas las transmisiones",
+    "transmissionAutomatic": "Automática",
+    "location": "Ubicación",
+    "locationPlaceholder": "Ciudad, estado o código postal",
+    "distance": "Distancia",
+    "distanceWithin": "Dentro de {miles} millas",
+    "distanceAny": "Cualquier distancia",
+    "activeFilters": "Filtros activos:",
+    "removeCategoryFilter": "Quitar filtro de categoría",
+    "removePartsSubcategoryFilter": "Quitar filtro de tipo de pieza",
+    "removeYearFilter": "Quitar filtro de año",
+    "removeManufacturerFilter": "Quitar filtro de fabricante",
+    "removeModelFilter": "Quitar filtro de modelo",
+    "removeConditionFilter": "Quitar filtro de estado",
+    "removePriceFilter": "Quitar filtro de precio",
+    "removeTransmissionFilter": "Quitar filtro de transmisión",
+    "removeLocationFilter": "Quitar filtro de ubicación"
+  },
+  "fr": {
+    "filters": "Filtres",
+    "clearAll": "Tout effacer",
+    "category": "Catégorie",
+    "allCategories": "Toutes les catégories",
+    "categoryVehicles": "Véhicules",
+    "categoryEngines": "Moteurs",
+    "categoryParts": "Pièces",
+    "partType": "Type de pièce",
+    "allPartTypes": "Tous les types de pièces",
+    "partBodyExterior": "Carrosserie et extérieur",
+    "partInterior": "Intérieur",
+    "partWheelsTires": "Roues et pneus",
+    "partEngineInternals": "Internes moteur",
+    "partSuspension": "Suspension",
+    "partElectrical": "Électrique",
+    "partOther": "Autre",
+    "year": "Année",
+    "allYears": "Toutes les années",
+    "manufacturer": "Fabricant",
+    "allManufacturers": "Tous les fabricants",
+    "manufacturerOther": "Autre",
+    "model": "Modèle",
+    "allModels": "Tous les modèles",
+    "modelOther": "Autre",
+    "condition": "État",
+    "allConditions": "Tous les états",
+    "conditionExcellent": "Excellent",
+    "conditionGood": "Bon",
+    "conditionFair": "Correct",
+    "conditionProject": "Projet",
+    "priceRange": "Fourchette de prix",
+    "allPrices": "Tous les prix",
+    "priceFree": "Gratuit",
+    "priceUnder10k": "Moins de 10 000 $",
+    "priceOver50k": "Plus de 50 000 $",
+    "transmission": "Transmission",
+    "allTransmissions": "Toutes les transmissions",
+    "transmissionAutomatic": "Automatique",
+    "location": "Emplacement",
+    "locationPlaceholder": "Ville, région ou code postal",
+    "distance": "Distance",
+    "distanceWithin": "Dans un rayon de {miles} miles",
+    "distanceAny": "N'importe quelle distance",
+    "activeFilters": "Filtres actifs :",
+    "removeCategoryFilter": "Supprimer le filtre de catégorie",
+    "removePartsSubcategoryFilter": "Supprimer le filtre de type de pièce",
+    "removeYearFilter": "Supprimer le filtre d'année",
+    "removeManufacturerFilter": "Supprimer le filtre de fabricant",
+    "removeModelFilter": "Supprimer le filtre de modèle",
+    "removeConditionFilter": "Supprimer le filtre d'état",
+    "removePriceFilter": "Supprimer le filtre de prix",
+    "removeTransmissionFilter": "Supprimer le filtre de transmission",
+    "removeLocationFilter": "Supprimer le filtre d'emplacement"
+  },
+  "de": {
+    "filters": "Filter",
+    "clearAll": "Alle löschen",
+    "category": "Kategorie",
+    "allCategories": "Alle Kategorien",
+    "categoryVehicles": "Fahrzeuge",
+    "categoryEngines": "Motoren",
+    "categoryParts": "Teile",
+    "partType": "Teiletyp",
+    "allPartTypes": "Alle Teiletypen",
+    "partBodyExterior": "Karosserie & Außenbereich",
+    "partInterior": "Innenraum",
+    "partWheelsTires": "Räder & Reifen",
+    "partEngineInternals": "Motorinnenteile",
+    "partSuspension": "Fahrwerk",
+    "partElectrical": "Elektrik",
+    "partOther": "Sonstiges",
+    "year": "Jahr",
+    "allYears": "Alle Jahre",
+    "manufacturer": "Hersteller",
+    "allManufacturers": "Alle Hersteller",
+    "manufacturerOther": "Sonstiges",
+    "model": "Modell",
+    "allModels": "Alle Modelle",
+    "modelOther": "Sonstiges",
+    "condition": "Zustand",
+    "allConditions": "Alle Zustände",
+    "conditionExcellent": "Ausgezeichnet",
+    "conditionGood": "Gut",
+    "conditionFair": "Akzeptabel",
+    "conditionProject": "Projekt",
+    "priceRange": "Preisspanne",
+    "allPrices": "Alle Preise",
+    "priceFree": "Kostenlos",
+    "priceUnder10k": "Unter 10.000 $",
+    "priceOver50k": "Über 50.000 $",
+    "transmission": "Getriebe",
+    "allTransmissions": "Alle Getriebe",
+    "transmissionAutomatic": "Automatik",
+    "location": "Standort",
+    "locationPlaceholder": "Stadt, Bundesland oder PLZ",
+    "distance": "Entfernung",
+    "distanceWithin": "Innerhalb von {miles} Meilen",
+    "distanceAny": "Beliebige Entfernung",
+    "activeFilters": "Aktive Filter:",
+    "removeCategoryFilter": "Kategoriefilter entfernen",
+    "removePartsSubcategoryFilter": "Teiletyp-Filter entfernen",
+    "removeYearFilter": "Jahresfilter entfernen",
+    "removeManufacturerFilter": "Herstellerfilter entfernen",
+    "removeModelFilter": "Modellfilter entfernen",
+    "removeConditionFilter": "Zustandsfilter entfernen",
+    "removePriceFilter": "Preisfilter entfernen",
+    "removeTransmissionFilter": "Getriebefilter entfernen",
+    "removeLocationFilter": "Standortfilter entfernen"
+  },
+  "it": {
+    "filters": "Filtri",
+    "clearAll": "Cancella tutto",
+    "category": "Categoria",
+    "allCategories": "Tutte le categorie",
+    "categoryVehicles": "Veicoli",
+    "categoryEngines": "Motori",
+    "categoryParts": "Ricambi",
+    "partType": "Tipo di ricambio",
+    "allPartTypes": "Tutti i tipi di ricambio",
+    "partBodyExterior": "Carrozzeria ed esterni",
+    "partInterior": "Interni",
+    "partWheelsTires": "Ruote e pneumatici",
+    "partEngineInternals": "Interni motore",
+    "partSuspension": "Sospensioni",
+    "partElectrical": "Impianto elettrico",
+    "partOther": "Altro",
+    "year": "Anno",
+    "allYears": "Tutti gli anni",
+    "manufacturer": "Produttore",
+    "allManufacturers": "Tutti i produttori",
+    "manufacturerOther": "Altro",
+    "model": "Modello",
+    "allModels": "Tutti i modelli",
+    "modelOther": "Altro",
+    "condition": "Condizione",
+    "allConditions": "Tutte le condizioni",
+    "conditionExcellent": "Eccellente",
+    "conditionGood": "Buono",
+    "conditionFair": "Discreto",
+    "conditionProject": "Progetto",
+    "priceRange": "Fascia di prezzo",
+    "allPrices": "Tutti i prezzi",
+    "priceFree": "Gratuito",
+    "priceUnder10k": "Sotto i $10.000",
+    "priceOver50k": "Oltre i $50.000",
+    "transmission": "Trasmissione",
+    "allTransmissions": "Tutte le trasmissioni",
+    "transmissionAutomatic": "Automatica",
+    "location": "Posizione",
+    "locationPlaceholder": "Città, regione o CAP",
+    "distance": "Distanza",
+    "distanceWithin": "Entro {miles} miglia",
+    "distanceAny": "Qualsiasi distanza",
+    "activeFilters": "Filtri attivi:",
+    "removeCategoryFilter": "Rimuovi filtro categoria",
+    "removePartsSubcategoryFilter": "Rimuovi filtro tipo di ricambio",
+    "removeYearFilter": "Rimuovi filtro anno",
+    "removeManufacturerFilter": "Rimuovi filtro produttore",
+    "removeModelFilter": "Rimuovi filtro modello",
+    "removeConditionFilter": "Rimuovi filtro condizione",
+    "removePriceFilter": "Rimuovi filtro prezzo",
+    "removeTransmissionFilter": "Rimuovi filtro trasmissione",
+    "removeLocationFilter": "Rimuovi filtro posizione"
+  },
+  "pt": {
+    "filters": "Filtros",
+    "clearAll": "Limpar tudo",
+    "category": "Categoria",
+    "allCategories": "Todas as categorias",
+    "categoryVehicles": "Veículos",
+    "categoryEngines": "Motores",
+    "categoryParts": "Peças",
+    "partType": "Tipo de peça",
+    "allPartTypes": "Todos os tipos de peças",
+    "partBodyExterior": "Carroceria e exterior",
+    "partInterior": "Interior",
+    "partWheelsTires": "Rodas e pneus",
+    "partEngineInternals": "Internos do motor",
+    "partSuspension": "Suspensão",
+    "partElectrical": "Elétrica",
+    "partOther": "Outro",
+    "year": "Ano",
+    "allYears": "Todos os anos",
+    "manufacturer": "Fabricante",
+    "allManufacturers": "Todos os fabricantes",
+    "manufacturerOther": "Outro",
+    "model": "Modelo",
+    "allModels": "Todos os modelos",
+    "modelOther": "Outro",
+    "condition": "Estado",
+    "allConditions": "Todos os estados",
+    "conditionExcellent": "Excelente",
+    "conditionGood": "Bom",
+    "conditionFair": "Razoável",
+    "conditionProject": "Projeto",
+    "priceRange": "Faixa de preço",
+    "allPrices": "Todos os preços",
+    "priceFree": "Grátis",
+    "priceUnder10k": "Abaixo de $10.000",
+    "priceOver50k": "Acima de $50.000",
+    "transmission": "Transmissão",
+    "allTransmissions": "Todas as transmissões",
+    "transmissionAutomatic": "Automática",
+    "location": "Localização",
+    "locationPlaceholder": "Cidade, estado ou CEP",
+    "distance": "Distância",
+    "distanceWithin": "Em até {miles} milhas",
+    "distanceAny": "Qualquer distância",
+    "activeFilters": "Filtros ativos:",
+    "removeCategoryFilter": "Remover filtro de categoria",
+    "removePartsSubcategoryFilter": "Remover filtro de tipo de peça",
+    "removeYearFilter": "Remover filtro de ano",
+    "removeManufacturerFilter": "Remover filtro de fabricante",
+    "removeModelFilter": "Remover filtro de modelo",
+    "removeConditionFilter": "Remover filtro de estado",
+    "removePriceFilter": "Remover filtro de preço",
+    "removeTransmissionFilter": "Remover filtro de transmissão",
+    "removeLocationFilter": "Remover filtro de localização"
+  },
+  "ru": {
+    "filters": "Фильтры",
+    "clearAll": "Очистить всё",
+    "category": "Категория",
+    "allCategories": "Все категории",
+    "categoryVehicles": "Автомобили",
+    "categoryEngines": "Двигатели",
+    "categoryParts": "Запчасти",
+    "partType": "Тип запчасти",
+    "allPartTypes": "Все типы запчастей",
+    "partBodyExterior": "Кузов и экстерьер",
+    "partInterior": "Интерьер",
+    "partWheelsTires": "Колёса и шины",
+    "partEngineInternals": "Внутренние детали двигателя",
+    "partSuspension": "Подвеска",
+    "partElectrical": "Электрика",
+    "partOther": "Другое",
+    "year": "Год",
+    "allYears": "Все годы",
+    "manufacturer": "Производитель",
+    "allManufacturers": "Все производители",
+    "manufacturerOther": "Другое",
+    "model": "Модель",
+    "allModels": "Все модели",
+    "modelOther": "Другое",
+    "condition": "Состояние",
+    "allConditions": "Все состояния",
+    "conditionExcellent": "Отличное",
+    "conditionGood": "Хорошее",
+    "conditionFair": "Удовлетворительное",
+    "conditionProject": "Проект",
+    "priceRange": "Диапазон цен",
+    "allPrices": "Все цены",
+    "priceFree": "Бесплатно",
+    "priceUnder10k": "До $10 000",
+    "priceOver50k": "Свыше $50 000",
+    "transmission": "Коробка передач",
+    "allTransmissions": "Все коробки передач",
+    "transmissionAutomatic": "Автоматическая",
+    "location": "Местоположение",
+    "locationPlaceholder": "Город, регион или индекс",
+    "distance": "Расстояние",
+    "distanceWithin": "В пределах {miles} миль",
+    "distanceAny": "Любое расстояние",
+    "activeFilters": "Активные фильтры:",
+    "removeCategoryFilter": "Убрать фильтр категории",
+    "removePartsSubcategoryFilter": "Убрать фильтр типа запчасти",
+    "removeYearFilter": "Убрать фильтр года",
+    "removeManufacturerFilter": "Убрать фильтр производителя",
+    "removeModelFilter": "Убрать фильтр модели",
+    "removeConditionFilter": "Убрать фильтр состояния",
+    "removePriceFilter": "Убрать фильтр цены",
+    "removeTransmissionFilter": "Убрать фильтр коробки передач",
+    "removeLocationFilter": "Убрать фильтр местоположения"
+  },
+  "ja": {
+    "filters": "フィルター",
+    "clearAll": "すべてクリア",
+    "category": "カテゴリー",
+    "allCategories": "すべてのカテゴリー",
+    "categoryVehicles": "車両",
+    "categoryEngines": "エンジン",
+    "categoryParts": "パーツ",
+    "partType": "パーツの種類",
+    "allPartTypes": "すべてのパーツの種類",
+    "partBodyExterior": "ボディ・外装",
+    "partInterior": "内装",
+    "partWheelsTires": "ホイール・タイヤ",
+    "partEngineInternals": "エンジン内部",
+    "partSuspension": "サスペンション",
+    "partElectrical": "電装",
+    "partOther": "その他",
+    "year": "年式",
+    "allYears": "すべての年式",
+    "manufacturer": "メーカー",
+    "allManufacturers": "すべてのメーカー",
+    "manufacturerOther": "その他",
+    "model": "モデル",
+    "allModels": "すべてのモデル",
+    "modelOther": "その他",
+    "condition": "状態",
+    "allConditions": "すべての状態",
+    "conditionExcellent": "優",
+    "conditionGood": "良",
+    "conditionFair": "可",
+    "conditionProject": "レストア素材",
+    "priceRange": "価格帯",
+    "allPrices": "すべての価格",
+    "priceFree": "無料",
+    "priceUnder10k": "$10,000未満",
+    "priceOver50k": "$50,000超",
+    "transmission": "トランスミッション",
+    "allTransmissions": "すべてのトランスミッション",
+    "transmissionAutomatic": "オートマチック",
+    "location": "場所",
+    "locationPlaceholder": "市区町村、都道府県、または郵便番号",
+    "distance": "距離",
+    "distanceWithin": "{miles}マイル以内",
+    "distanceAny": "距離を問わない",
+    "activeFilters": "適用中のフィルター:",
+    "removeCategoryFilter": "カテゴリーフィルターを削除",
+    "removePartsSubcategoryFilter": "パーツの種類フィルターを削除",
+    "removeYearFilter": "年式フィルターを削除",
+    "removeManufacturerFilter": "メーカーフィルターを削除",
+    "removeModelFilter": "モデルフィルターを削除",
+    "removeConditionFilter": "状態フィルターを削除",
+    "removePriceFilter": "価格フィルターを削除",
+    "removeTransmissionFilter": "トランスミッションフィルターを削除",
+    "removeLocationFilter": "場所フィルターを削除"
+  },
+  "zh": {
+    "filters": "筛选",
+    "clearAll": "全部清除",
+    "category": "类别",
+    "allCategories": "所有类别",
+    "categoryVehicles": "整车",
+    "categoryEngines": "发动机",
+    "categoryParts": "配件",
+    "partType": "配件类型",
+    "allPartTypes": "所有配件类型",
+    "partBodyExterior": "车身与外观",
+    "partInterior": "内饰",
+    "partWheelsTires": "轮毂与轮胎",
+    "partEngineInternals": "发动机内部件",
+    "partSuspension": "悬挂",
+    "partElectrical": "电气",
+    "partOther": "其他",
+    "year": "年份",
+    "allYears": "所有年份",
+    "manufacturer": "制造商",
+    "allManufacturers": "所有制造商",
+    "manufacturerOther": "其他",
+    "model": "型号",
+    "allModels": "所有型号",
+    "modelOther": "其他",
+    "condition": "状况",
+    "allConditions": "所有状况",
+    "conditionExcellent": "极佳",
+    "conditionGood": "良好",
+    "conditionFair": "一般",
+    "conditionProject": "待修复",
+    "priceRange": "价格区间",
+    "allPrices": "所有价格",
+    "priceFree": "免费",
+    "priceUnder10k": "低于 $10,000",
+    "priceOver50k": "高于 $50,000",
+    "transmission": "变速箱",
+    "allTransmissions": "所有变速箱",
+    "transmissionAutomatic": "自动",
+    "location": "位置",
+    "locationPlaceholder": "城市、州或邮编",
+    "distance": "距离",
+    "distanceWithin": "{miles} 英里以内",
+    "distanceAny": "任意距离",
+    "activeFilters": "已启用筛选：",
+    "removeCategoryFilter": "移除类别筛选",
+    "removePartsSubcategoryFilter": "移除配件类型筛选",
+    "removeYearFilter": "移除年份筛选",
+    "removeManufacturerFilter": "移除制造商筛选",
+    "removeModelFilter": "移除型号筛选",
+    "removeConditionFilter": "移除状况筛选",
+    "removePriceFilter": "移除价格筛选",
+    "removeTransmissionFilter": "移除变速箱筛选",
+    "removeLocationFilter": "移除位置筛选"
+  },
+  "ko": {
+    "filters": "필터",
+    "clearAll": "모두 지우기",
+    "category": "카테고리",
+    "allCategories": "모든 카테고리",
+    "categoryVehicles": "차량",
+    "categoryEngines": "엔진",
+    "categoryParts": "부품",
+    "partType": "부품 유형",
+    "allPartTypes": "모든 부품 유형",
+    "partBodyExterior": "차체 및 외장",
+    "partInterior": "내장",
+    "partWheelsTires": "휠 및 타이어",
+    "partEngineInternals": "엔진 내부",
+    "partSuspension": "서스펜션",
+    "partElectrical": "전장",
+    "partOther": "기타",
+    "year": "연식",
+    "allYears": "모든 연식",
+    "manufacturer": "제조사",
+    "allManufacturers": "모든 제조사",
+    "manufacturerOther": "기타",
+    "model": "모델",
+    "allModels": "모든 모델",
+    "modelOther": "기타",
+    "condition": "상태",
+    "allConditions": "모든 상태",
+    "conditionExcellent": "최상",
+    "conditionGood": "양호",
+    "conditionFair": "보통",
+    "conditionProject": "복원용",
+    "priceRange": "가격대",
+    "allPrices": "모든 가격",
+    "priceFree": "무료",
+    "priceUnder10k": "$10,000 미만",
+    "priceOver50k": "$50,000 초과",
+    "transmission": "변속기",
+    "allTransmissions": "모든 변속기",
+    "transmissionAutomatic": "자동",
+    "location": "위치",
+    "locationPlaceholder": "도시, 주 또는 우편번호",
+    "distance": "거리",
+    "distanceWithin": "{miles}마일 이내",
+    "distanceAny": "거리 제한 없음",
+    "activeFilters": "적용된 필터:",
+    "removeCategoryFilter": "카테고리 필터 제거",
+    "removePartsSubcategoryFilter": "부품 유형 필터 제거",
+    "removeYearFilter": "연식 필터 제거",
+    "removeManufacturerFilter": "제조사 필터 제거",
+    "removeModelFilter": "모델 필터 제거",
+    "removeConditionFilter": "상태 필터 제거",
+    "removePriceFilter": "가격 필터 제거",
+    "removeTransmissionFilter": "변속기 필터 제거",
+    "removeLocationFilter": "위치 필터 제거"
+  }
+}
+</i18n>

--- a/app/components/exchange/listings/SaveSearchButton.vue
+++ b/app/components/exchange/listings/SaveSearchButton.vue
@@ -1,0 +1,93 @@
+<template>
+  <div v-if="user">
+    <button class="btn btn-outline btn-sm w-full gap-2" @click="showModal = true">
+      <i class="fas fa-bell"></i>
+      {{ t('saveThisSearch') }}
+    </button>
+
+    <dialog :class="['modal', { 'modal-open': showModal }]">
+      <div class="modal-box">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-lg font-semibold">{{ t('saveSearch') }}</h3>
+          <button class="btn btn-ghost btn-sm btn-circle" @click="closeModal">
+            <i class="fas fa-xmark"></i>
+          </button>
+        </div>
+
+        <p class="text-base-content/70 text-sm mb-4">{{ t('description') }}</p>
+
+        <fieldset class="fieldset mb-4">
+          <legend class="fieldset-legend">{{ t('searchNameLabel') }}</legend>
+          <input
+            v-model="searchName"
+            type="text"
+            :placeholder="t('searchNamePlaceholder')"
+            class="input w-full"
+            maxlength="100"
+          />
+        </fieldset>
+
+        <div v-if="filterSummary" class="bg-base-200 rounded-lg p-3 mb-4">
+          <p class="text-xs text-base-content/70 mb-1">{{ t('matchingFilters') }}</p>
+          <p class="text-sm">{{ filterSummary }}</p>
+        </div>
+
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeModal">{{ t('cancel') }}</button>
+          <button class="btn btn-primary" :disabled="!searchName.trim() || saving" @click="handleSave">
+            <span v-if="saving" class="loading loading-spinner loading-sm"></span>
+            {{ t('save') }}
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button @click="closeModal">{{ t('close') }}</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    filters: Record<string, any>;
+    filterSummary?: string;
+  }>();
+
+  const { user } = useAuth();
+  const { createSavedSearch, saving } = useSavedSearches();
+
+  const showModal = ref(false);
+  const searchName = ref('');
+
+  const closeModal = () => {
+    showModal.value = false;
+  };
+
+  const handleSave = async () => {
+    if (!searchName.value.trim()) return;
+
+    const result = await createSavedSearch(searchName.value.trim(), props.filters);
+
+    if (result) {
+      searchName.value = '';
+      showModal.value = false;
+    }
+  };
+</script>
+
+<i18n lang="json">
+{
+  "en": { "saveThisSearch": "Save this Search", "saveSearch": "Save Search", "description": "Get email notifications when new listings match these filters.", "searchNameLabel": "Search Name *", "searchNamePlaceholder": "e.g., My dream Cooper S", "matchingFilters": "Matching filters:", "cancel": "Cancel", "save": "Save", "close": "close" },
+  "es": { "saveThisSearch": "Guardar esta búsqueda", "saveSearch": "Guardar búsqueda", "description": "Recibe notificaciones por correo cuando nuevos anuncios coincidan con estos filtros.", "searchNameLabel": "Nombre de la búsqueda *", "searchNamePlaceholder": "p. ej., Mi Cooper S soñado", "matchingFilters": "Filtros coincidentes:", "cancel": "Cancelar", "save": "Guardar", "close": "cerrar" },
+  "fr": { "saveThisSearch": "Enregistrer cette recherche", "saveSearch": "Enregistrer la recherche", "description": "Recevez des notifications par e-mail lorsque de nouvelles annonces correspondent à ces filtres.", "searchNameLabel": "Nom de la recherche *", "searchNamePlaceholder": "ex. : Ma Cooper S de rêve", "matchingFilters": "Filtres correspondants :", "cancel": "Annuler", "save": "Enregistrer", "close": "fermer" },
+  "de": { "saveThisSearch": "Diese Suche speichern", "saveSearch": "Suche speichern", "description": "Erhalte E-Mail-Benachrichtigungen, wenn neue Anzeigen zu diesen Filtern passen.", "searchNameLabel": "Suchname *", "searchNamePlaceholder": "z. B. Mein Traum-Cooper-S", "matchingFilters": "Passende Filter:", "cancel": "Abbrechen", "save": "Speichern", "close": "schließen" },
+  "it": { "saveThisSearch": "Salva questa ricerca", "saveSearch": "Salva ricerca", "description": "Ricevi notifiche via e-mail quando nuovi annunci corrispondono a questi filtri.", "searchNameLabel": "Nome della ricerca *", "searchNamePlaceholder": "es. La mia Cooper S dei sogni", "matchingFilters": "Filtri corrispondenti:", "cancel": "Annulla", "save": "Salva", "close": "chiudi" },
+  "pt": { "saveThisSearch": "Salvar esta busca", "saveSearch": "Salvar busca", "description": "Receba notificações por e-mail quando novos anúncios corresponderem a esses filtros.", "searchNameLabel": "Nome da busca *", "searchNamePlaceholder": "ex.: Meu Cooper S dos sonhos", "matchingFilters": "Filtros correspondentes:", "cancel": "Cancelar", "save": "Salvar", "close": "fechar" },
+  "ru": { "saveThisSearch": "Сохранить этот поиск", "saveSearch": "Сохранить поиск", "description": "Получайте уведомления по электронной почте, когда новые объявления соответствуют этим фильтрам.", "searchNameLabel": "Название поиска *", "searchNamePlaceholder": "например, Мой Cooper S мечты", "matchingFilters": "Подходящие фильтры:", "cancel": "Отмена", "save": "Сохранить", "close": "закрыть" },
+  "ja": { "saveThisSearch": "この検索を保存", "saveSearch": "検索を保存", "description": "これらのフィルターに一致する新しい出品があるとメールで通知します。", "searchNameLabel": "検索名 *", "searchNamePlaceholder": "例：理想のクーパーS", "matchingFilters": "一致するフィルター：", "cancel": "キャンセル", "save": "保存", "close": "閉じる" },
+  "zh": { "saveThisSearch": "保存此搜索", "saveSearch": "保存搜索", "description": "当有新刊登匹配这些筛选条件时，通过电子邮件通知您。", "searchNameLabel": "搜索名称 *", "searchNamePlaceholder": "例如：我梦想中的 Cooper S", "matchingFilters": "匹配的筛选条件：", "cancel": "取消", "save": "保存", "close": "关闭" },
+  "ko": { "saveThisSearch": "이 검색 저장", "saveSearch": "검색 저장", "description": "이 필터와 일치하는 새 매물이 있으면 이메일로 알려드립니다.", "searchNameLabel": "검색 이름 *", "searchNamePlaceholder": "예: 내 꿈의 Cooper S", "matchingFilters": "일치하는 필터:", "cancel": "취소", "save": "저장", "close": "닫기" }
+}
+</i18n>

--- a/app/components/exchange/listings/SearchBar.vue
+++ b/app/components/exchange/listings/SearchBar.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="relative w-full">
+    <label class="input input-lg flex items-center gap-2 w-full">
+      <i class="fas fa-magnifying-glass text-base-content/50"></i>
+      <input
+        v-model="searchQuery"
+        type="text"
+        :placeholder="t('placeholder')"
+        class="grow"
+        @keyup.enter="onEnter"
+      />
+      <button
+        v-if="searchQuery"
+        type="button"
+        class="btn btn-ghost btn-xs btn-circle"
+        @click="clearSearch"
+        :aria-label="t('clear')"
+      >
+        <i class="fas fa-xmark"></i>
+      </button>
+    </label>
+
+    <!-- Search suggestions (future enhancement) -->
+    <div v-if="showSuggestions && suggestions.length > 0" class="absolute top-full left-0 right-0 mt-2 z-50">
+      <div class="card bg-base-100 shadow-lg">
+        <div class="card-body p-2" role="listbox">
+          <div
+            v-for="suggestion in suggestions"
+            :key="suggestion"
+            role="option"
+            tabindex="0"
+            class="px-4 py-2 hover:bg-base-200 rounded cursor-pointer"
+            @click="applySuggestion(suggestion)"
+            @keydown.enter="applySuggestion(suggestion)"
+            @keydown.space.prevent="applySuggestion(suggestion)"
+          >
+            <i class="fas fa-magnifying-glass inline mr-2 text-base-content/50"></i>
+            {{ suggestion }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  const searchQuery = defineModel<string>({ required: true });
+
+  const showSuggestions = ref(false);
+  const suggestions = ref<string[]>([]);
+
+  const onEnter = () => {
+    showSuggestions.value = false;
+  };
+
+  const clearSearch = () => {
+    searchQuery.value = '';
+    showSuggestions.value = false;
+  };
+
+  const applySuggestion = (suggestion: string) => {
+    searchQuery.value = suggestion;
+    showSuggestions.value = false;
+  };
+
+  // Close suggestions when clicking outside
+  onMounted(() => {
+    document.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('.relative')) {
+        showSuggestions.value = false;
+      }
+    });
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": { "placeholder": "Search listings by title, description, model...", "clear": "Clear search" },
+  "es": { "placeholder": "Buscar anuncios por título, descripción, modelo...", "clear": "Borrar búsqueda" },
+  "fr": { "placeholder": "Rechercher des annonces par titre, description, modèle...", "clear": "Effacer la recherche" },
+  "de": { "placeholder": "Anzeigen nach Titel, Beschreibung, Modell suchen...", "clear": "Suche löschen" },
+  "it": { "placeholder": "Cerca annunci per titolo, descrizione, modello...", "clear": "Cancella ricerca" },
+  "pt": { "placeholder": "Pesquisar anúncios por título, descrição, modelo...", "clear": "Limpar pesquisa" },
+  "ru": { "placeholder": "Поиск объявлений по названию, описанию, модели...", "clear": "Очистить поиск" },
+  "ja": { "placeholder": "タイトル、説明、モデルで出品を検索...", "clear": "検索をクリア" },
+  "zh": { "placeholder": "按标题、描述、车型搜索刊登...", "clear": "清除搜索" },
+  "ko": { "placeholder": "제목, 설명, 모델로 매물 검색...", "clear": "검색 지우기" }
+}
+</i18n>

--- a/app/components/exchange/listings/SearchBar.vue
+++ b/app/components/exchange/listings/SearchBar.vue
@@ -66,13 +66,19 @@
   };
 
   // Close suggestions when clicking outside
+  const handleClickOutside = (e: MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (!target.closest('.relative')) {
+      showSuggestions.value = false;
+    }
+  };
+
   onMounted(() => {
-    document.addEventListener('click', (e) => {
-      const target = e.target as HTMLElement;
-      if (!target.closest('.relative')) {
-        showSuggestions.value = false;
-      }
-    });
+    document.addEventListener('click', handleClickOutside);
+  });
+
+  onBeforeUnmount(() => {
+    document.removeEventListener('click', handleClickOutside);
   });
 </script>
 

--- a/app/components/exchange/listings/SortDropdown.vue
+++ b/app/components/exchange/listings/SortDropdown.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="flex items-center gap-2">
+    <label for="listing-sort-select" class="label">
+      <span class="label-text text-sm font-medium">{{ t('sortBy') }}</span>
+    </label>
+    <select id="listing-sort-select" v-model="sortBy" class="select select-sm">
+      <option value="newest">{{ t('newestFirst') }}</option>
+      <option value="oldest">{{ t('oldestFirst') }}</option>
+      <option value="price_asc">{{ t('priceLowToHigh') }}</option>
+      <option value="price_desc">{{ t('priceHighToLow') }}</option>
+      <option value="year_asc">{{ t('yearOldestFirst') }}</option>
+      <option value="year_desc">{{ t('yearNewestFirst') }}</option>
+    </select>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+  const { capture } = usePostHog();
+
+  const props = defineProps<{
+    resultsCount?: number;
+  }>();
+
+  const sortBy = defineModel<string>({ required: true });
+
+  // Map internal sort values to analytics sort values
+  const mapSortToAnalytics = (sort: string): 'newest' | 'oldest' | 'price_low' | 'price_high' | null => {
+    switch (sort) {
+      case 'newest':
+        return 'newest';
+      case 'oldest':
+        return 'oldest';
+      case 'price_asc':
+        return 'price_low';
+      case 'price_desc':
+        return 'price_high';
+      default:
+        return null;
+    }
+  };
+
+  // Track sort changes
+  watch(sortBy, (newValue, oldValue) => {
+    // Only track if actually changed and not initial load
+    if (newValue && newValue !== oldValue) {
+      const analyticsSort = mapSortToAnalytics(newValue);
+      if (analyticsSort) {
+        capture('sort_changed', {
+          sort_by: analyticsSort,
+          results_count: props.resultsCount ?? 0,
+        });
+      }
+    }
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": { "sortBy": "Sort by:", "newestFirst": "Newest First", "oldestFirst": "Oldest First", "priceLowToHigh": "Price: Low to High", "priceHighToLow": "Price: High to Low", "yearOldestFirst": "Year: Oldest First", "yearNewestFirst": "Year: Newest First", "results": "{count} results" },
+  "es": { "sortBy": "Ordenar por:", "newestFirst": "Más recientes primero", "oldestFirst": "Más antiguos primero", "priceLowToHigh": "Precio: de menor a mayor", "priceHighToLow": "Precio: de mayor a menor", "yearOldestFirst": "Año: más antiguos primero", "yearNewestFirst": "Año: más recientes primero", "results": "{count} resultados" },
+  "fr": { "sortBy": "Trier par :", "newestFirst": "Plus récents d'abord", "oldestFirst": "Plus anciens d'abord", "priceLowToHigh": "Prix : du plus bas au plus élevé", "priceHighToLow": "Prix : du plus élevé au plus bas", "yearOldestFirst": "Année : du plus ancien au plus récent", "yearNewestFirst": "Année : du plus récent au plus ancien", "results": "{count} résultats" },
+  "de": { "sortBy": "Sortieren nach:", "newestFirst": "Neueste zuerst", "oldestFirst": "Älteste zuerst", "priceLowToHigh": "Preis: aufsteigend", "priceHighToLow": "Preis: absteigend", "yearOldestFirst": "Jahr: älteste zuerst", "yearNewestFirst": "Jahr: neueste zuerst", "results": "{count} Ergebnisse" },
+  "it": { "sortBy": "Ordina per:", "newestFirst": "Più recenti prima", "oldestFirst": "Più vecchi prima", "priceLowToHigh": "Prezzo: dal più basso al più alto", "priceHighToLow": "Prezzo: dal più alto al più basso", "yearOldestFirst": "Anno: dal più vecchio al più recente", "yearNewestFirst": "Anno: dal più recente al più vecchio", "results": "{count} risultati" },
+  "pt": { "sortBy": "Ordenar por:", "newestFirst": "Mais recentes primeiro", "oldestFirst": "Mais antigos primeiro", "priceLowToHigh": "Preço: do menor ao maior", "priceHighToLow": "Preço: do maior ao menor", "yearOldestFirst": "Ano: dos mais antigos aos mais recentes", "yearNewestFirst": "Ano: dos mais recentes aos mais antigos", "results": "{count} resultados" },
+  "ru": { "sortBy": "Сортировать по:", "newestFirst": "Сначала новые", "oldestFirst": "Сначала старые", "priceLowToHigh": "Цена: по возрастанию", "priceHighToLow": "Цена: по убыванию", "yearOldestFirst": "Год: сначала старые", "yearNewestFirst": "Год: сначала новые", "results": "{count} результатов" },
+  "ja": { "sortBy": "並び替え:", "newestFirst": "新しい順", "oldestFirst": "古い順", "priceLowToHigh": "価格: 安い順", "priceHighToLow": "価格: 高い順", "yearOldestFirst": "年式: 古い順", "yearNewestFirst": "年式: 新しい順", "results": "{count} 件" },
+  "zh": { "sortBy": "排序方式：", "newestFirst": "最新优先", "oldestFirst": "最早优先", "priceLowToHigh": "价格：从低到高", "priceHighToLow": "价格：从高到低", "yearOldestFirst": "年份：从旧到新", "yearNewestFirst": "年份：从新到旧", "results": "{count} 个结果" },
+  "ko": { "sortBy": "정렬 기준:", "newestFirst": "최신순", "oldestFirst": "오래된순", "priceLowToHigh": "가격: 낮은순", "priceHighToLow": "가격: 높은순", "yearOldestFirst": "연식: 오래된순", "yearNewestFirst": "연식: 최신순", "results": "결과 {count}개" }
+}
+</i18n>

--- a/app/components/exchange/wanted/WantedCard.vue
+++ b/app/components/exchange/wanted/WantedCard.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow h-full">
+    <div class="card-body p-4">
+      <!-- Top row: Category badge + Status badge -->
+      <div class="flex items-center justify-between gap-2">
+        <span class="badge badge-sm" :class="categoryBadgeClass(post.category)">
+          {{ formatCategory(post.category) }}
+        </span>
+        <span v-if="post.status !== 'active'" class="badge badge-sm" :class="statusBadgeClass">
+          {{ formatStatus(post.status) }}
+        </span>
+      </div>
+
+      <!-- Title -->
+      <NuxtLink
+        :to="`/exchange/wanted/${post.id}`"
+        class="card-title text-base font-bold line-clamp-1 hover:text-primary transition-colors"
+      >
+        {{ post.title }}
+      </NuxtLink>
+
+      <!-- Description -->
+      <p class="text-sm text-base-content/70 line-clamp-3">
+        {{ post.description }}
+      </p>
+
+      <!-- Budget -->
+      <div v-if="formattedBudget" class="flex items-center gap-1.5 text-sm font-semibold text-primary">
+        <i class="fas fa-money-bill-wave shrink-0"></i>
+        <span>{{ formattedBudget }}</span>
+      </div>
+
+      <!-- Location -->
+      <div v-if="formattedLocation" class="flex items-center gap-1.5 text-sm text-base-content/60">
+        <template v-if="countryFlag">{{ countryFlag }}</template>
+        <i v-else class="fas fa-location-dot shrink-0"></i>
+        <span class="truncate">{{ formattedLocation }}</span>
+      </div>
+
+      <!-- Condition preference -->
+      <div v-if="post.condition_preference && post.condition_preference !== 'any'" class="flex items-center gap-1.5">
+        <span class="badge badge-ghost badge-sm capitalize">
+          {{ post.condition_preference }}
+        </span>
+      </div>
+
+      <!-- Footer: Posted date + User info -->
+      <div class="flex items-center justify-between gap-2 pt-3 mt-auto border-t border-base-300">
+        <span class="text-xs text-base-content/50">
+          {{ timeAgo(post.created_at) }}
+        </span>
+        <div v-if="post.profiles" class="flex items-center gap-1.5 min-w-0">
+          <ExchangeAvatar
+            :avatar-url="post.profiles.avatar_url"
+            :display-name="post.profiles.display_name"
+            :username="post.profiles.username"
+            size="xs"
+          />
+          <span class="text-xs font-medium truncate">
+            {{ post.profiles.display_name || post.profiles.username || t('anonymous') }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Action buttons (owner management) -->
+      <div v-if="showActions" class="flex items-center gap-2 pt-2 border-t border-base-300">
+        <button
+          v-if="post.status === 'active'"
+          class="btn btn-sm btn-ghost flex-1 gap-1"
+          @click.prevent="emit('fulfill', post.id)"
+        >
+          <i class="fas fa-circle-check text-success"></i>
+          <span>{{ t('fulfilled') }}</span>
+        </button>
+        <button
+          v-if="post.status === 'expired'"
+          class="btn btn-sm btn-ghost flex-1 gap-1"
+          @click.prevent="emit('renew', post.id)"
+        >
+          <i class="fas fa-arrows-rotate text-info"></i>
+          <span>{{ t('renew') }}</span>
+        </button>
+        <button class="btn btn-sm btn-ghost flex-1 gap-1 text-error" @click.prevent="emit('delete', post.id)">
+          <i class="fas fa-trash"></i>
+          <span>{{ t('delete') }}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { WantedPost } from '~/composables/useWantedPosts';
+  import { getCountryFlag } from '~/utils/countryFlags';
+  import {
+    categoryBadgeClass,
+    formatCategory,
+    formatWantedStatus as formatStatus,
+    wantedStatusBadgeClass,
+    formatBudget,
+    formatLocation,
+    timeAgo,
+  } from '~/utils/wantedFormatters';
+
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    post: WantedPost;
+    showActions?: boolean;
+  }>();
+
+  const emit = defineEmits<{
+    (e: 'delete', id: string): void;
+    (e: 'fulfill', id: string): void;
+    (e: 'renew', id: string): void;
+  }>();
+
+  const statusBadgeClass = computed(() => wantedStatusBadgeClass(props.post.status));
+
+  const formattedBudget = computed(() => {
+    return formatBudget(props.post.budget_min, props.post.budget_max, props.post.currency);
+  });
+
+  const formattedLocation = computed(() => {
+    return formatLocation(props.post.city, props.post.state_province, props.post.country);
+  });
+
+  const countryFlag = computed(() => getCountryFlag(props.post.country));
+</script>
+
+<i18n lang="json">
+{
+  "en": { "anonymous": "Anonymous", "fulfilled": "Fulfilled", "renew": "Renew", "delete": "Delete" },
+  "es": { "anonymous": "Anónimo", "fulfilled": "Conseguido", "renew": "Renovar", "delete": "Eliminar" },
+  "fr": { "anonymous": "Anonyme", "fulfilled": "Trouvé", "renew": "Renouveler", "delete": "Supprimer" },
+  "de": { "anonymous": "Anonym", "fulfilled": "Gefunden", "renew": "Erneuern", "delete": "Löschen" },
+  "it": { "anonymous": "Anonimo", "fulfilled": "Trovato", "renew": "Rinnova", "delete": "Elimina" },
+  "pt": { "anonymous": "Anônimo", "fulfilled": "Encontrado", "renew": "Renovar", "delete": "Excluir" },
+  "ru": { "anonymous": "Аноним", "fulfilled": "Найдено", "renew": "Продлить", "delete": "Удалить" },
+  "ja": { "anonymous": "匿名", "fulfilled": "見つかった", "renew": "更新", "delete": "削除" },
+  "zh": { "anonymous": "匿名", "fulfilled": "已找到", "renew": "续期", "delete": "删除" },
+  "ko": { "anonymous": "익명", "fulfilled": "찾음", "renew": "갱신", "delete": "삭제" }
+}
+</i18n>

--- a/app/components/exchange/wanted/WantedCard.vue
+++ b/app/components/exchange/wanted/WantedCard.vue
@@ -46,9 +46,11 @@
 
       <!-- Footer: Posted date + User info -->
       <div class="flex items-center justify-between gap-2 pt-3 mt-auto border-t border-base-300">
-        <span class="text-xs text-base-content/50">
-          {{ timeAgo(post.created_at) }}
-        </span>
+        <ClientOnly>
+          <span class="text-xs text-base-content/50">
+            {{ timeAgo(post.created_at) }}
+          </span>
+        </ClientOnly>
         <div v-if="post.profiles" class="flex items-center gap-1.5 min-w-0">
           <ExchangeAvatar
             :avatar-url="post.profiles.avatar_url"

--- a/app/components/exchange/wanted/WantedCard.vue
+++ b/app/components/exchange/wanted/WantedCard.vue
@@ -48,7 +48,7 @@
       <div class="flex items-center justify-between gap-2 pt-3 mt-auto border-t border-base-300">
         <ClientOnly>
           <span class="text-xs text-base-content/50">
-            {{ timeAgo(post.created_at) }}
+            {{ timeAgo(post.created_at, locale) }}
           </span>
         </ClientOnly>
         <div v-if="post.profiles" class="flex items-center gap-1.5 min-w-0">
@@ -104,7 +104,7 @@
     timeAgo,
   } from '~/utils/wantedFormatters';
 
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
 
   const props = defineProps<{
     post: WantedPost;

--- a/app/components/exchange/wanted/WantedFilterBar.vue
+++ b/app/components/exchange/wanted/WantedFilterBar.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="flex flex-wrap gap-3 items-end">
+    <!-- Category Filter -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">{{ t('category.label') }}</legend>
+      <select
+        :value="category"
+        class="select select-bordered select-sm"
+        @change="emit('update:category', ($event.target as HTMLSelectElement).value)"
+      >
+        <option value="">{{ t('all') }}</option>
+        <option value="vehicle">{{ t('category.vehicle') }}</option>
+        <option value="engine">{{ t('category.engine') }}</option>
+        <option value="parts">{{ t('category.parts') }}</option>
+      </select>
+    </fieldset>
+
+    <!-- Condition Preference Filter -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">{{ t('condition.label') }}</legend>
+      <select
+        :value="conditionPreference"
+        class="select select-bordered select-sm"
+        @change="emit('update:conditionPreference', ($event.target as HTMLSelectElement).value)"
+      >
+        <option value="">{{ t('all') }}</option>
+        <option value="any">{{ t('condition.any') }}</option>
+        <option value="excellent">{{ t('condition.excellent') }}</option>
+        <option value="good">{{ t('condition.good') }}</option>
+        <option value="fair">{{ t('condition.fair') }}</option>
+        <option value="project">{{ t('condition.project') }}</option>
+      </select>
+    </fieldset>
+
+    <!-- Budget Min -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">{{ t('budgetMin.label') }}</legend>
+      <input
+        type="number"
+        class="input input-bordered input-sm w-24"
+        :placeholder="t('budgetMin.placeholder')"
+        :value="budgetMin"
+        min="0"
+        @input="handleBudgetMin"
+      />
+    </fieldset>
+
+    <!-- Budget Max -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">{{ t('budgetMax.label') }}</legend>
+      <input
+        type="number"
+        class="input input-bordered input-sm w-24"
+        :placeholder="t('budgetMax.placeholder')"
+        :value="budgetMax"
+        min="0"
+        @input="handleBudgetMax"
+      />
+    </fieldset>
+
+    <!-- Country -->
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">{{ t('country.label') }}</legend>
+      <input
+        type="text"
+        class="input input-bordered input-sm w-32"
+        :placeholder="t('country.placeholder')"
+        :value="country"
+        @input="emit('update:country', ($event.target as HTMLInputElement).value)"
+      />
+    </fieldset>
+
+    <!-- Clear All Button -->
+    <button v-if="hasActiveFilters" type="button" class="btn btn-ghost btn-sm" @click="emit('clear')">
+      <i class="fas fa-xmark"></i>
+      {{ t('clearAll') }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    category: string;
+    conditionPreference: string;
+    budgetMin: number | undefined;
+    budgetMax: number | undefined;
+    country: string;
+  }>();
+
+  const emit = defineEmits<{
+    (e: 'update:category', value: string): void;
+    (e: 'update:conditionPreference', value: string): void;
+    (e: 'update:budgetMin', value: number | undefined): void;
+    (e: 'update:budgetMax', value: number | undefined): void;
+    (e: 'update:country', value: string): void;
+    (e: 'clear'): void;
+  }>();
+
+  const hasActiveFilters = computed(
+    () =>
+      !!(
+        props.category ||
+        props.conditionPreference ||
+        props.budgetMin !== undefined ||
+        props.budgetMax !== undefined ||
+        props.country
+      )
+  );
+
+  const handleBudgetMin = (event: Event) => {
+    const value = (event.target as HTMLInputElement).value;
+    emit('update:budgetMin', value ? Number(value) : undefined);
+  };
+
+  const handleBudgetMax = (event: Event) => {
+    const value = (event.target as HTMLInputElement).value;
+    emit('update:budgetMax', value ? Number(value) : undefined);
+  };
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "all": "All",
+    "clearAll": "Clear All",
+    "category": { "label": "Category", "vehicle": "Vehicle", "engine": "Engine", "parts": "Parts" },
+    "condition": { "label": "Condition", "any": "Any", "excellent": "Excellent", "good": "Good", "fair": "Fair", "project": "Project" },
+    "budgetMin": { "label": "Budget Min", "placeholder": "Min" },
+    "budgetMax": { "label": "Budget Max", "placeholder": "Max" },
+    "country": { "label": "Country", "placeholder": "Country" }
+  },
+  "es": {
+    "all": "Todos",
+    "clearAll": "Borrar todo",
+    "category": { "label": "Categoría", "vehicle": "Vehículo", "engine": "Motor", "parts": "Piezas" },
+    "condition": { "label": "Estado", "any": "Cualquiera", "excellent": "Excelente", "good": "Bueno", "fair": "Aceptable", "project": "Proyecto" },
+    "budgetMin": { "label": "Presupuesto mín.", "placeholder": "Mín." },
+    "budgetMax": { "label": "Presupuesto máx.", "placeholder": "Máx." },
+    "country": { "label": "País", "placeholder": "País" }
+  },
+  "fr": {
+    "all": "Tous",
+    "clearAll": "Tout effacer",
+    "category": { "label": "Catégorie", "vehicle": "Véhicule", "engine": "Moteur", "parts": "Pièces" },
+    "condition": { "label": "État", "any": "Tous", "excellent": "Excellent", "good": "Bon", "fair": "Correct", "project": "Projet" },
+    "budgetMin": { "label": "Budget min.", "placeholder": "Min." },
+    "budgetMax": { "label": "Budget max.", "placeholder": "Max." },
+    "country": { "label": "Pays", "placeholder": "Pays" }
+  },
+  "de": {
+    "all": "Alle",
+    "clearAll": "Alle löschen",
+    "category": { "label": "Kategorie", "vehicle": "Fahrzeug", "engine": "Motor", "parts": "Teile" },
+    "condition": { "label": "Zustand", "any": "Beliebig", "excellent": "Ausgezeichnet", "good": "Gut", "fair": "Akzeptabel", "project": "Projekt" },
+    "budgetMin": { "label": "Budget Min.", "placeholder": "Min." },
+    "budgetMax": { "label": "Budget Max.", "placeholder": "Max." },
+    "country": { "label": "Land", "placeholder": "Land" }
+  },
+  "it": {
+    "all": "Tutti",
+    "clearAll": "Cancella tutto",
+    "category": { "label": "Categoria", "vehicle": "Veicolo", "engine": "Motore", "parts": "Ricambi" },
+    "condition": { "label": "Condizione", "any": "Qualsiasi", "excellent": "Eccellente", "good": "Buono", "fair": "Discreto", "project": "Progetto" },
+    "budgetMin": { "label": "Budget min.", "placeholder": "Min." },
+    "budgetMax": { "label": "Budget max.", "placeholder": "Max." },
+    "country": { "label": "Paese", "placeholder": "Paese" }
+  },
+  "pt": {
+    "all": "Todos",
+    "clearAll": "Limpar tudo",
+    "category": { "label": "Categoria", "vehicle": "Veículo", "engine": "Motor", "parts": "Peças" },
+    "condition": { "label": "Condição", "any": "Qualquer", "excellent": "Excelente", "good": "Bom", "fair": "Razoável", "project": "Projeto" },
+    "budgetMin": { "label": "Orçamento mín.", "placeholder": "Mín." },
+    "budgetMax": { "label": "Orçamento máx.", "placeholder": "Máx." },
+    "country": { "label": "País", "placeholder": "País" }
+  },
+  "ru": {
+    "all": "Все",
+    "clearAll": "Очистить все",
+    "category": { "label": "Категория", "vehicle": "Автомобиль", "engine": "Двигатель", "parts": "Запчасти" },
+    "condition": { "label": "Состояние", "any": "Любое", "excellent": "Отличное", "good": "Хорошее", "fair": "Удовлетворительное", "project": "Под восстановление" },
+    "budgetMin": { "label": "Бюджет мин.", "placeholder": "Мин." },
+    "budgetMax": { "label": "Бюджет макс.", "placeholder": "Макс." },
+    "country": { "label": "Страна", "placeholder": "Страна" }
+  },
+  "ja": {
+    "all": "すべて",
+    "clearAll": "すべてクリア",
+    "category": { "label": "カテゴリー", "vehicle": "車両", "engine": "エンジン", "parts": "パーツ" },
+    "condition": { "label": "状態", "any": "指定なし", "excellent": "極上", "good": "良好", "fair": "並", "project": "レストア向き" },
+    "budgetMin": { "label": "予算（最小）", "placeholder": "最小" },
+    "budgetMax": { "label": "予算（最大）", "placeholder": "最大" },
+    "country": { "label": "国", "placeholder": "国" }
+  },
+  "zh": {
+    "all": "全部",
+    "clearAll": "清除全部",
+    "category": { "label": "类别", "vehicle": "整车", "engine": "发动机", "parts": "零件" },
+    "condition": { "label": "成色", "any": "不限", "excellent": "极佳", "good": "良好", "fair": "一般", "project": "待修复" },
+    "budgetMin": { "label": "预算下限", "placeholder": "最低" },
+    "budgetMax": { "label": "预算上限", "placeholder": "最高" },
+    "country": { "label": "国家", "placeholder": "国家" }
+  },
+  "ko": {
+    "all": "전체",
+    "clearAll": "모두 지우기",
+    "category": { "label": "카테고리", "vehicle": "차량", "engine": "엔진", "parts": "부품" },
+    "condition": { "label": "상태", "any": "전체", "excellent": "최상", "good": "양호", "fair": "보통", "project": "복원용" },
+    "budgetMin": { "label": "예산 최소", "placeholder": "최소" },
+    "budgetMax": { "label": "예산 최대", "placeholder": "최대" },
+    "country": { "label": "국가", "placeholder": "국가" }
+  }
+}
+</i18n>

--- a/app/components/exchange/wanted/WantedTable.vue
+++ b/app/components/exchange/wanted/WantedTable.vue
@@ -82,7 +82,7 @@
 
           <!-- Posted -->
           <td class="whitespace-nowrap text-base-content/70">
-            <ClientOnly>{{ timeAgo(post.created_at) }}</ClientOnly>
+            <ClientOnly>{{ timeAgo(post.created_at, locale) }}</ClientOnly>
           </td>
 
           <!-- User (optional column) -->
@@ -121,7 +121,7 @@
   import { getCountryFlag } from '~/utils/countryFlags';
   import { categoryBadgeClass, formatCategory, formatBudget, formatLocation, timeAgo } from '~/utils/wantedFormatters';
 
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
 
   const props = defineProps<{
     posts: WantedPost[];

--- a/app/components/exchange/wanted/WantedTable.vue
+++ b/app/components/exchange/wanted/WantedTable.vue
@@ -82,7 +82,7 @@
 
           <!-- Posted -->
           <td class="whitespace-nowrap text-base-content/70">
-            {{ timeAgo(post.created_at) }}
+            <ClientOnly>{{ timeAgo(post.created_at) }}</ClientOnly>
           </td>
 
           <!-- User (optional column) -->

--- a/app/components/exchange/wanted/WantedTable.vue
+++ b/app/components/exchange/wanted/WantedTable.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="overflow-x-auto">
+    <table class="table table-zebra w-full">
+      <thead>
+        <tr>
+          <th class="cursor-pointer select-none hover:bg-base-300 transition-colors" @click="emit('sort', 'title')">
+            <div class="flex items-center gap-1">
+              {{ t('columns.title') }}
+              <i v-if="sortBy === 'title'" class="fas fa-sort text-primary"></i>
+            </div>
+          </th>
+          <th>{{ t('columns.category') }}</th>
+          <th class="cursor-pointer select-none hover:bg-base-300 transition-colors" @click="emit('sort', 'budget')">
+            <div class="flex items-center gap-1">
+              {{ t('columns.budget') }}
+              <i
+                v-if="sortBy === 'budget' || sortBy === 'budget_high' || sortBy === 'budget_low'"
+                class="fas fa-sort text-primary"
+              ></i>
+            </div>
+          </th>
+          <th>{{ t('columns.location') }}</th>
+          <th>{{ t('columns.condition') }}</th>
+          <th class="cursor-pointer select-none hover:bg-base-300 transition-colors" @click="emit('sort', 'date')">
+            <div class="flex items-center gap-1">
+              {{ t('columns.posted') }}
+              <i
+                v-if="sortBy === 'date' || sortBy === 'newest' || sortBy === 'oldest'"
+                class="fas fa-sort text-primary"
+              ></i>
+            </div>
+          </th>
+          <th v-if="showUserColumn">{{ t('columns.user') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="post in posts" :key="post.id" class="hover:bg-base-300/50 transition-colors">
+          <!-- Title -->
+          <td>
+            <NuxtLink
+              :to="`/exchange/wanted/${post.id}`"
+              class="font-medium hover:text-primary transition-colors line-clamp-1 max-w-xs"
+            >
+              {{ post.title }}
+            </NuxtLink>
+          </td>
+
+          <!-- Category -->
+          <td>
+            <span class="badge badge-sm" :class="categoryBadgeClass(post.category)">
+              {{ formatCategory(post.category) }}
+            </span>
+          </td>
+
+          <!-- Budget -->
+          <td>
+            <span v-if="formatBudget(post.budget_min, post.budget_max, post.currency)" class="whitespace-nowrap">
+              {{ formatBudget(post.budget_min, post.budget_max, post.currency) }}
+            </span>
+            <span v-else class="text-base-content/40">&mdash;</span>
+          </td>
+
+          <!-- Location -->
+          <td>
+            <span
+              v-if="formatLocation(post.city, post.state_province, post.country)"
+              class="flex items-center gap-1 whitespace-nowrap"
+            >
+              <template v-if="getCountryFlag(post.country)">{{ getCountryFlag(post.country) }}</template>
+              {{ formatLocation(post.city, post.state_province, post.country) }}
+            </span>
+            <span v-else class="text-base-content/40">&mdash;</span>
+          </td>
+
+          <!-- Condition -->
+          <td>
+            <span v-if="post.condition_preference && post.condition_preference !== 'any'" class="capitalize">
+              {{ post.condition_preference }}
+            </span>
+            <span v-else class="text-base-content/60">{{ t('any') }}</span>
+          </td>
+
+          <!-- Posted -->
+          <td class="whitespace-nowrap text-base-content/70">
+            {{ timeAgo(post.created_at) }}
+          </td>
+
+          <!-- User (optional column) -->
+          <td v-if="showUserColumn">
+            <div v-if="post.profiles" class="flex items-center gap-2">
+              <ExchangeAvatar
+                :avatar-url="post.profiles.avatar_url"
+                :display-name="post.profiles.display_name"
+                :username="post.profiles.username"
+                size="xs"
+              />
+              <span class="text-sm font-medium truncate max-w-[120px]">
+                {{ post.profiles.display_name || post.profiles.username || t('anonymous') }}
+              </span>
+            </div>
+            <span v-else class="text-base-content/40">&mdash;</span>
+          </td>
+        </tr>
+
+        <!-- Empty state -->
+        <tr v-if="posts.length === 0">
+          <td :colspan="showUserColumn ? 7 : 6" class="text-center py-8 text-base-content/50">
+            <div class="flex flex-col items-center gap-2">
+              <i class="fas fa-magnifying-glass text-2xl"></i>
+              <p>{{ t('empty') }}</p>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { WantedPost } from '~/composables/useWantedPosts';
+  import { getCountryFlag } from '~/utils/countryFlags';
+  import { categoryBadgeClass, formatCategory, formatBudget, formatLocation, timeAgo } from '~/utils/wantedFormatters';
+
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    posts: WantedPost[];
+    sortBy?: string;
+    showUserColumn?: boolean;
+  }>();
+
+  const emit = defineEmits<{
+    (e: 'sort', column: string): void;
+  }>();
+</script>
+
+<i18n lang="json">
+{
+  "en": { "columns": { "title": "Title", "category": "Category", "budget": "Budget", "location": "Location", "condition": "Condition", "posted": "Posted", "user": "User" }, "any": "Any", "anonymous": "Anonymous", "empty": "No wanted posts found" },
+  "es": { "columns": { "title": "Título", "category": "Categoría", "budget": "Presupuesto", "location": "Ubicación", "condition": "Estado", "posted": "Publicado", "user": "Usuario" }, "any": "Cualquiera", "anonymous": "Anónimo", "empty": "No se encontraron anuncios de búsqueda" },
+  "fr": { "columns": { "title": "Titre", "category": "Catégorie", "budget": "Budget", "location": "Lieu", "condition": "État", "posted": "Publié", "user": "Utilisateur" }, "any": "Tout", "anonymous": "Anonyme", "empty": "Aucune annonce de recherche trouvée" },
+  "de": { "columns": { "title": "Titel", "category": "Kategorie", "budget": "Budget", "location": "Ort", "condition": "Zustand", "posted": "Veröffentlicht", "user": "Nutzer" }, "any": "Beliebig", "anonymous": "Anonym", "empty": "Keine Gesuche gefunden" },
+  "it": { "columns": { "title": "Titolo", "category": "Categoria", "budget": "Budget", "location": "Posizione", "condition": "Condizione", "posted": "Pubblicato", "user": "Utente" }, "any": "Qualsiasi", "anonymous": "Anonimo", "empty": "Nessun annuncio di ricerca trovato" },
+  "pt": { "columns": { "title": "Título", "category": "Categoria", "budget": "Orçamento", "location": "Localização", "condition": "Condição", "posted": "Publicado", "user": "Usuário" }, "any": "Qualquer", "anonymous": "Anônimo", "empty": "Nenhum anúncio de procura encontrado" },
+  "ru": { "columns": { "title": "Название", "category": "Категория", "budget": "Бюджет", "location": "Местоположение", "condition": "Состояние", "posted": "Опубликовано", "user": "Пользователь" }, "any": "Любое", "anonymous": "Аноним", "empty": "Объявления о поиске не найдены" },
+  "ja": { "columns": { "title": "タイトル", "category": "カテゴリー", "budget": "予算", "location": "場所", "condition": "状態", "posted": "投稿日", "user": "ユーザー" }, "any": "指定なし", "anonymous": "匿名", "empty": "募集投稿が見つかりません" },
+  "zh": { "columns": { "title": "标题", "category": "类别", "budget": "预算", "location": "位置", "condition": "状况", "posted": "发布时间", "user": "用户" }, "any": "任意", "anonymous": "匿名", "empty": "未找到求购信息" },
+  "ko": { "columns": { "title": "제목", "category": "카테고리", "budget": "예산", "location": "위치", "condition": "상태", "posted": "게시일", "user": "사용자" }, "any": "모두", "anonymous": "익명", "empty": "구함 게시물을 찾을 수 없습니다" }
+}
+</i18n>

--- a/app/composables/useSavedSearches.ts
+++ b/app/composables/useSavedSearches.ts
@@ -1,0 +1,201 @@
+export interface SavedSearch {
+  id: string;
+  user_id: string;
+  name: string;
+  filters: Record<string, any>;
+  notify_email: boolean;
+  is_active: boolean;
+  notified_listing_ids: string[];
+  created_at: string;
+}
+
+const MAX_SAVED_SEARCHES = 10;
+
+export const useSavedSearches = () => {
+  const supabase = useSupabase();
+  const { user } = useAuth();
+  const toast = useToast();
+  const { capture } = usePostHog();
+
+  const savedSearches = ref<SavedSearch[]>([]);
+  const loading = ref(false);
+  const saving = ref(false);
+
+  /**
+   * Fetch all saved searches for the current user
+   */
+  const fetchSavedSearches = async () => {
+    if (!user.value) {
+      savedSearches.value = [];
+      return;
+    }
+
+    loading.value = true;
+
+    try {
+      const { data, error } = await supabase
+        .from('saved_searches')
+        .select('*')
+        .eq('user_id', user.value.id)
+        .order('created_at', { ascending: false });
+
+      if (error) throw error;
+
+      savedSearches.value = (data as SavedSearch[]) || [];
+    } catch (error: any) {
+      console.error('Failed to fetch saved searches:', error);
+      toast.add({
+        title: 'Error',
+        description: 'Failed to load saved searches',
+        color: 'error',
+      });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /**
+   * Create a new saved search
+   * Enforces a client-side max of 10 saved searches
+   */
+  const createSavedSearch = async (name: string, filters: Record<string, any>): Promise<SavedSearch | null> => {
+    if (!user.value) {
+      toast.add({
+        title: 'Authentication Required',
+        description: 'Please sign in to save searches',
+        color: 'warning',
+      });
+      return null;
+    }
+
+    if (savedSearches.value.length >= MAX_SAVED_SEARCHES) {
+      toast.add({
+        title: 'Limit Reached',
+        description: `You can save up to ${MAX_SAVED_SEARCHES} searches. Please delete one before adding another.`,
+        color: 'warning',
+      });
+      return null;
+    }
+
+    saving.value = true;
+
+    try {
+      const { data, error } = await supabase
+        .from('saved_searches')
+        .insert({
+          user_id: user.value.id,
+          name,
+          filters,
+        })
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      savedSearches.value.unshift(data as SavedSearch);
+
+      capture('saved_search_created', {
+        search_name: name,
+        filter_count: Object.keys(filters).length,
+      });
+
+      toast.add({
+        title: 'Search Saved',
+        description: 'You will be notified when new listings match your search',
+        color: 'success',
+      });
+
+      return data as SavedSearch;
+    } catch (error: any) {
+      console.error('Failed to create saved search:', error);
+      toast.add({
+        title: 'Error',
+        description: error.message || 'Failed to save search',
+        color: 'error',
+      });
+      return null;
+    } finally {
+      saving.value = false;
+    }
+  };
+
+  /**
+   * Toggle the is_active flag on a saved search (optimistic update)
+   */
+  const toggleActive = async (searchId: string) => {
+    if (!user.value) return false;
+
+    const index = savedSearches.value.findIndex((s) => s.id === searchId);
+    if (index === -1) return false;
+
+    const previousValue = savedSearches.value[index].is_active;
+    const newValue = !previousValue;
+
+    // Optimistic update
+    savedSearches.value[index] = { ...savedSearches.value[index], is_active: newValue };
+
+    try {
+      const { error } = await supabase
+        .from('saved_searches')
+        .update({ is_active: newValue })
+        .eq('id', searchId)
+        .eq('user_id', user.value.id);
+
+      if (error) throw error;
+
+      return true;
+    } catch (error: any) {
+      // Revert optimistic update
+      savedSearches.value[index] = { ...savedSearches.value[index], is_active: previousValue };
+
+      console.error('Failed to toggle saved search:', error);
+      toast.add({
+        title: 'Error',
+        description: error.message || 'Failed to update saved search',
+        color: 'error',
+      });
+      return false;
+    }
+  };
+
+  /**
+   * Delete a saved search by id
+   */
+  const deleteSavedSearch = async (searchId: string) => {
+    if (!user.value) return false;
+
+    try {
+      const { error } = await supabase.from('saved_searches').delete().eq('id', searchId).eq('user_id', user.value.id);
+
+      if (error) throw error;
+
+      savedSearches.value = savedSearches.value.filter((s) => s.id !== searchId);
+
+      toast.add({
+        title: 'Deleted',
+        description: 'Saved search has been removed',
+        color: 'success',
+      });
+
+      return true;
+    } catch (error: any) {
+      console.error('Failed to delete saved search:', error);
+      toast.add({
+        title: 'Error',
+        description: error.message || 'Failed to delete saved search',
+        color: 'error',
+      });
+      return false;
+    }
+  };
+
+  return {
+    savedSearches,
+    loading,
+    saving,
+    fetchSavedSearches,
+    createSavedSearch,
+    toggleActive,
+    deleteSavedSearch,
+  };
+};

--- a/app/composables/useWantedPosts.ts
+++ b/app/composables/useWantedPosts.ts
@@ -1,0 +1,580 @@
+/**
+ * Composable for managing Wanted Posts (Classic Mini parts/vehicles wanted ads)
+ *
+ * Provides CRUD operations, filtering, pagination, and status management
+ * for the wanted_posts table. Uses server API endpoints for create/update/delete
+ * (with server-side sanitization and moderation) and direct Supabase queries for reads.
+ */
+
+export interface WantedPost {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  category: string;
+  parts_subcategory?: string | null;
+  condition_preference: string;
+  budget_min?: number | null;
+  budget_max?: number | null;
+  currency: string;
+  city?: string | null;
+  state_province?: string | null;
+  country?: string | null;
+  status: string;
+  moderation_status: string;
+  moderation_issues?: string[] | null;
+  expires_at: string;
+  created_at: string;
+  updated_at: string;
+  profiles?: {
+    id: string;
+    display_name: string | null;
+    username: string | null;
+    avatar_url: string | null;
+  } | null;
+}
+
+export interface WantedPostFilters {
+  search?: string;
+  category?: string;
+  conditionPreference?: string;
+  budgetMin?: number;
+  budgetMax?: number;
+  country?: string;
+  page?: number;
+  perPage?: number;
+  sortBy?: 'newest' | 'oldest' | 'budget_high' | 'budget_low';
+}
+
+export interface CreateWantedPostData {
+  title: string;
+  description: string;
+  category: string;
+  partsSubcategory?: string | null;
+  conditionPreference?: string;
+  budgetMin?: number | null;
+  budgetMax?: number | null;
+  currency?: string;
+  city?: string | null;
+  stateProvince?: string | null;
+  country?: string | null;
+}
+
+export interface UpdateWantedPostData {
+  title?: string;
+  description?: string;
+  category?: string;
+  partsSubcategory?: string | null;
+  conditionPreference?: string;
+  budgetMin?: number | null;
+  budgetMax?: number | null;
+  currency?: string;
+  city?: string | null;
+  stateProvince?: string | null;
+  country?: string | null;
+}
+
+export const useWantedPosts = () => {
+  const supabase = useSupabase();
+  const toast = useToast();
+  const { handleError } = useErrorHandler();
+  const { capture } = usePostHog();
+
+  // Lazy-load auth only when needed (for create/update/delete operations)
+  // This allows public pages to browse wanted posts without requiring authentication
+  const getUser = () => {
+    const { user } = useAuth();
+    return user.value;
+  };
+
+  /**
+   * Resolve the current Supabase session access token, or surface a "Session
+   * Expired" toast and return null. Used by every mutating operation to
+   * authenticate against the server endpoints.
+   */
+  async function getAccessTokenOrWarn(action: string): Promise<string | null> {
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData?.session?.access_token;
+    if (!accessToken) {
+      toast.add({
+        title: 'Session Expired',
+        description: `Please sign in again to ${action}`,
+        color: 'warning',
+      });
+      return null;
+    }
+    return accessToken;
+  }
+
+  // Reactive state
+  const wantedPosts = ref<WantedPost[]>([]);
+  const currentPost = ref<WantedPost | null>(null);
+  const loading = ref(false);
+  const totalCount = ref(0);
+
+  /**
+   * Fetch wanted posts with filters, search, and pagination.
+   * Only returns active + approved posts for public browsing.
+   */
+  async function fetchWantedPosts(filters?: WantedPostFilters) {
+    loading.value = true;
+
+    try {
+      const page = filters?.page ?? 1;
+      const perPage = filters?.perPage ?? 20;
+      const from = (page - 1) * perPage;
+      const to = from + perPage - 1;
+
+      let query = supabase
+        .from('wanted_posts')
+        .select('*, profiles:public_profiles!wanted_posts_user_id_fkey(id, display_name, username, avatar_url)', {
+          count: 'exact',
+        })
+        .eq('status', 'active')
+        .eq('moderation_status', 'approved');
+
+      // Search filter (title + description)
+      if (filters?.search) {
+        query = query.or(`title.ilike.%${filters.search}%,description.ilike.%${filters.search}%`);
+      }
+
+      // Category filter
+      if (filters?.category) {
+        query = query.eq('category', filters.category);
+      }
+
+      // Condition preference filter
+      if (filters?.conditionPreference) {
+        query = query.eq('condition_preference', filters.conditionPreference);
+      }
+
+      // Budget range filters
+      if (filters?.budgetMin !== undefined) {
+        query = query.gte('budget_max', filters.budgetMin);
+      }
+      if (filters?.budgetMax !== undefined) {
+        query = query.lte('budget_min', filters.budgetMax);
+      }
+
+      // Country filter
+      if (filters?.country) {
+        query = query.ilike('country', `%${filters.country}%`);
+      }
+
+      // Sorting
+      const sortBy = filters?.sortBy ?? 'newest';
+      switch (sortBy) {
+        case 'oldest':
+          query = query.order('created_at', { ascending: true });
+          break;
+        case 'budget_high':
+          query = query.order('budget_max', { ascending: false, nullsFirst: false });
+          break;
+        case 'budget_low':
+          query = query.order('budget_min', { ascending: true, nullsFirst: false });
+          break;
+        case 'newest':
+        default:
+          query = query.order('created_at', { ascending: false });
+          break;
+      }
+
+      // Pagination
+      query = query.range(from, to);
+
+      const { data, error, count } = await query;
+
+      if (error) throw error;
+
+      wantedPosts.value = (data as unknown as WantedPost[]) || [];
+      totalCount.value = count ?? 0;
+
+      return wantedPosts.value;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to load wanted posts' });
+      return [];
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Fetch a single wanted post by ID with profile join.
+   */
+  async function fetchWantedPost(id: string) {
+    loading.value = true;
+
+    try {
+      const { data, error } = await supabase
+        .from('wanted_posts')
+        .select('*, profiles:public_profiles!wanted_posts_user_id_fkey(id, display_name, username, avatar_url)')
+        .eq('id', id)
+        .single();
+
+      if (error) throw error;
+
+      currentPost.value = data as unknown as WantedPost;
+      return currentPost.value;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to load wanted post' });
+      return null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Fetch the current user's wanted posts for their dashboard.
+   * Shows all statuses (not filtered to active/approved) so the user
+   * can manage their own flagged, fulfilled, or expired posts.
+   */
+  async function fetchUserWantedPosts(userId?: string) {
+    loading.value = true;
+
+    try {
+      const user = getUser();
+      const targetUserId = userId || user?.id;
+
+      if (!targetUserId) throw new Error('User not authenticated');
+
+      const { data, error } = await supabase
+        .from('wanted_posts')
+        .select('*, profiles:public_profiles!wanted_posts_user_id_fkey(id, display_name, username, avatar_url)')
+        .eq('user_id', targetUserId)
+        .order('created_at', { ascending: false });
+
+      if (error) throw error;
+
+      wantedPosts.value = (data as unknown as WantedPost[]) || [];
+      return wantedPosts.value;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to load your wanted posts' });
+      return [];
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Create a new wanted post via server API (handles sanitization + moderation).
+   */
+  async function createWantedPost(postData: CreateWantedPostData) {
+    try {
+      const user = getUser();
+      if (!user) {
+        toast.add({
+          title: 'Authentication Required',
+          description: 'Please sign in to create a wanted post',
+          color: 'warning',
+        });
+        return null;
+      }
+
+      const accessToken = await getAccessTokenOrWarn('create a wanted post');
+      if (!accessToken) return null;
+
+      const response = await $fetch('/api/wanted/create', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${accessToken}` },
+        body: {
+          title: postData.title,
+          description: postData.description,
+          category: postData.category,
+          partsSubcategory: postData.partsSubcategory,
+          conditionPreference: postData.conditionPreference,
+          budgetMin: postData.budgetMin,
+          budgetMax: postData.budgetMax,
+          currency: postData.currency,
+          city: postData.city,
+          stateProvince: postData.stateProvince,
+          country: postData.country,
+        },
+      });
+
+      const createdPost = response.post as WantedPost;
+
+      // Track analytics
+      capture('wanted_post_created', {
+        wanted_post_id: createdPost.id,
+        category: createdPost.category,
+        has_budget: createdPost.budget_min !== null || createdPost.budget_max !== null,
+        has_location: !!createdPost.city || !!createdPost.country,
+      });
+
+      if (response.flagged) {
+        toast.add({
+          title: 'Post Created',
+          description: 'Your wanted post was created but flagged for review due to content moderation.',
+          color: 'warning',
+        });
+      } else {
+        toast.add({
+          title: 'Wanted Post Created',
+          description: 'Your wanted post is now live!',
+          color: 'success',
+        });
+      }
+
+      return createdPost;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to create wanted post' });
+      return null;
+    }
+  }
+
+  /**
+   * Update an existing wanted post via server API (handles sanitization + moderation).
+   */
+  async function updateWantedPost(id: string, postData: UpdateWantedPostData) {
+    try {
+      const user = getUser();
+      if (!user) {
+        toast.add({
+          title: 'Authentication Required',
+          description: 'Please sign in to update your wanted post',
+          color: 'warning',
+        });
+        return null;
+      }
+
+      const accessToken = await getAccessTokenOrWarn('update your wanted post');
+      if (!accessToken) return null;
+
+      const response = await $fetch(`/api/wanted/${id}`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${accessToken}` },
+        body: {
+          title: postData.title,
+          description: postData.description,
+          category: postData.category,
+          partsSubcategory: postData.partsSubcategory,
+          conditionPreference: postData.conditionPreference,
+          budgetMin: postData.budgetMin,
+          budgetMax: postData.budgetMax,
+          currency: postData.currency,
+          city: postData.city,
+          stateProvince: postData.stateProvince,
+          country: postData.country,
+        },
+      });
+
+      const updatedPost = response.post as WantedPost;
+
+      // Update local state if this post is in the list
+      const index = wantedPosts.value.findIndex((p) => p.id === id);
+      if (index !== -1) {
+        wantedPosts.value[index] = updatedPost;
+      }
+
+      // Update currentPost if it matches
+      if (currentPost.value?.id === id) {
+        currentPost.value = updatedPost;
+      }
+
+      // Track analytics
+      capture('wanted_post_edited', {
+        wanted_post_id: id,
+      });
+
+      if (response.flagged) {
+        toast.add({
+          title: 'Post Updated',
+          description: 'Your wanted post was updated but flagged for review due to content moderation.',
+          color: 'warning',
+        });
+      } else {
+        toast.add({
+          title: 'Wanted Post Updated',
+          description: 'Your changes have been saved.',
+          color: 'success',
+        });
+      }
+
+      return updatedPost;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to update wanted post' });
+      return null;
+    }
+  }
+
+  /**
+   * Delete a wanted post via server API.
+   */
+  async function deleteWantedPost(id: string) {
+    try {
+      const user = getUser();
+      if (!user) {
+        toast.add({
+          title: 'Authentication Required',
+          description: 'Please sign in to delete your wanted post',
+          color: 'warning',
+        });
+        return false;
+      }
+
+      const accessToken = await getAccessTokenOrWarn('delete your wanted post');
+      if (!accessToken) return false;
+
+      await $fetch(`/api/wanted/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      // Remove from local state
+      wantedPosts.value = wantedPosts.value.filter((p) => p.id !== id);
+
+      // Clear currentPost if it matches
+      if (currentPost.value?.id === id) {
+        currentPost.value = null;
+      }
+
+      // Track analytics
+      capture('wanted_post_deleted', {
+        wanted_post_id: id,
+      });
+
+      toast.add({
+        title: 'Wanted Post Deleted',
+        description: 'Your wanted post has been removed.',
+        color: 'info',
+      });
+
+      return true;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to delete wanted post' });
+      return false;
+    }
+  }
+
+  /**
+   * Mark a wanted post as fulfilled (the user found what they were looking for).
+   */
+  async function markFulfilled(id: string) {
+    try {
+      const user = getUser();
+      if (!user) {
+        toast.add({
+          title: 'Authentication Required',
+          description: 'Please sign in to update your wanted post',
+          color: 'warning',
+        });
+        return false;
+      }
+
+      const { data, error } = await supabase
+        .from('wanted_posts')
+        .update({ status: 'fulfilled' })
+        .eq('id', id)
+        .eq('user_id', user.id)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      // Update local state
+      const index = wantedPosts.value.findIndex((p) => p.id === id);
+      if (index !== -1) {
+        wantedPosts.value[index] = data as unknown as WantedPost;
+      }
+
+      if (currentPost.value?.id === id) {
+        currentPost.value = data as unknown as WantedPost;
+      }
+
+      // Track analytics
+      capture('wanted_post_fulfilled', {
+        wanted_post_id: id,
+      });
+
+      toast.add({
+        title: 'Marked as Fulfilled',
+        description: 'Glad you found what you were looking for!',
+        color: 'success',
+      });
+
+      return true;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to mark as fulfilled' });
+      return false;
+    }
+  }
+
+  /**
+   * Renew a wanted post by extending the expiration by 90 days from now
+   * and setting status back to active.
+   */
+  async function renewWantedPost(id: string) {
+    try {
+      const user = getUser();
+      if (!user) {
+        toast.add({
+          title: 'Authentication Required',
+          description: 'Please sign in to renew your wanted post',
+          color: 'warning',
+        });
+        return false;
+      }
+
+      // Calculate new expiry: 90 days from now
+      const newExpiresAt = new Date();
+      newExpiresAt.setDate(newExpiresAt.getDate() + 90);
+
+      const { data, error } = await supabase
+        .from('wanted_posts')
+        .update({
+          expires_at: newExpiresAt.toISOString(),
+          status: 'active',
+        })
+        .eq('id', id)
+        .eq('user_id', user.id)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      // Update local state
+      const index = wantedPosts.value.findIndex((p) => p.id === id);
+      if (index !== -1) {
+        wantedPosts.value[index] = data as unknown as WantedPost;
+      }
+
+      if (currentPost.value?.id === id) {
+        currentPost.value = data as unknown as WantedPost;
+      }
+
+      // Track analytics
+      capture('wanted_post_renewed', {
+        wanted_post_id: id,
+      });
+
+      toast.add({
+        title: 'Wanted Post Renewed',
+        description: 'Your wanted post has been renewed for another 90 days.',
+        color: 'success',
+      });
+
+      return true;
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to renew wanted post' });
+      return false;
+    }
+  }
+
+  return {
+    // State
+    wantedPosts,
+    currentPost,
+    loading,
+    totalCount,
+
+    // Methods
+    fetchWantedPosts,
+    fetchWantedPost,
+    fetchUserWantedPosts,
+    createWantedPost,
+    updateWantedPost,
+    deleteWantedPost,
+    markFulfilled,
+    renewWantedPost,
+  };
+};

--- a/app/pages/exchange/finds/[slug].vue
+++ b/app/pages/exchange/finds/[slug].vue
@@ -1,0 +1,630 @@
+<template>
+  <div>
+    <!-- Loading State -->
+    <div v-if="loading" class="py-12">
+      <div class="container">
+        <div class="skeleton h-96 mb-6"></div>
+        <div class="skeleton h-8 w-2/3 mb-4"></div>
+        <div class="skeleton h-4 w-1/2 mb-2"></div>
+        <div class="skeleton h-32"></div>
+      </div>
+    </div>
+
+    <!-- Find Content -->
+    <div v-else-if="currentFind">
+      <!-- Hero Image -->
+      <section class="bg-base-200">
+        <div class="container">
+          <div class="py-8 flex justify-center">
+            <div class="bg-base-300 rounded-lg overflow-hidden max-h-125 max-w-3xl w-full">
+              <img
+                v-if="currentFind.og_image_url && !imageError"
+                :src="currentFind.og_image_url"
+                :alt="currentFind.title"
+                class="w-full h-auto object-contain max-h-125 mx-auto"
+                @error="imageError = true"
+              />
+              <div v-else class="aspect-video w-full flex items-center justify-center">
+                <i class="fas fa-link text-7xl text-base-content/20"></i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Find Details -->
+      <section class="py-12">
+        <div class="container">
+          <div class="grid lg:grid-cols-3 gap-8">
+            <!-- Main Content -->
+            <div class="lg:col-span-2 space-y-8 order-2 lg:order-1">
+              <!-- Badges Row -->
+              <div class="flex flex-wrap items-center gap-2">
+                <ExchangeFindsSourceSiteBadge :site="currentFind.source_site" size="md" />
+                <span v-if="currentFind.is_editors_pick" class="badge badge-accent gap-1">
+                  <i class="fas fa-star"></i>
+                  {{ t('editorsPick') }}
+                </span>
+                <span v-if="currentFind.category" class="badge badge-outline">
+                  {{ formatCategory(currentFind.category) }}
+                </span>
+              </div>
+
+              <!-- Title -->
+              <h1 class="text-4xl font-bold">{{ currentFind.title }}</h1>
+
+              <!-- Metadata Row -->
+              <div class="flex flex-wrap items-center gap-4 text-base-content/70">
+                <div v-if="currentFind.year" class="flex items-center gap-1.5">
+                  <i class="fas fa-calendar"></i>
+                  <span>{{ currentFind.year }}</span>
+                </div>
+                <div v-if="currentFind.model" class="flex items-center gap-1.5">
+                  <i class="fas fa-truck"></i>
+                  <span>{{ currentFind.model }}</span>
+                </div>
+                <div v-if="currentFind.price != null || currentFind.price_label" class="flex items-center gap-1.5">
+                  <i class="fas fa-dollar-sign"></i>
+                  <span class="font-semibold text-primary text-lg">
+                    {{ currentFind.price_label || formatPrice(currentFind.price!) }}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Auction Countdown -->
+              <div v-if="auctionLabel" class="alert" :class="auctionEnded ? 'alert-info' : 'alert-warning'">
+                <i :class="auctionEnded ? 'fas fa-clock' : 'fas fa-fire'"></i>
+                <span class="font-medium">{{ auctionLabel }}</span>
+              </div>
+
+              <!-- Editor Commentary -->
+              <div v-if="currentFind.editor_commentary" class="mt-8">
+                <h2 class="text-xl font-semibold mb-3">{{ t('editorsCommentary') }}</h2>
+                <blockquote class="border-l-4 border-primary pl-4 py-2 bg-base-200 rounded-r-lg">
+                  <p class="text-base-content/80 whitespace-pre-wrap italic">{{ currentFind.editor_commentary }}</p>
+                </blockquote>
+              </div>
+
+              <!-- User Description -->
+              <div v-if="currentFind.description" class="mt-8">
+                <h2 class="text-xl font-semibold mb-3">{{ t('aboutThisFind') }}</h2>
+                <p class="text-base-content/80 whitespace-pre-wrap">{{ currentFind.description }}</p>
+              </div>
+
+              <!-- OG Description (fallback from source site) -->
+              <div v-else-if="currentFind.og_description" class="mt-8">
+                <h2 class="text-xl font-semibold mb-3">{{ t('fromTheSource') }}</h2>
+                <p class="text-base-content/80 whitespace-pre-wrap">{{ currentFind.og_description }}</p>
+              </div>
+
+              <!-- Tags -->
+              <div v-if="currentFind.tags && currentFind.tags.length > 0" class="flex flex-wrap gap-2">
+                <span v-for="tag in currentFind.tags" :key="tag" class="badge badge-outline">
+                  {{ tag }}
+                </span>
+              </div>
+
+              <!-- Comments Section -->
+              <div class="mt-8">
+                <ExchangeListingsCommentSection :listing-id="currentFind.id" :external-listing-id="currentFind.id" />
+              </div>
+            </div>
+
+            <!-- Sidebar -->
+            <div class="lg:col-span-1 order-1 lg:order-2">
+              <div class="lg:sticky lg:top-20 space-y-6">
+                <!-- Action Card -->
+                <div class="card bg-base-100 shadow-sm">
+                  <div class="card-body">
+                    <!-- Price / Auction Info -->
+                    <div v-if="currentFind.price != null || currentFind.price_label" class="text-center mb-2">
+                      <div class="text-2xl font-bold text-primary">
+                        {{ currentFind.price_label || formatPrice(currentFind.price!) }}
+                      </div>
+                    </div>
+
+                    <!-- View Original -->
+                    <a
+                      :href="currentFind.source_url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="btn btn-primary btn-block gap-2"
+                      @click="trackSourceClick"
+                    >
+                      <i class="fas fa-arrow-up-right-from-square"></i>
+                      {{ t('viewOnSource', { source: sourceSiteDisplayName }) }}
+                    </a>
+
+                    <!-- Like & Watchlist Row -->
+                    <div class="flex gap-2 mt-2">
+                      <ExchangeFindsLikeButton
+                        :find-id="currentFind.id"
+                        :like-count="currentFind.like_count"
+                        :is-liked="isLiked(currentFind.id)"
+                        class="flex-1 justify-center"
+                        @toggle="toggleLike(currentFind.id)"
+                      />
+                      <ExchangeListingsWatchlistButton
+                        :listing-id="currentFind.id"
+                        :external-listing-id="currentFind.id"
+                        class="flex-1"
+                      />
+                    </div>
+
+                    <!-- Share Buttons -->
+                    <div class="pt-4 border-t border-base-300 mt-2">
+                      <ExchangeListingsShareButtons
+                        :title="currentFind.title"
+                        :url="currentUrl"
+                        :description="currentFind.description || currentFind.og_description || ''"
+                        :show-label="true"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Submitter Info -->
+                <div class="card bg-base-100 shadow-sm">
+                  <div class="card-body">
+                    <div class="text-sm font-medium text-base-content/60 mb-3">{{ t('submittedBy') }}</div>
+                    <div class="flex items-center gap-3">
+                      <div class="avatar shrink-0">
+                        <div class="w-10 h-10 rounded-full bg-base-300">
+                          <img
+                            v-if="currentFind.profiles?.avatar_url"
+                            :src="currentFind.profiles.avatar_url"
+                            :alt="currentFind.profiles.display_name || t('userAlt')"
+                            loading="lazy"
+                          />
+                          <div
+                            v-else
+                            class="flex items-center justify-center h-full text-sm font-semibold text-base-content/70"
+                          >
+                            {{ getInitials(currentFind.profiles?.display_name || currentFind.profiles?.username || 'U') }}
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        <div class="font-medium">
+                          {{ currentFind.profiles?.display_name || currentFind.profiles?.username || t('communityMember') }}
+                        </div>
+                        <div class="text-sm text-base-content/60">
+                          {{ formatDate(currentFind.created_at) }}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Not Found State -->
+    <div v-else class="py-20">
+      <div class="container">
+        <div class="text-center">
+          <i class="fas fa-triangle-exclamation text-6xl mb-4 text-base-content/30"></i>
+          <h1 class="text-3xl font-bold mb-2">{{ t('notFoundTitle') }}</h1>
+          <p class="text-base-content/70 mb-6">{{ t('notFoundBody') }}</p>
+          <NuxtLink to="/exchange/finds" class="btn btn-primary btn-lg">{{ t('browseAllFinds') }}</NuxtLink>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+  const route = useRoute();
+  const config = useRuntimeConfig();
+  const { user } = useAuth();
+  const { capture } = usePostHog();
+  const { currentFind, loading, fetchFind, toggleLike, isLiked, loadUserInteractions } = useExternalListings();
+
+  const slug = route.params.slug as string;
+  const imageError = ref(false);
+
+  // Source site display names (used for "View on ..." button) — dynamic data, not translated
+  const sourceSiteDisplayName = computed(() => {
+    if (!currentFind.value) return 'Other';
+    const map: Record<string, string> = {
+      bat: 'Bring a Trailer',
+      carsandbids: 'Cars & Bids',
+      copart: 'Copart',
+      craigslist: 'Craigslist',
+      facebook: 'Facebook',
+      ebay: 'eBay',
+      other: 'Other',
+    };
+    return map[currentFind.value.source_site] || 'Other';
+  });
+
+  // Format price as currency
+  const formatPrice = (price: number): string => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(price);
+  };
+
+  // Format category display name
+  const formatCategory = (category: string): string => {
+    const map: Record<string, string> = {
+      vehicle: t('categoryVehicle'),
+      engine: t('categoryEngine'),
+      parts: t('categoryParts'),
+    };
+    return map[category] || category;
+  };
+
+  // Format date
+  const formatDate = (dateStr: string): string => {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  // Get initials from a name
+  const getInitials = (name: string): string => {
+    return name
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+  };
+
+  // Current page URL for sharing
+  const currentUrl = computed(() => {
+    if (typeof window !== 'undefined') {
+      return window.location.href;
+    }
+    return `${config.public.siteUrl || 'https://www.classicminidiy.com'}/exchange/finds/${slug}`;
+  });
+
+  // Don't show auction countdown if the listing is already sold
+  const isSold = computed(() => {
+    return currentFind.value?.price_label ? /sold/i.test(currentFind.value.price_label) : false;
+  });
+
+  // Auction countdown logic
+  const auctionEnded = computed(() => {
+    if (!currentFind.value?.auction_end_time || isSold.value) return false;
+    return new Date(currentFind.value.auction_end_time) <= new Date();
+  });
+
+  const auctionLabel = computed(() => {
+    if (!currentFind.value?.auction_end_time || isSold.value) return null;
+
+    const endTime = new Date(currentFind.value.auction_end_time);
+    const now = new Date();
+
+    if (endTime <= now) {
+      return t('auctionEnded');
+    }
+
+    const diffMs = endTime.getTime() - now.getTime();
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+    const diffDays = Math.floor(diffHours / 24);
+    const remainingHours = diffHours % 24;
+
+    if (diffDays > 0) {
+      return t('auctionEndsInDays', { days: diffDays, hours: remainingHours });
+    }
+    return t('auctionEndsInHours', { hours: diffHours, minutes: diffMinutes });
+  });
+
+  // Track click to source listing
+  const trackSourceClick = () => {
+    if (!currentFind.value) return;
+    capture('find_clicked_source', {
+      id: currentFind.value.id,
+      source_site: currentFind.value.source_site,
+      source_url: currentFind.value.source_url,
+    });
+  };
+
+  // SEO metadata (reactive based on loaded find)
+  const siteUrl = config.public.siteUrl || 'https://www.classicminidiy.com';
+
+  useSeoMeta({
+    title: () =>
+      currentFind.value ? `${currentFind.value.title} | ${t('seoSuffix')}` : t('seoFallbackTitle'),
+    description: () =>
+      currentFind.value?.description ||
+      currentFind.value?.og_description ||
+      t('seoDescription'),
+    ogTitle: () => currentFind.value?.title || t('seoOgTitle'),
+    ogDescription: () =>
+      currentFind.value?.description || currentFind.value?.og_description || t('seoOgDescription'),
+    ogType: 'article',
+    ogUrl: `${siteUrl}/exchange/finds/${slug}`,
+    ogImage: () => currentFind.value?.og_image_url || `${siteUrl}/og-image.jpg`,
+    ogSiteName: 'Classic Mini DIY',
+    twitterCard: 'summary_large_image',
+    twitterTitle: () => currentFind.value?.title || t('seoOgTitle'),
+    twitterDescription: () =>
+      currentFind.value?.description || currentFind.value?.og_description || t('seoOgDescription'),
+    twitterImage: () => currentFind.value?.og_image_url || `${siteUrl}/og-image.jpg`,
+  });
+
+  // Track view on mount
+  const hasTrackedView = ref(false);
+
+  watch(
+    () => currentFind.value,
+    (find) => {
+      if (find && !hasTrackedView.value && import.meta.client) {
+        hasTrackedView.value = true;
+        capture('find_viewed', {
+          id: find.id,
+          source_site: find.source_site,
+          is_editors_pick: find.is_editors_pick,
+        });
+      }
+    },
+    { immediate: true }
+  );
+
+  // Fetch find on mount
+  onMounted(async () => {
+    await fetchFind(slug);
+
+    if (user.value) {
+      loadUserInteractions();
+    }
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "editorsPick": "Editor's Pick",
+    "editorsCommentary": "Editor's Commentary",
+    "aboutThisFind": "About This Find",
+    "fromTheSource": "From the Source",
+    "viewOnSource": "View on {source}",
+    "submittedBy": "Submitted by",
+    "communityMember": "Community Member",
+    "userAlt": "User",
+    "auctionEnded": "Auction Ended",
+    "auctionEndsInDays": "Auction ends in {days}d {hours}h",
+    "auctionEndsInHours": "Auction ends in {hours}h {minutes}m",
+    "categoryVehicle": "Vehicle",
+    "categoryEngine": "Engine",
+    "categoryParts": "Parts",
+    "notFoundTitle": "Find Not Found",
+    "notFoundBody": "The find you are looking for does not exist or has been removed.",
+    "browseAllFinds": "Browse All Finds",
+    "seoSuffix": "Mini Finds | Classic Mini DIY",
+    "seoFallbackTitle": "Find | Classic Mini DIY",
+    "seoDescription": "A Classic Mini listing found on the web by the community.",
+    "seoOgTitle": "Mini Find",
+    "seoOgDescription": "A Classic Mini listing found on the web."
+  },
+  "es": {
+    "editorsPick": "Selección del editor",
+    "editorsCommentary": "Comentario del editor",
+    "aboutThisFind": "Sobre este hallazgo",
+    "fromTheSource": "Desde la fuente",
+    "viewOnSource": "Ver en {source}",
+    "submittedBy": "Enviado por",
+    "communityMember": "Miembro de la comunidad",
+    "userAlt": "Usuario",
+    "auctionEnded": "Subasta finalizada",
+    "auctionEndsInDays": "La subasta termina en {days}d {hours}h",
+    "auctionEndsInHours": "La subasta termina en {hours}h {minutes}m",
+    "categoryVehicle": "Vehículo",
+    "categoryEngine": "Motor",
+    "categoryParts": "Piezas",
+    "notFoundTitle": "Hallazgo no encontrado",
+    "notFoundBody": "El hallazgo que buscas no existe o ha sido eliminado.",
+    "browseAllFinds": "Explorar todos los hallazgos",
+    "seoSuffix": "Hallazgos Mini | Classic Mini DIY",
+    "seoFallbackTitle": "Hallazgo | Classic Mini DIY",
+    "seoDescription": "Un anuncio de Classic Mini encontrado en la web por la comunidad.",
+    "seoOgTitle": "Hallazgo Mini",
+    "seoOgDescription": "Un anuncio de Classic Mini encontrado en la web."
+  },
+  "fr": {
+    "editorsPick": "Choix de la rédaction",
+    "editorsCommentary": "Commentaire de la rédaction",
+    "aboutThisFind": "À propos de cette trouvaille",
+    "fromTheSource": "Depuis la source",
+    "viewOnSource": "Voir sur {source}",
+    "submittedBy": "Soumis par",
+    "communityMember": "Membre de la communauté",
+    "userAlt": "Utilisateur",
+    "auctionEnded": "Enchère terminée",
+    "auctionEndsInDays": "L'enchère se termine dans {days}j {hours}h",
+    "auctionEndsInHours": "L'enchère se termine dans {hours}h {minutes}m",
+    "categoryVehicle": "Véhicule",
+    "categoryEngine": "Moteur",
+    "categoryParts": "Pièces",
+    "notFoundTitle": "Trouvaille introuvable",
+    "notFoundBody": "La trouvaille que vous recherchez n'existe pas ou a été supprimée.",
+    "browseAllFinds": "Parcourir toutes les trouvailles",
+    "seoSuffix": "Trouvailles Mini | Classic Mini DIY",
+    "seoFallbackTitle": "Trouvaille | Classic Mini DIY",
+    "seoDescription": "Une annonce Classic Mini trouvée sur le web par la communauté.",
+    "seoOgTitle": "Trouvaille Mini",
+    "seoOgDescription": "Une annonce Classic Mini trouvée sur le web."
+  },
+  "de": {
+    "editorsPick": "Empfehlung der Redaktion",
+    "editorsCommentary": "Kommentar der Redaktion",
+    "aboutThisFind": "Über diesen Fund",
+    "fromTheSource": "Von der Quelle",
+    "viewOnSource": "Auf {source} ansehen",
+    "submittedBy": "Eingereicht von",
+    "communityMember": "Community-Mitglied",
+    "userAlt": "Benutzer",
+    "auctionEnded": "Auktion beendet",
+    "auctionEndsInDays": "Auktion endet in {days}T {hours}Std",
+    "auctionEndsInHours": "Auktion endet in {hours}Std {minutes}Min",
+    "categoryVehicle": "Fahrzeug",
+    "categoryEngine": "Motor",
+    "categoryParts": "Teile",
+    "notFoundTitle": "Fund nicht gefunden",
+    "notFoundBody": "Der gesuchte Fund existiert nicht oder wurde entfernt.",
+    "browseAllFinds": "Alle Funde durchsuchen",
+    "seoSuffix": "Mini-Funde | Classic Mini DIY",
+    "seoFallbackTitle": "Fund | Classic Mini DIY",
+    "seoDescription": "Ein Classic-Mini-Inserat, das die Community im Web gefunden hat.",
+    "seoOgTitle": "Mini-Fund",
+    "seoOgDescription": "Ein Classic-Mini-Inserat, im Web gefunden."
+  },
+  "it": {
+    "editorsPick": "Scelta della redazione",
+    "editorsCommentary": "Commento della redazione",
+    "aboutThisFind": "Informazioni su questa scoperta",
+    "fromTheSource": "Dalla fonte",
+    "viewOnSource": "Vedi su {source}",
+    "submittedBy": "Inviato da",
+    "communityMember": "Membro della community",
+    "userAlt": "Utente",
+    "auctionEnded": "Asta terminata",
+    "auctionEndsInDays": "L'asta termina tra {days}g {hours}h",
+    "auctionEndsInHours": "L'asta termina tra {hours}h {minutes}m",
+    "categoryVehicle": "Veicolo",
+    "categoryEngine": "Motore",
+    "categoryParts": "Ricambi",
+    "notFoundTitle": "Scoperta non trovata",
+    "notFoundBody": "La scoperta che stai cercando non esiste o è stata rimossa.",
+    "browseAllFinds": "Sfoglia tutte le scoperte",
+    "seoSuffix": "Scoperte Mini | Classic Mini DIY",
+    "seoFallbackTitle": "Scoperta | Classic Mini DIY",
+    "seoDescription": "Un annuncio di Classic Mini trovato sul web dalla community.",
+    "seoOgTitle": "Scoperta Mini",
+    "seoOgDescription": "Un annuncio di Classic Mini trovato sul web."
+  },
+  "pt": {
+    "editorsPick": "Escolha do editor",
+    "editorsCommentary": "Comentário do editor",
+    "aboutThisFind": "Sobre este achado",
+    "fromTheSource": "Da fonte",
+    "viewOnSource": "Ver em {source}",
+    "submittedBy": "Enviado por",
+    "communityMember": "Membro da comunidade",
+    "userAlt": "Usuário",
+    "auctionEnded": "Leilão encerrado",
+    "auctionEndsInDays": "O leilão termina em {days}d {hours}h",
+    "auctionEndsInHours": "O leilão termina em {hours}h {minutes}m",
+    "categoryVehicle": "Veículo",
+    "categoryEngine": "Motor",
+    "categoryParts": "Peças",
+    "notFoundTitle": "Achado não encontrado",
+    "notFoundBody": "O achado que você procura não existe ou foi removido.",
+    "browseAllFinds": "Ver todos os achados",
+    "seoSuffix": "Achados Mini | Classic Mini DIY",
+    "seoFallbackTitle": "Achado | Classic Mini DIY",
+    "seoDescription": "Um anúncio de Classic Mini encontrado na web pela comunidade.",
+    "seoOgTitle": "Achado Mini",
+    "seoOgDescription": "Um anúncio de Classic Mini encontrado na web."
+  },
+  "ru": {
+    "editorsPick": "Выбор редакции",
+    "editorsCommentary": "Комментарий редакции",
+    "aboutThisFind": "Об этой находке",
+    "fromTheSource": "Из источника",
+    "viewOnSource": "Открыть на {source}",
+    "submittedBy": "Добавил",
+    "communityMember": "Участник сообщества",
+    "userAlt": "Пользователь",
+    "auctionEnded": "Аукцион завершён",
+    "auctionEndsInDays": "Аукцион завершится через {days}д {hours}ч",
+    "auctionEndsInHours": "Аукцион завершится через {hours}ч {minutes}м",
+    "categoryVehicle": "Автомобиль",
+    "categoryEngine": "Двигатель",
+    "categoryParts": "Запчасти",
+    "notFoundTitle": "Находка не найдена",
+    "notFoundBody": "Находка, которую вы ищете, не существует или была удалена.",
+    "browseAllFinds": "Все находки",
+    "seoSuffix": "Находки Mini | Classic Mini DIY",
+    "seoFallbackTitle": "Находка | Classic Mini DIY",
+    "seoDescription": "Объявление о Classic Mini, найденное в сети участниками сообщества.",
+    "seoOgTitle": "Находка Mini",
+    "seoOgDescription": "Объявление о Classic Mini, найденное в сети."
+  },
+  "ja": {
+    "editorsPick": "編集者のおすすめ",
+    "editorsCommentary": "編集者のコメント",
+    "aboutThisFind": "この発見について",
+    "fromTheSource": "出典元より",
+    "viewOnSource": "{source} で見る",
+    "submittedBy": "投稿者",
+    "communityMember": "コミュニティメンバー",
+    "userAlt": "ユーザー",
+    "auctionEnded": "オークション終了",
+    "auctionEndsInDays": "オークション終了まで {days}日 {hours}時間",
+    "auctionEndsInHours": "オークション終了まで {hours}時間 {minutes}分",
+    "categoryVehicle": "車両",
+    "categoryEngine": "エンジン",
+    "categoryParts": "パーツ",
+    "notFoundTitle": "発見が見つかりません",
+    "notFoundBody": "お探しの発見は存在しないか、削除されました。",
+    "browseAllFinds": "すべての発見を見る",
+    "seoSuffix": "Mini ファインド | Classic Mini DIY",
+    "seoFallbackTitle": "ファインド | Classic Mini DIY",
+    "seoDescription": "コミュニティがウェブ上で見つけた Classic Mini の出品です。",
+    "seoOgTitle": "Mini ファインド",
+    "seoOgDescription": "ウェブ上で見つかった Classic Mini の出品です。"
+  },
+  "zh": {
+    "editorsPick": "编辑精选",
+    "editorsCommentary": "编辑点评",
+    "aboutThisFind": "关于此发现",
+    "fromTheSource": "来自来源",
+    "viewOnSource": "在 {source} 上查看",
+    "submittedBy": "提交者",
+    "communityMember": "社区成员",
+    "userAlt": "用户",
+    "auctionEnded": "拍卖已结束",
+    "auctionEndsInDays": "拍卖将在 {days}天 {hours}小时 后结束",
+    "auctionEndsInHours": "拍卖将在 {hours}小时 {minutes}分钟 后结束",
+    "categoryVehicle": "车辆",
+    "categoryEngine": "发动机",
+    "categoryParts": "零件",
+    "notFoundTitle": "未找到该发现",
+    "notFoundBody": "您查找的发现不存在或已被删除。",
+    "browseAllFinds": "浏览所有发现",
+    "seoSuffix": "Mini 发现 | Classic Mini DIY",
+    "seoFallbackTitle": "发现 | Classic Mini DIY",
+    "seoDescription": "社区在网络上发现的 Classic Mini 刊登。",
+    "seoOgTitle": "Mini 发现",
+    "seoOgDescription": "在网络上发现的 Classic Mini 刊登。"
+  },
+  "ko": {
+    "editorsPick": "에디터 추천",
+    "editorsCommentary": "에디터 코멘트",
+    "aboutThisFind": "이 발견에 대하여",
+    "fromTheSource": "출처에서",
+    "viewOnSource": "{source}에서 보기",
+    "submittedBy": "제출자",
+    "communityMember": "커뮤니티 회원",
+    "userAlt": "사용자",
+    "auctionEnded": "경매 종료",
+    "auctionEndsInDays": "경매가 {days}일 {hours}시간 후 종료됩니다",
+    "auctionEndsInHours": "경매가 {hours}시간 {minutes}분 후 종료됩니다",
+    "categoryVehicle": "차량",
+    "categoryEngine": "엔진",
+    "categoryParts": "부품",
+    "notFoundTitle": "발견을 찾을 수 없습니다",
+    "notFoundBody": "찾고 있는 발견이 존재하지 않거나 삭제되었습니다.",
+    "browseAllFinds": "모든 발견 보기",
+    "seoSuffix": "Mini 발견 | Classic Mini DIY",
+    "seoFallbackTitle": "발견 | Classic Mini DIY",
+    "seoDescription": "커뮤니티가 웹에서 발견한 Classic Mini 매물입니다.",
+    "seoOgTitle": "Mini 발견",
+    "seoOgDescription": "웹에서 발견한 Classic Mini 매물입니다."
+  }
+}
+</i18n>

--- a/app/pages/exchange/finds/index.vue
+++ b/app/pages/exchange/finds/index.vue
@@ -1,0 +1,407 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <section class="bg-base-100 border-b border-base-300 py-12">
+      <div class="container">
+        <h1 class="text-4xl font-bold mb-3">{{ t('hero.title') }}</h1>
+        <p class="text-base-content/70 max-w-2xl text-lg leading-relaxed">
+          {{ t('hero.intro') }}
+          <span v-if="!loading && totalCount > 0" class="whitespace-nowrap">
+            {{ t('hero.count', totalCount, { count: totalCount }) }}
+          </span>
+        </p>
+      </div>
+    </section>
+
+    <!-- Filters -->
+    <section class="bg-base-200 py-6 border-b border-base-300">
+      <div class="container">
+        <div class="flex flex-wrap items-end gap-3">
+          <ExchangeFindsFindFilters v-model="filters" class="contents" />
+          <NuxtLink v-if="isAuthenticated" to="/exchange/finds/submit" class="btn btn-primary btn-sm ml-auto">
+            <i class="fas fa-plus"></i>
+            {{ t('actions.submit') }}
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <!-- Main Content -->
+    <section class="py-8">
+      <div class="container">
+        <!-- Results Header -->
+        <div class="flex items-center justify-between mb-6">
+          <p class="text-base-content/70 text-sm">
+            <span v-if="loading">{{ t('results.loading') }}</span>
+            <span v-else-if="finds.length > 0">{{ t('results.showing', { shown: finds.length, total: totalCount }) }}</span>
+            <span v-else>{{ t('results.none') }}</span>
+          </p>
+        </div>
+
+        <!-- Loading Skeleton -->
+        <div v-if="loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div v-for="i in 6" :key="i" class="card bg-base-100 shadow-sm">
+            <div class="skeleton aspect-video w-full"></div>
+            <div class="card-body p-4 space-y-3">
+              <div class="skeleton h-5 w-3/4"></div>
+              <div class="skeleton h-4 w-1/2"></div>
+              <div class="skeleton h-6 w-1/3"></div>
+              <div class="skeleton h-3 w-full"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Finds Grid -->
+        <div v-else-if="finds.length > 0">
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <ExchangeFindsFindCard v-for="find in finds" :key="find.id" :find="find" />
+          </div>
+
+          <!-- Load More -->
+          <div v-if="hasMore" class="flex justify-center mt-8">
+            <button class="btn btn-outline" :disabled="loadingMore" @click="loadMore">
+              <span v-if="loadingMore" class="loading loading-spinner loading-sm"></span>
+              <i v-else class="fas fa-arrow-down text-xl"></i>
+              {{ t('actions.loadMore') }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Empty State -->
+        <div v-else class="text-center py-16">
+          <i class="fas fa-globe text-6xl mx-auto mb-4 text-base-content/30"></i>
+          <h3 class="text-xl font-semibold mb-2">{{ t('empty.title') }}</h3>
+          <p class="text-base-content/70 mb-6">
+            {{ t('empty.body') }}
+          </p>
+          <NuxtLink v-if="isAuthenticated" to="/exchange/finds/submit" class="btn btn-primary">
+            {{ t('actions.submit') }}
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { FindFilters } from '~/composables/useExternalListings';
+
+  const { t } = useI18n();
+  const config = useRuntimeConfig();
+  const { user, isAuthenticated } = useAuth();
+  const { capture } = usePostHog();
+  const { finds, loading, totalCount, fetchFinds, loadUserInteractions } = useExternalListings();
+
+  const canonicalUrl = `${config.public.siteUrl || 'https://www.classicminidiy.com'}/exchange/finds`;
+
+  // SEO metadata
+  useSeoMeta({
+    title: t('seo.title'),
+    description: t('seo.description'),
+    ogTitle: t('seo.title'),
+    ogDescription: t('seo.ogDescription'),
+    ogType: 'website',
+    ogUrl: canonicalUrl,
+    ogImage: `${config.public.siteUrl || 'https://www.classicminidiy.com'}/og-image.jpg`,
+    twitterCard: 'summary_large_image',
+  });
+
+  useHead({
+    link: [{ rel: 'canonical', href: 'https://www.classicminidiy.com/exchange/finds' }],
+  });
+
+  // Filters state
+  const filters = ref<FindFilters & { _sort?: string }>({});
+  const currentPage = ref(1);
+  const limit = 20;
+  const loadingMore = ref(false);
+
+  // Whether there are more results to load
+  const hasMore = computed(() => finds.value.length < totalCount.value);
+
+  // Fetch finds with current filters
+  const loadFinds = async () => {
+    const queryFilters: FindFilters = {
+      sourceSite: filters.value.sourceSite,
+      category: filters.value.category,
+      tags: filters.value.tags,
+      page: currentPage.value,
+      limit,
+    };
+
+    await fetchFinds(queryFilters);
+  };
+
+  // Load more finds (next page)
+  const loadMore = async () => {
+    currentPage.value++;
+    // For "load more" we need to append, but fetchFinds replaces the array.
+    // We'll manually handle this by fetching and concatenating.
+    loadingMore.value = true;
+    const prevFinds = [...finds.value];
+
+    await fetchFinds({
+      sourceSite: filters.value.sourceSite,
+      category: filters.value.category,
+      tags: filters.value.tags,
+      page: currentPage.value,
+      limit,
+    });
+
+    // Prepend previous finds to the newly fetched ones
+    finds.value = [...prevFinds, ...finds.value];
+    loadingMore.value = false;
+  };
+
+  // Watch for filter changes and reload
+  watch(
+    filters,
+    () => {
+      currentPage.value = 1;
+      loadFinds();
+
+      capture('finds_browsed', {
+        filters: {
+          sourceSite: filters.value.sourceSite || null,
+          category: filters.value.category || null,
+          sort: (filters.value as any)._sort || 'newest',
+        },
+        page: currentPage.value,
+      });
+    },
+    { deep: true }
+  );
+
+  // Initial load
+  onMounted(() => {
+    loadFinds();
+    if (user.value) {
+      loadUserInteractions();
+    }
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "hero": {
+      "title": "Mini Finds",
+      "intro": "Spotted a Classic Mini for sale somewhere on the web? So has our community. Mini Finds collects listings from Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay, and beyond — helping you discover Classic Minis for sale no matter where they turn up.",
+      "count": "{count} find and counting. | {count} finds and counting."
+    },
+    "actions": { "submit": "Submit a Find", "loadMore": "Load More" },
+    "results": {
+      "loading": "Loading finds...",
+      "showing": "Showing {shown} of {total} finds",
+      "none": "No finds yet"
+    },
+    "empty": {
+      "title": "No Finds Yet",
+      "body": "Be the first to share an interesting Classic Mini listing from across the web."
+    },
+    "seo": {
+      "title": "Mini Finds | Classic Mini DIY",
+      "description": "Community-curated Classic Mini listings from Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay, and beyond. Discover Classic Minis for sale no matter where they turn up.",
+      "ogDescription": "Community-curated Classic Mini listings from across the web. Discover Minis for sale on Bring a Trailer, Cars & Bids, eBay, and beyond."
+    }
+  },
+  "es": {
+    "hero": {
+      "title": "Hallazgos Mini",
+      "intro": "¿Has visto un Classic Mini en venta en algún sitio de la web? Nuestra comunidad también. Hallazgos Mini reúne anuncios de Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay y más — para ayudarte a descubrir Classic Minis en venta dondequiera que aparezcan.",
+      "count": "{count} hallazgo y contando. | {count} hallazgos y contando."
+    },
+    "actions": { "submit": "Enviar un hallazgo", "loadMore": "Cargar más" },
+    "results": {
+      "loading": "Cargando hallazgos...",
+      "showing": "Mostrando {shown} de {total} hallazgos",
+      "none": "Aún no hay hallazgos"
+    },
+    "empty": {
+      "title": "Aún no hay hallazgos",
+      "body": "Sé el primero en compartir un anuncio interesante de un Classic Mini de cualquier parte de la web."
+    },
+    "seo": {
+      "title": "Hallazgos Mini | Classic Mini DIY",
+      "description": "Anuncios de Classic Mini seleccionados por la comunidad de Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay y más. Descubre Classic Minis en venta dondequiera que aparezcan.",
+      "ogDescription": "Anuncios de Classic Mini seleccionados por la comunidad de toda la web. Descubre Minis en venta en Bring a Trailer, Cars & Bids, eBay y más."
+    }
+  },
+  "fr": {
+    "hero": {
+      "title": "Trouvailles Mini",
+      "intro": "Vous avez repéré une Classic Mini à vendre quelque part sur le web ? Notre communauté aussi. Trouvailles Mini rassemble les annonces de Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay et au-delà — pour vous aider à découvrir des Classic Mini à vendre où qu'elles apparaissent.",
+      "count": "{count} trouvaille et plus encore. | {count} trouvailles et plus encore."
+    },
+    "actions": { "submit": "Soumettre une trouvaille", "loadMore": "Charger plus" },
+    "results": {
+      "loading": "Chargement des trouvailles...",
+      "showing": "Affichage de {shown} sur {total} trouvailles",
+      "none": "Aucune trouvaille pour le moment"
+    },
+    "empty": {
+      "title": "Aucune trouvaille pour le moment",
+      "body": "Soyez le premier à partager une annonce intéressante de Classic Mini repérée sur le web."
+    },
+    "seo": {
+      "title": "Trouvailles Mini | Classic Mini DIY",
+      "description": "Annonces de Classic Mini sélectionnées par la communauté depuis Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay et au-delà. Découvrez des Classic Mini à vendre où qu'elles apparaissent.",
+      "ogDescription": "Annonces de Classic Mini sélectionnées par la communauté à travers le web. Découvrez des Mini à vendre sur Bring a Trailer, Cars & Bids, eBay et au-delà."
+    }
+  },
+  "de": {
+    "hero": {
+      "title": "Mini-Funde",
+      "intro": "Irgendwo im Netz einen Classic Mini zum Verkauf entdeckt? Unsere Community auch. Mini-Funde sammelt Inserate von Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay und mehr — damit du Classic Minis zum Verkauf findest, egal wo sie auftauchen.",
+      "count": "{count} Fund und es werden mehr. | {count} Funde und es werden mehr."
+    },
+    "actions": { "submit": "Einen Fund einreichen", "loadMore": "Mehr laden" },
+    "results": {
+      "loading": "Funde werden geladen...",
+      "showing": "{shown} von {total} Funden werden angezeigt",
+      "none": "Noch keine Funde"
+    },
+    "empty": {
+      "title": "Noch keine Funde",
+      "body": "Sei der Erste, der ein interessantes Classic-Mini-Inserat aus dem Netz teilt."
+    },
+    "seo": {
+      "title": "Mini-Funde | Classic Mini DIY",
+      "description": "Von der Community kuratierte Classic-Mini-Inserate von Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay und mehr. Entdecke Classic Minis zum Verkauf, egal wo sie auftauchen.",
+      "ogDescription": "Von der Community kuratierte Classic-Mini-Inserate aus dem ganzen Netz. Entdecke Minis zum Verkauf bei Bring a Trailer, Cars & Bids, eBay und mehr."
+    }
+  },
+  "it": {
+    "hero": {
+      "title": "Trovate Mini",
+      "intro": "Hai visto una Classic Mini in vendita da qualche parte sul web? Anche la nostra community. Trovate Mini raccoglie annunci da Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay e oltre — per aiutarti a scoprire Classic Mini in vendita ovunque appaiano.",
+      "count": "{count} trovata e si continua. | {count} trovate e si continua."
+    },
+    "actions": { "submit": "Invia una trovata", "loadMore": "Carica altro" },
+    "results": {
+      "loading": "Caricamento trovate...",
+      "showing": "Visualizzazione di {shown} su {total} trovate",
+      "none": "Ancora nessuna trovata"
+    },
+    "empty": {
+      "title": "Ancora nessuna trovata",
+      "body": "Sii il primo a condividere un interessante annuncio di Classic Mini trovato sul web."
+    },
+    "seo": {
+      "title": "Trovate Mini | Classic Mini DIY",
+      "description": "Annunci di Classic Mini selezionati dalla community da Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay e oltre. Scopri Classic Mini in vendita ovunque appaiano.",
+      "ogDescription": "Annunci di Classic Mini selezionati dalla community da tutto il web. Scopri Mini in vendita su Bring a Trailer, Cars & Bids, eBay e oltre."
+    }
+  },
+  "pt": {
+    "hero": {
+      "title": "Achados Mini",
+      "intro": "Viu um Classic Mini à venda em algum lugar na web? A nossa comunidade também. Achados Mini reúne anúncios de Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay e mais — para ajudar você a descobrir Classic Minis à venda onde quer que apareçam.",
+      "count": "{count} achado e contando. | {count} achados e contando."
+    },
+    "actions": { "submit": "Enviar um achado", "loadMore": "Carregar mais" },
+    "results": {
+      "loading": "Carregando achados...",
+      "showing": "Mostrando {shown} de {total} achados",
+      "none": "Ainda sem achados"
+    },
+    "empty": {
+      "title": "Ainda sem achados",
+      "body": "Seja o primeiro a compartilhar um anúncio interessante de Classic Mini de qualquer parte da web."
+    },
+    "seo": {
+      "title": "Achados Mini | Classic Mini DIY",
+      "description": "Anúncios de Classic Mini selecionados pela comunidade de Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay e mais. Descubra Classic Minis à venda onde quer que apareçam.",
+      "ogDescription": "Anúncios de Classic Mini selecionados pela comunidade de toda a web. Descubra Minis à venda no Bring a Trailer, Cars & Bids, eBay e mais."
+    }
+  },
+  "ru": {
+    "hero": {
+      "title": "Находки Mini",
+      "intro": "Заметили Classic Mini на продажу где-то в сети? Наше сообщество тоже. «Находки Mini» собирают объявления с Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay и не только — помогая вам находить Classic Mini на продажу, где бы они ни появились.",
+      "count": "{count} находка и это не предел. | {count} находки и это не предел. | {count} находок и это не предел."
+    },
+    "actions": { "submit": "Добавить находку", "loadMore": "Загрузить ещё" },
+    "results": {
+      "loading": "Загрузка находок...",
+      "showing": "Показано {shown} из {total} находок",
+      "none": "Пока нет находок"
+    },
+    "empty": {
+      "title": "Пока нет находок",
+      "body": "Станьте первым, кто поделится интересным объявлением о Classic Mini со всего интернета."
+    },
+    "seo": {
+      "title": "Находки Mini | Classic Mini DIY",
+      "description": "Подобранные сообществом объявления о Classic Mini с Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay и не только. Находите Classic Mini на продажу, где бы они ни появились.",
+      "ogDescription": "Подобранные сообществом объявления о Classic Mini со всего интернета. Находите Mini на продажу на Bring a Trailer, Cars & Bids, eBay и не только."
+    }
+  },
+  "ja": {
+    "hero": {
+      "title": "Mini ファインド",
+      "intro": "ウェブのどこかで売りに出ているクラシック Mini を見つけましたか？私たちのコミュニティも同じです。Mini ファインドは Bring a Trailer、Cars & Bids、Craigslist、Facebook、eBay などの出品を集め、どこに現れても売りに出ているクラシック Mini を見つけるお手伝いをします。",
+      "count": "{count} 件のファインド、まだまだ増えています。"
+    },
+    "actions": { "submit": "ファインドを投稿", "loadMore": "もっと読み込む" },
+    "results": {
+      "loading": "ファインドを読み込み中...",
+      "showing": "{total} 件中 {shown} 件を表示",
+      "none": "まだファインドはありません"
+    },
+    "empty": {
+      "title": "まだファインドはありません",
+      "body": "ウェブで見つけた興味深いクラシック Mini の出品を最初に共有しましょう。"
+    },
+    "seo": {
+      "title": "Mini ファインド | Classic Mini DIY",
+      "description": "Bring a Trailer、Cars & Bids、Craigslist、Facebook、eBay などからコミュニティが厳選したクラシック Mini の出品。どこに現れても売りに出ているクラシック Mini を見つけましょう。",
+      "ogDescription": "ウェブ全体からコミュニティが厳選したクラシック Mini の出品。Bring a Trailer、Cars & Bids、eBay などで売りに出ている Mini を見つけましょう。"
+    }
+  },
+  "zh": {
+    "hero": {
+      "title": "Mini 发现",
+      "intro": "在网上某处看到出售的经典 Mini 了吗？我们的社区也一样。Mini 发现汇集来自 Bring a Trailer、Cars & Bids、Craigslist、Facebook、eBay 等平台的刊登信息——帮助你无论在哪里都能发现待售的经典 Mini。",
+      "count": "{count} 条发现，还在不断增加。"
+    },
+    "actions": { "submit": "提交发现", "loadMore": "加载更多" },
+    "results": {
+      "loading": "正在加载发现...",
+      "showing": "显示 {total} 条中的 {shown} 条发现",
+      "none": "暂无发现"
+    },
+    "empty": {
+      "title": "暂无发现",
+      "body": "成为第一个分享来自网络各处有趣经典 Mini 刊登的人。"
+    },
+    "seo": {
+      "title": "Mini 发现 | Classic Mini DIY",
+      "description": "由社区精选的经典 Mini 刊登信息，来自 Bring a Trailer、Cars & Bids、Craigslist、Facebook、eBay 等平台。无论在哪里都能发现待售的经典 Mini。",
+      "ogDescription": "由社区精选、来自网络各处的经典 Mini 刊登信息。在 Bring a Trailer、Cars & Bids、eBay 等平台发现待售的 Mini。"
+    }
+  },
+  "ko": {
+    "hero": {
+      "title": "Mini 파인드",
+      "intro": "웹 어딘가에서 판매 중인 클래식 Mini를 발견하셨나요? 우리 커뮤니티도 마찬가지입니다. Mini 파인드는 Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay 등의 매물을 모아 어디에 등장하든 판매 중인 클래식 Mini를 발견하도록 도와드립니다.",
+      "count": "{count}개의 파인드, 계속 늘어나고 있습니다."
+    },
+    "actions": { "submit": "파인드 제출", "loadMore": "더 보기" },
+    "results": {
+      "loading": "파인드를 불러오는 중...",
+      "showing": "{total}개 중 {shown}개 파인드 표시 중",
+      "none": "아직 파인드가 없습니다"
+    },
+    "empty": {
+      "title": "아직 파인드가 없습니다",
+      "body": "웹 곳곳에서 발견한 흥미로운 클래식 Mini 매물을 가장 먼저 공유해 보세요."
+    },
+    "seo": {
+      "title": "Mini 파인드 | Classic Mini DIY",
+      "description": "Bring a Trailer, Cars & Bids, Craigslist, Facebook, eBay 등에서 커뮤니티가 엄선한 클래식 Mini 매물. 어디에 등장하든 판매 중인 클래식 Mini를 발견하세요.",
+      "ogDescription": "웹 곳곳에서 커뮤니티가 엄선한 클래식 Mini 매물. Bring a Trailer, Cars & Bids, eBay 등에서 판매 중인 Mini를 발견하세요."
+    }
+  }
+}
+</i18n>

--- a/app/pages/exchange/listings/index.vue
+++ b/app/pages/exchange/listings/index.vue
@@ -199,8 +199,6 @@
   const { t } = useI18n();
 
   const config = useRuntimeConfig();
-  const supabase = useSupabase();
-  const { user } = useAuth();
   const { capture } = usePostHog();
 
   const {
@@ -288,8 +286,8 @@
   const listingsWithCoordinates = computed(() => {
     return listings.value.filter(
       (listing) =>
-        listing.latitude &&
-        listing.longitude &&
+        listing.latitude != null &&
+        listing.longitude != null &&
         !isNaN(listing.latitude) &&
         !isNaN(listing.longitude) &&
         listing.latitude >= -90 &&
@@ -300,15 +298,15 @@
   });
 
   // Check if we're on desktop (for SSR compatibility)
+  const checkDesktop = () => {
+    isDesktop.value = window.innerWidth >= 1024; // lg breakpoint
+  };
   onMounted(() => {
-    const checkDesktop = () => {
-      isDesktop.value = window.innerWidth >= 1024; // lg breakpoint
-    };
     checkDesktop();
     window.addEventListener('resize', checkDesktop);
-    onBeforeUnmount(() => {
-      window.removeEventListener('resize', checkDesktop);
-    });
+  });
+  onBeforeUnmount(() => {
+    window.removeEventListener('resize', checkDesktop);
   });
 
   // Compute pagination range for display

--- a/app/pages/exchange/listings/index.vue
+++ b/app/pages/exchange/listings/index.vue
@@ -1,96 +1,602 @@
-<script setup lang="ts">
-  // Stage 3 browse page — exercises the ported useSearch data path + the
-  // ExchangeListingsListingCard graph against the shared DB. The rich
-  // FilterSidebar / SortDropdown / SearchBar / Map components land in the next
-  // Stage 3 increment; this ships a working search box + grid + pagination.
-  const { t } = useI18n();
-
-  const { searchQuery, listings, loading, totalCount, currentPage, totalPages, hasNextPage, hasPrevPage, performSearch, nextPage, prevPage } =
-    useSearch();
-
-  onMounted(() => {
-    performSearch();
-  });
-
-  useHead({
-    title: t('seo.title'),
-    meta: [{ key: 'description', name: 'description', content: t('seo.description') }],
-    link: [{ rel: 'canonical', href: 'https://www.classicminidiy.com/exchange/listings' }],
-  });
-</script>
-
 <template>
-  <div class="container mx-auto px-4 py-8">
-    <div class="mb-6">
-      <h1 class="text-3xl font-bold">{{ t('heading') }}</h1>
-      <p class="text-base-content/70 mt-1">{{ t('subheading') }}</p>
-    </div>
-
-    <!-- Search -->
-    <div class="mb-6">
-      <label class="input input-bordered flex items-center gap-2 max-w-xl">
-        <i class="fas fa-magnifying-glass text-base-content/50"></i>
-        <input v-model="searchQuery" type="search" class="grow" :placeholder="t('searchPlaceholder')" />
-      </label>
-    </div>
-
-    <!-- Results are fetched client-side via performSearch() in onMounted, so the
-         data-dependent area is ClientOnly to avoid an SSR/client hydration
-         mismatch. The full browse page (next increment) moves the initial query
-         to SSR via useAsyncData alongside the FilterSidebar/SortDropdown/Map. -->
-    <ClientOnly>
-      <template #fallback>
-        <div class="flex justify-center py-16">
-          <span class="loading loading-spinner loading-lg text-primary"></span>
+  <div>
+    <!-- Page Header -->
+    <section class="bg-base-100 border-b border-base-300 py-12">
+      <div class="container">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 class="text-4xl font-bold mb-2">{{ t('heading') }}</h1>
+            <p class="text-base-content/70">
+              <ClientOnly>{{ t('resultCount', { count: totalCount }) }}</ClientOnly>
+            </p>
+          </div>
+          <NuxtLink to="/exchange/listings/new" class="btn btn-primary">
+            <i class="fas fa-plus"></i>
+            {{ t('postListing') }}
+          </NuxtLink>
         </div>
-      </template>
-
-      <!-- Loading -->
-      <div v-if="loading" class="flex justify-center py-16">
-        <span class="loading loading-spinner loading-lg text-primary"></span>
       </div>
+    </section>
 
-      <!-- Empty -->
-      <div v-else-if="listings.length === 0" class="text-center py-16 text-base-content/60">
-        <i class="fas fa-magnifying-glass text-4xl mb-3 opacity-40"></i>
-        <p>{{ t('noResults') }}</p>
+    <!-- Search Bar -->
+    <section class="bg-base-200 py-6 border-b border-base-300">
+      <div class="container">
+        <ExchangeListingsSearchBar v-model="searchQuery" />
       </div>
+    </section>
 
-      <!-- Results -->
-      <template v-else>
-        <p class="text-sm text-base-content/60 mb-4">{{ t('resultCount', { count: totalCount }) }}</p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          <ExchangeListingsListingCard v-for="listing in listings" :key="listing.id" :listing="listing" />
-        </div>
+    <!-- Main Content -->
+    <section class="py-8">
+      <div class="container">
+        <div class="flex flex-col lg:flex-row gap-8">
+          <!-- Sidebar Filters -->
+          <aside class="lg:w-80 shrink-0">
+            <!-- Mobile Filter Toggle -->
+            <div class="lg:hidden mb-4">
+              <button @click="filtersOpen = !filtersOpen" class="btn btn-outline w-full">
+                <i class="fas fa-filter"></i>
+                {{ filtersOpen ? t('hideFilters') : t('showFilters') }}
+                <i :class="filtersOpen ? 'fas fa-chevron-up' : 'fas fa-chevron-down'" class="ml-auto"></i>
+              </button>
+            </div>
 
-        <!-- Pagination -->
-        <div v-if="totalPages > 1" class="flex items-center justify-center gap-4 mt-8">
-          <button class="btn btn-sm btn-outline" :disabled="!hasPrevPage" @click="prevPage">
-            <i class="fas fa-chevron-left"></i>
-            {{ t('prev') }}
-          </button>
-          <span class="text-sm text-base-content/70">{{ t('pageOf', { current: currentPage, total: totalPages }) }}</span>
-          <button class="btn btn-sm btn-outline" :disabled="!hasNextPage" @click="nextPage">
-            {{ t('next') }}
-            <i class="fas fa-chevron-right"></i>
-          </button>
+            <!-- Filters Container -->
+            <div class="lg:sticky lg:top-4" :class="{ hidden: !filtersOpen && !isDesktop }">
+              <ExchangeListingsFilterSidebar
+                v-model:category="selectedCategory"
+                v-model:parts-subcategory="selectedPartsSubcategory"
+                v-model:year-range="selectedYearRange"
+                v-model:manufacturer="selectedManufacturer"
+                v-model:model="selectedModel"
+                v-model:condition="selectedCondition"
+                v-model:price-range="selectedPriceRange"
+                v-model:transmission="selectedTransmission"
+                v-model:location="selectedLocation"
+                v-model:distance="selectedDistance"
+                v-model:shipping-available="selectedShippingAvailable"
+                v-model:ships-international="selectedShipsInternational"
+                v-model:free-shipping="selectedFreeShipping"
+                :results-count="totalCount"
+                @clear-filters="clearFilters"
+              />
+            </div>
+          </aside>
+
+          <!-- Listings Grid -->
+          <div class="flex-1 min-w-0">
+            <!-- Results Header -->
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+              <div>
+                <p class="text-base-content/70">
+                  <ClientOnly>
+                    <span v-if="loading">{{ t('searching') }}</span>
+                    <span v-else-if="totalCount > 0">
+                      {{ t('showingCount', { shown: listings.length, total: totalCount }) }}
+                    </span>
+                    <span v-else>{{ t('noResults') }}</span>
+                  </ClientOnly>
+                </p>
+              </div>
+
+              <div class="flex items-center gap-2">
+                <!-- View Toggle -->
+                <div class="join">
+                  <button
+                    @click="viewMode = 'grid'"
+                    class="btn btn-sm join-item"
+                    :class="{ 'btn-active': viewMode === 'grid' }"
+                  >
+                    <i class="fas fa-table-cells-large"></i>
+                    {{ t('gridView') }}
+                  </button>
+                  <button
+                    @click="viewMode = 'map'"
+                    class="btn btn-sm join-item"
+                    :class="{ 'btn-active': viewMode === 'map' }"
+                  >
+                    <i class="fas fa-map"></i>
+                    {{ t('mapView') }}
+                  </button>
+                </div>
+
+                <ExchangeListingsSortDropdown v-model="sortBy" :results-count="totalCount" />
+              </div>
+            </div>
+
+            <!-- Results region (fetched client-side via performSearch() in onMounted/watch,
+                 so wrap in ClientOnly to avoid an SSR/client hydration mismatch). -->
+            <ClientOnly>
+              <template #fallback>
+                <div class="flex justify-center py-16">
+                  <span class="loading loading-spinner loading-lg text-primary"></span>
+                </div>
+              </template>
+
+              <!-- Loading State -->
+              <div v-if="loading" class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6">
+                <div v-for="i in 6" :key="i" class="skeleton h-80 w-full"></div>
+              </div>
+
+              <!-- Grid View -->
+              <div v-if="viewMode === 'grid' && !loading && listings.length > 0">
+                <div class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6">
+                  <ExchangeListingsListingCard
+                    v-for="(listing, index) in listings"
+                    :key="listing.id"
+                    :listing="listing"
+                    :user-currency="userCurrency"
+                    @click="trackListingClick(listing.id, index + 1)"
+                  />
+                </div>
+
+                <!-- Pagination (Grid View Only) -->
+                <div v-if="viewMode === 'grid' && totalPages > 1" class="flex justify-center items-center gap-2 mt-8">
+                  <button
+                    @click="prevPage"
+                    :disabled="!hasPrevPage"
+                    class="btn btn-outline btn-sm"
+                    :class="{ 'btn-disabled': !hasPrevPage }"
+                  >
+                    <i class="fas fa-chevron-left"></i>
+                    {{ t('prev') }}
+                  </button>
+
+                  <div class="flex gap-1">
+                    <template v-for="page in paginationRange" :key="page">
+                      <button
+                        v-if="typeof page === 'number'"
+                        @click="goToPage(page)"
+                        class="btn btn-sm"
+                        :class="page === currentPage ? 'btn-primary' : 'btn-outline'"
+                      >
+                        {{ page }}
+                      </button>
+                      <span v-else class="flex items-center px-2">...</span>
+                    </template>
+                  </div>
+
+                  <button
+                    @click="nextPage"
+                    :disabled="!hasNextPage"
+                    class="btn btn-outline btn-sm"
+                    :class="{ 'btn-disabled': !hasNextPage }"
+                  >
+                    {{ t('next') }}
+                    <i class="fas fa-chevron-right"></i>
+                  </button>
+                </div>
+              </div>
+
+              <!-- Map View -->
+              <div v-if="viewMode === 'map' && !loading && listings.length > 0">
+                <div class="h-[600px] rounded-lg overflow-hidden border border-base-300">
+                  <ExchangeListingsMap
+                    :listings="listingsWithCoordinates"
+                    @markerClick="navigateTo(`/exchange/listings/${$event.slug}`)"
+                  />
+                </div>
+                <div class="mt-4 text-sm text-base-content/70 text-center">
+                  {{ t('mapShowing', { shown: listingsWithCoordinates.length, total: totalCount }) }}
+                </div>
+              </div>
+
+              <!-- Empty State -->
+              <div v-else-if="!loading && listings.length === 0" class="text-center py-16">
+                <i class="fas fa-inbox text-6xl mb-4 text-base-content/30"></i>
+                <h3 class="text-xl font-semibold mb-2">{{ t('emptyTitle') }}</h3>
+                <p class="text-base-content/70 mb-6">{{ t('emptyBody') }}</p>
+                <button class="btn btn-outline" @click="clearFilters">{{ t('clearFilters') }}</button>
+              </div>
+            </ClientOnly>
+          </div>
         </div>
-      </template>
-    </ClientOnly>
+      </div>
+    </section>
   </div>
 </template>
 
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  const config = useRuntimeConfig();
+  const supabase = useSupabase();
+  const { user } = useAuth();
+  const { capture } = usePostHog();
+
+  const {
+    searchQuery,
+    selectedCategory,
+    selectedPartsSubcategory,
+    selectedYearRange,
+    selectedManufacturer,
+    selectedModel,
+    selectedCondition,
+    selectedPriceRange,
+    selectedTransmission,
+    selectedLocation,
+    selectedDistance,
+    selectedShippingAvailable,
+    selectedShipsInternational,
+    selectedFreeShipping,
+    sortBy,
+    listings,
+    loading,
+    totalCount,
+    currentPage,
+    totalPages,
+    hasNextPage,
+    hasPrevPage,
+    performSearch,
+    clearFilters,
+    nextPage,
+    prevPage,
+    goToPage,
+    cleanup,
+  } = useSearch();
+
+  onBeforeUnmount(() => {
+    cleanup();
+  });
+
+  // Remember the exact listings URL (with filters + ?page=N) so that a
+  // listing detail page can render a "Back to Listings" button that
+  // returns the user to this exact state. Fixes #83.
+  const route = useRoute();
+  const { rememberListingsReturnUrl } = useListingsReturnUrl();
+  watch(
+    () => route.fullPath,
+    (fullPath) => {
+      if (route.path === '/exchange/listings') {
+        rememberListingsReturnUrl(fullPath);
+      }
+    },
+    { immediate: true }
+  );
+
+  // SEO metadata
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.title'),
+    ogDescription: () => t('seo.ogDescription'),
+    ogType: 'website',
+    ogUrl: 'https://www.classicminidiy.com/exchange/listings',
+    ogImage: `${config.public.siteUrl}/og-image.jpg`,
+    twitterCard: 'summary_large_image',
+  });
+
+  // Schema.org CollectionPage markup
+  useSchemaOrg([
+    {
+      '@type': 'CollectionPage',
+      name: 'Classic Mini Listings',
+      description: 'Classic Mini vehicles, engines, and parts for sale from enthusiasts worldwide.',
+      url: 'https://www.classicminidiy.com/exchange/listings',
+    },
+  ]);
+
+  const { userCurrency } = useCurrency();
+
+  // Mobile filters toggle
+  const filtersOpen = ref(false);
+  const isDesktop = ref(false);
+
+  // View mode toggle (grid vs map)
+  const viewMode = ref<'grid' | 'map'>('grid');
+
+  // Filter listings with valid coordinates for map display
+  const listingsWithCoordinates = computed(() => {
+    return listings.value.filter(
+      (listing) =>
+        listing.latitude &&
+        listing.longitude &&
+        !isNaN(listing.latitude) &&
+        !isNaN(listing.longitude) &&
+        listing.latitude >= -90 &&
+        listing.latitude <= 90 &&
+        listing.longitude >= -180 &&
+        listing.longitude <= 180
+    );
+  });
+
+  // Check if we're on desktop (for SSR compatibility)
+  onMounted(() => {
+    const checkDesktop = () => {
+      isDesktop.value = window.innerWidth >= 1024; // lg breakpoint
+    };
+    checkDesktop();
+    window.addEventListener('resize', checkDesktop);
+    onBeforeUnmount(() => {
+      window.removeEventListener('resize', checkDesktop);
+    });
+  });
+
+  // Compute pagination range for display
+  const paginationRange = computed(() => {
+    const pages: (number | string)[] = [];
+    const maxVisible = 5;
+
+    if (totalPages.value <= maxVisible) {
+      // Show all pages if total is small
+      for (let i = 1; i <= totalPages.value; i++) {
+        pages.push(i);
+      }
+    } else {
+      // Always show first page
+      pages.push(1);
+
+      // Calculate range around current page
+      const start = Math.max(2, currentPage.value - 1);
+      const end = Math.min(totalPages.value - 1, currentPage.value + 1);
+
+      // Add ellipsis if needed
+      if (start > 2) {
+        pages.push('...');
+      }
+
+      // Add middle pages
+      for (let i = start; i <= end; i++) {
+        pages.push(i);
+      }
+
+      // Add ellipsis if needed
+      if (end < totalPages.value - 1) {
+        pages.push('...');
+      }
+
+      // Always show last page
+      pages.push(totalPages.value);
+    }
+
+    return pages;
+  });
+
+  // Track listing click from search results
+  const trackListingClick = (listingId: string, position: number) => {
+    capture('listing_clicked_from_search', {
+      listing_id: listingId,
+      position,
+      query: searchQuery.value || undefined,
+    });
+  };
+
+  // Perform initial search on mount
+  onMounted(() => {
+    performSearch();
+  });
+</script>
+
 <i18n lang="json">
 {
-  "en": { "seo": { "title": "Browse Listings — The Mini Exchange | Classic Mini DIY", "description": "Browse Classic Mini Coopers, engines, and parts for sale in the Classic Mini DIY marketplace." }, "heading": "Browse Listings", "subheading": "Classic Mini Coopers, engines, and parts for sale.", "searchPlaceholder": "Search listings…", "noResults": "No listings match your search.", "resultCount": "{count} listings", "prev": "Previous", "next": "Next", "pageOf": "Page {current} of {total}" },
-  "es": { "seo": { "title": "Explorar anuncios — The Mini Exchange | Classic Mini DIY", "description": "Explora Classic Mini Cooper, motores y piezas en venta en el mercado de Classic Mini DIY." }, "heading": "Explorar anuncios", "subheading": "Classic Mini Cooper, motores y piezas en venta.", "searchPlaceholder": "Buscar anuncios…", "noResults": "Ningún anuncio coincide con tu búsqueda.", "resultCount": "{count} anuncios", "prev": "Anterior", "next": "Siguiente", "pageOf": "Página {current} de {total}" },
-  "fr": { "seo": { "title": "Parcourir les annonces — The Mini Exchange | Classic Mini DIY", "description": "Parcourez les Classic Mini Cooper, moteurs et pièces à vendre sur la place de marché Classic Mini DIY." }, "heading": "Parcourir les annonces", "subheading": "Classic Mini Cooper, moteurs et pièces à vendre.", "searchPlaceholder": "Rechercher des annonces…", "noResults": "Aucune annonce ne correspond à votre recherche.", "resultCount": "{count} annonces", "prev": "Précédent", "next": "Suivant", "pageOf": "Page {current} sur {total}" },
-  "de": { "seo": { "title": "Anzeigen durchsuchen — The Mini Exchange | Classic Mini DIY", "description": "Durchsuche Classic Mini Cooper, Motoren und Teile zum Verkauf auf dem Classic-Mini-DIY-Marktplatz." }, "heading": "Anzeigen durchsuchen", "subheading": "Classic Mini Cooper, Motoren und Teile zu verkaufen.", "searchPlaceholder": "Anzeigen suchen…", "noResults": "Keine Anzeigen entsprechen deiner Suche.", "resultCount": "{count} Anzeigen", "prev": "Zurück", "next": "Weiter", "pageOf": "Seite {current} von {total}" },
-  "it": { "seo": { "title": "Sfoglia gli annunci — The Mini Exchange | Classic Mini DIY", "description": "Sfoglia Classic Mini Cooper, motori e ricambi in vendita nel mercato di Classic Mini DIY." }, "heading": "Sfoglia gli annunci", "subheading": "Classic Mini Cooper, motori e ricambi in vendita.", "searchPlaceholder": "Cerca annunci…", "noResults": "Nessun annuncio corrisponde alla tua ricerca.", "resultCount": "{count} annunci", "prev": "Precedente", "next": "Successivo", "pageOf": "Pagina {current} di {total}" },
-  "pt": { "seo": { "title": "Explorar anúncios — The Mini Exchange | Classic Mini DIY", "description": "Explore Classic Mini Cooper, motores e peças à venda no mercado da Classic Mini DIY." }, "heading": "Explorar anúncios", "subheading": "Classic Mini Cooper, motores e peças à venda.", "searchPlaceholder": "Pesquisar anúncios…", "noResults": "Nenhum anúncio corresponde à sua pesquisa.", "resultCount": "{count} anúncios", "prev": "Anterior", "next": "Próximo", "pageOf": "Página {current} de {total}" },
-  "ru": { "seo": { "title": "Просмотр объявлений — The Mini Exchange | Classic Mini DIY", "description": "Просматривайте Classic Mini Cooper, двигатели и запчасти на площадке Classic Mini DIY." }, "heading": "Просмотр объявлений", "subheading": "Classic Mini Cooper, двигатели и запчасти на продажу.", "searchPlaceholder": "Поиск объявлений…", "noResults": "Нет объявлений по вашему запросу.", "resultCount": "{count} объявлений", "prev": "Назад", "next": "Вперёд", "pageOf": "Страница {current} из {total}" },
-  "ja": { "seo": { "title": "出品を見る — The Mini Exchange | Classic Mini DIY", "description": "Classic Mini DIY マーケットプレイスでクラシックミニ クーパー、エンジン、部品を探せます。" }, "heading": "出品を見る", "subheading": "クラシックミニ クーパー、エンジン、部品の販売。", "searchPlaceholder": "出品を検索…", "noResults": "条件に一致する出品はありません。", "resultCount": "{count} 件の出品", "prev": "前へ", "next": "次へ", "pageOf": "{total} ページ中 {current} ページ" },
-  "zh": { "seo": { "title": "浏览刊登 — The Mini Exchange | Classic Mini DIY", "description": "在 Classic Mini DIY 交易市场浏览经典 Mini Cooper、发动机和零件。" }, "heading": "浏览刊登", "subheading": "出售经典 Mini Cooper、发动机和零件。", "searchPlaceholder": "搜索刊登…", "noResults": "没有符合搜索条件的刊登。", "resultCount": "{count} 条刊登", "prev": "上一页", "next": "下一页", "pageOf": "第 {current} 页，共 {total} 页" },
-  "ko": { "seo": { "title": "매물 둘러보기 — The Mini Exchange | Classic Mini DIY", "description": "Classic Mini DIY 마켓플레이스에서 클래식 미니 쿠퍼, 엔진, 부품을 둘러보세요." }, "heading": "매물 둘러보기", "subheading": "판매 중인 클래식 미니 쿠퍼, 엔진, 부품.", "searchPlaceholder": "매물 검색…", "noResults": "검색과 일치하는 매물이 없습니다.", "resultCount": "매물 {count}건", "prev": "이전", "next": "다음", "pageOf": "{total}페이지 중 {current}페이지" }
+  "en": {
+    "seo": {
+      "title": "Browse Classic Mini Listings — The Mini Exchange | Classic Mini DIY",
+      "description": "Find Classic Mini vehicles, engines, and parts for sale. Search by model, year, price, condition, and more.",
+      "ogDescription": "Find Classic Mini vehicles, engines, and parts for sale from enthusiasts worldwide."
+    },
+    "heading": "Browse Listings",
+    "resultCount": "{count} listings available",
+    "postListing": "Post a Listing",
+    "hideFilters": "Hide Filters",
+    "showFilters": "Show Filters",
+    "searching": "Searching...",
+    "showingCount": "Showing {shown} of {total} listings",
+    "noResults": "No listings found",
+    "gridView": "Grid",
+    "mapView": "Map",
+    "mapShowing": "Showing {shown} of {total} listings with location data",
+    "emptyTitle": "No Listings Found",
+    "emptyBody": "Try adjusting your search or filters to find what you're looking for.",
+    "clearFilters": "Clear All Filters",
+    "prev": "Previous",
+    "next": "Next"
+  },
+  "es": {
+    "seo": {
+      "title": "Explorar anuncios de Classic Mini — The Mini Exchange | Classic Mini DIY",
+      "description": "Encuentra vehículos Classic Mini, motores y piezas en venta. Busca por modelo, año, precio, estado y más.",
+      "ogDescription": "Encuentra vehículos Classic Mini, motores y piezas en venta de aficionados de todo el mundo."
+    },
+    "heading": "Explorar anuncios",
+    "resultCount": "{count} anuncios disponibles",
+    "postListing": "Publicar un anuncio",
+    "hideFilters": "Ocultar filtros",
+    "showFilters": "Mostrar filtros",
+    "searching": "Buscando...",
+    "showingCount": "Mostrando {shown} de {total} anuncios",
+    "noResults": "No se encontraron anuncios",
+    "gridView": "Cuadrícula",
+    "mapView": "Mapa",
+    "mapShowing": "Mostrando {shown} de {total} anuncios con datos de ubicación",
+    "emptyTitle": "No se encontraron anuncios",
+    "emptyBody": "Prueba a ajustar tu búsqueda o filtros para encontrar lo que buscas.",
+    "clearFilters": "Borrar todos los filtros",
+    "prev": "Anterior",
+    "next": "Siguiente"
+  },
+  "fr": {
+    "seo": {
+      "title": "Parcourir les annonces Classic Mini — The Mini Exchange | Classic Mini DIY",
+      "description": "Trouvez des Classic Mini, moteurs et pièces à vendre. Recherchez par modèle, année, prix, état et plus.",
+      "ogDescription": "Trouvez des Classic Mini, moteurs et pièces à vendre proposés par des passionnés du monde entier."
+    },
+    "heading": "Parcourir les annonces",
+    "resultCount": "{count} annonces disponibles",
+    "postListing": "Publier une annonce",
+    "hideFilters": "Masquer les filtres",
+    "showFilters": "Afficher les filtres",
+    "searching": "Recherche...",
+    "showingCount": "Affichage de {shown} sur {total} annonces",
+    "noResults": "Aucune annonce trouvée",
+    "gridView": "Grille",
+    "mapView": "Carte",
+    "mapShowing": "Affichage de {shown} sur {total} annonces avec données de localisation",
+    "emptyTitle": "Aucune annonce trouvée",
+    "emptyBody": "Essayez d'ajuster votre recherche ou vos filtres pour trouver ce que vous cherchez.",
+    "clearFilters": "Effacer tous les filtres",
+    "prev": "Précédent",
+    "next": "Suivant"
+  },
+  "de": {
+    "seo": {
+      "title": "Classic-Mini-Anzeigen durchsuchen — The Mini Exchange | Classic Mini DIY",
+      "description": "Finde Classic Mini, Motoren und Teile zum Verkauf. Suche nach Modell, Baujahr, Preis, Zustand und mehr.",
+      "ogDescription": "Finde Classic Mini, Motoren und Teile zum Verkauf von Enthusiasten weltweit."
+    },
+    "heading": "Anzeigen durchsuchen",
+    "resultCount": "{count} Anzeigen verfügbar",
+    "postListing": "Anzeige aufgeben",
+    "hideFilters": "Filter ausblenden",
+    "showFilters": "Filter anzeigen",
+    "searching": "Suche läuft...",
+    "showingCount": "{shown} von {total} Anzeigen werden angezeigt",
+    "noResults": "Keine Anzeigen gefunden",
+    "gridView": "Raster",
+    "mapView": "Karte",
+    "mapShowing": "{shown} von {total} Anzeigen mit Standortdaten werden angezeigt",
+    "emptyTitle": "Keine Anzeigen gefunden",
+    "emptyBody": "Passe deine Suche oder Filter an, um zu finden, was du suchst.",
+    "clearFilters": "Alle Filter zurücksetzen",
+    "prev": "Zurück",
+    "next": "Weiter"
+  },
+  "it": {
+    "seo": {
+      "title": "Sfoglia gli annunci Classic Mini — The Mini Exchange | Classic Mini DIY",
+      "description": "Trova Classic Mini, motori e ricambi in vendita. Cerca per modello, anno, prezzo, condizione e altro.",
+      "ogDescription": "Trova Classic Mini, motori e ricambi in vendita da appassionati di tutto il mondo."
+    },
+    "heading": "Sfoglia gli annunci",
+    "resultCount": "{count} annunci disponibili",
+    "postListing": "Pubblica un annuncio",
+    "hideFilters": "Nascondi filtri",
+    "showFilters": "Mostra filtri",
+    "searching": "Ricerca in corso...",
+    "showingCount": "Visualizzazione di {shown} su {total} annunci",
+    "noResults": "Nessun annuncio trovato",
+    "gridView": "Griglia",
+    "mapView": "Mappa",
+    "mapShowing": "Visualizzazione di {shown} su {total} annunci con dati di posizione",
+    "emptyTitle": "Nessun annuncio trovato",
+    "emptyBody": "Prova a modificare la ricerca o i filtri per trovare ciò che cerchi.",
+    "clearFilters": "Cancella tutti i filtri",
+    "prev": "Precedente",
+    "next": "Successivo"
+  },
+  "pt": {
+    "seo": {
+      "title": "Explorar anúncios Classic Mini — The Mini Exchange | Classic Mini DIY",
+      "description": "Encontre Classic Mini, motores e peças à venda. Pesquise por modelo, ano, preço, condição e mais.",
+      "ogDescription": "Encontre Classic Mini, motores e peças à venda de entusiastas de todo o mundo."
+    },
+    "heading": "Explorar anúncios",
+    "resultCount": "{count} anúncios disponíveis",
+    "postListing": "Publicar um anúncio",
+    "hideFilters": "Ocultar filtros",
+    "showFilters": "Mostrar filtros",
+    "searching": "Pesquisando...",
+    "showingCount": "Mostrando {shown} de {total} anúncios",
+    "noResults": "Nenhum anúncio encontrado",
+    "gridView": "Grade",
+    "mapView": "Mapa",
+    "mapShowing": "Mostrando {shown} de {total} anúncios com dados de localização",
+    "emptyTitle": "Nenhum anúncio encontrado",
+    "emptyBody": "Tente ajustar sua pesquisa ou filtros para encontrar o que procura.",
+    "clearFilters": "Limpar todos os filtros",
+    "prev": "Anterior",
+    "next": "Próximo"
+  },
+  "ru": {
+    "seo": {
+      "title": "Просмотр объявлений Classic Mini — The Mini Exchange | Classic Mini DIY",
+      "description": "Найдите Classic Mini, двигатели и запчасти на продажу. Поиск по модели, году, цене, состоянию и другому.",
+      "ogDescription": "Найдите Classic Mini, двигатели и запчасти на продажу от энтузиастов со всего мира."
+    },
+    "heading": "Просмотр объявлений",
+    "resultCount": "Доступно объявлений: {count}",
+    "postListing": "Разместить объявление",
+    "hideFilters": "Скрыть фильтры",
+    "showFilters": "Показать фильтры",
+    "searching": "Поиск...",
+    "showingCount": "Показано {shown} из {total} объявлений",
+    "noResults": "Объявления не найдены",
+    "gridView": "Сетка",
+    "mapView": "Карта",
+    "mapShowing": "Показано {shown} из {total} объявлений с данными о местоположении",
+    "emptyTitle": "Объявления не найдены",
+    "emptyBody": "Попробуйте изменить поиск или фильтры, чтобы найти то, что ищете.",
+    "clearFilters": "Сбросить все фильтры",
+    "prev": "Назад",
+    "next": "Вперёд"
+  },
+  "ja": {
+    "seo": {
+      "title": "クラシックミニの出品を見る — The Mini Exchange | Classic Mini DIY",
+      "description": "販売中のクラシックミニ、エンジン、部品を探せます。モデル、年式、価格、状態などで検索。",
+      "ogDescription": "世界中の愛好家が出品するクラシックミニ、エンジン、部品を探せます。"
+    },
+    "heading": "出品を見る",
+    "resultCount": "{count} 件の出品があります",
+    "postListing": "出品する",
+    "hideFilters": "フィルターを隠す",
+    "showFilters": "フィルターを表示",
+    "searching": "検索中...",
+    "showingCount": "{total} 件中 {shown} 件を表示",
+    "noResults": "出品が見つかりません",
+    "gridView": "グリッド",
+    "mapView": "地図",
+    "mapShowing": "位置情報のある {total} 件中 {shown} 件を表示",
+    "emptyTitle": "出品が見つかりません",
+    "emptyBody": "検索条件やフィルターを調整してお探しのものを見つけてください。",
+    "clearFilters": "すべてのフィルターをクリア",
+    "prev": "前へ",
+    "next": "次へ"
+  },
+  "zh": {
+    "seo": {
+      "title": "浏览经典 Mini 刊登 — The Mini Exchange | Classic Mini DIY",
+      "description": "查找出售的经典 Mini 车辆、发动机和零件。按车型、年份、价格、状况等搜索。",
+      "ogDescription": "查找来自全球爱好者出售的经典 Mini 车辆、发动机和零件。"
+    },
+    "heading": "浏览刊登",
+    "resultCount": "{count} 条刊登可用",
+    "postListing": "发布刊登",
+    "hideFilters": "隐藏筛选",
+    "showFilters": "显示筛选",
+    "searching": "搜索中...",
+    "showingCount": "显示 {total} 条中的 {shown} 条刊登",
+    "noResults": "未找到刊登",
+    "gridView": "网格",
+    "mapView": "地图",
+    "mapShowing": "显示 {total} 条中带位置数据的 {shown} 条刊登",
+    "emptyTitle": "未找到刊登",
+    "emptyBody": "请尝试调整搜索或筛选条件以找到所需内容。",
+    "clearFilters": "清除所有筛选",
+    "prev": "上一页",
+    "next": "下一页"
+  },
+  "ko": {
+    "seo": {
+      "title": "클래식 미니 매물 둘러보기 — The Mini Exchange | Classic Mini DIY",
+      "description": "판매 중인 클래식 미니, 엔진, 부품을 찾아보세요. 모델, 연식, 가격, 상태 등으로 검색하세요.",
+      "ogDescription": "전 세계 애호가가 판매하는 클래식 미니, 엔진, 부품을 찾아보세요."
+    },
+    "heading": "매물 둘러보기",
+    "resultCount": "{count}건의 매물 이용 가능",
+    "postListing": "매물 등록",
+    "hideFilters": "필터 숨기기",
+    "showFilters": "필터 표시",
+    "searching": "검색 중...",
+    "showingCount": "{total}건 중 {shown}건 표시",
+    "noResults": "매물을 찾을 수 없습니다",
+    "gridView": "그리드",
+    "mapView": "지도",
+    "mapShowing": "위치 데이터가 있는 {total}건 중 {shown}건 표시",
+    "emptyTitle": "매물을 찾을 수 없습니다",
+    "emptyBody": "검색어나 필터를 조정하여 찾으시는 항목을 확인하세요.",
+    "clearFilters": "모든 필터 지우기",
+    "prev": "이전",
+    "next": "다음"
+  }
 }
 </i18n>

--- a/app/pages/exchange/sold/index.vue
+++ b/app/pages/exchange/sold/index.vue
@@ -1,0 +1,419 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <section class="bg-base-100 border-b border-base-300 py-12">
+      <div class="container">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 class="text-4xl font-bold mb-2">{{ t('header.title') }}</h1>
+            <p class="text-base-content/70">
+              {{ t('header.subtitle', { count: totalCount }) }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Search Bar -->
+    <section class="bg-base-200 py-6 border-b border-base-300">
+      <div class="container">
+        <ExchangeListingsSearchBar v-model="searchQuery" :placeholder="t('search.placeholder')" />
+      </div>
+    </section>
+
+    <!-- Main Content -->
+    <section class="py-8">
+      <div class="container">
+        <!-- Listings Grid -->
+        <div>
+          <!-- Results Header -->
+          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+            <div>
+              <p class="text-base-content/70">
+                <span v-if="loading">{{ t('results.searching') }}</span>
+                <span v-else-if="totalCount > 0">
+                  {{ t('results.showing', { shown: listings.length, total: totalCount }) }}
+                </span>
+                <span v-else>{{ t('results.none') }}</span>
+              </p>
+            </div>
+
+            <select v-model="sortBy" class="select select-sm w-auto" :aria-label="t('sort.ariaLabel')">
+              <option value="newest">{{ t('sort.newest') }}</option>
+              <option value="oldest">{{ t('sort.oldest') }}</option>
+              <option value="price_desc">{{ t('sort.priceDesc') }}</option>
+              <option value="price_asc">{{ t('sort.priceAsc') }}</option>
+            </select>
+          </div>
+
+          <!-- Loading State -->
+          <div v-if="loading" class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6">
+            <div v-for="i in 6" :key="i" class="skeleton h-80 w-full"></div>
+          </div>
+
+          <!-- Sold Listings Grid -->
+          <div v-else-if="listings.length > 0" class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6">
+            <NuxtLink
+              v-for="listing in listings"
+              :key="listing.id"
+              :to="`/exchange/listings/${listing.slug}`"
+              class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+            >
+              <figure class="h-56 bg-base-300 relative">
+                <img
+                  v-if="getPrimaryPhoto(listing)"
+                  :src="getPrimaryPhoto(listing)"
+                  :alt="listing.title"
+                  class="w-full h-full object-contain"
+                  style="object-fit: contain"
+                  loading="lazy"
+                />
+                <div v-else class="flex items-center justify-center w-full h-full">
+                  <i class="fas fa-image text-5xl text-base-content/30"></i>
+                </div>
+                <div class="absolute top-3 right-3">
+                  <div class="badge badge-neutral">{{ t('badge.sold') }}</div>
+                </div>
+              </figure>
+
+              <div class="card-body">
+                <h3 class="card-title text-base">{{ listing.year }} {{ listing.model }}</h3>
+                <p class="text-sm text-base-content/70 line-clamp-1">{{ listing.title }}</p>
+
+                <div class="mt-2">
+                  <div class="text-lg font-bold text-success">
+                    {{
+                      formatListingPrice(
+                        getSoldPrice(listing),
+                        formatCurrency(getSoldPrice(listing), getListingCurrency(listing))
+                      )
+                    }}
+                  </div>
+                  <div
+                    v-if="getConvertedPrice(listing) && getSoldPrice(listing) !== 0"
+                    class="text-xs text-base-content/60"
+                  >
+                    {{ t('price.about', { amount: formatCurrency(getConvertedPrice(listing)!, userCurrency), currency: userCurrency }) }}
+                  </div>
+                  <div class="text-xs text-base-content/60">{{ t('price.soldOn', { date: formatSoldDate(listing.sold_date) }) }}</div>
+                </div>
+
+                <div v-if="displayLocation(listing)" class="mt-2">
+                  <div class="flex items-center gap-1 text-xs text-base-content/60">
+                    <template v-if="getCountryFlag(listing.country)">{{ getCountryFlag(listing.country) }}</template>
+                    <i v-else class="fas fa-location-dot"></i>
+                    <span>{{ displayLocation(listing) }}</span>
+                  </div>
+                </div>
+              </div>
+            </NuxtLink>
+          </div>
+
+          <!-- Empty State -->
+          <div v-else class="text-center py-16">
+            <i class="fas fa-box-archive text-5xl mx-auto mb-4 text-base-content/30"></i>
+            <h3 class="text-xl font-semibold mb-2">{{ t('empty.title') }}</h3>
+            <p class="text-base-content/70 mb-6">{{ t('empty.body') }}</p>
+            <button v-if="searchQuery" class="btn btn-outline" @click="clearFilters">{{ t('empty.clear') }}</button>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { ListingWithPhotos } from '~/composables/useListings';
+  import type { CurrencyCode } from '~/composables/useCurrency';
+  import { getCountryFlag } from '~/utils/countryFlags';
+
+  const { t } = useI18n();
+
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.title'),
+    ogDescription: () => t('seo.description'),
+    robots: 'noindex, follow',
+  });
+
+  useHead({
+    link: [{ rel: 'canonical', href: 'https://www.classicminidiy.com/exchange/sold' }],
+  });
+
+  const supabase = useSupabase();
+  const { user } = useAuth();
+  const { getPhotoUrl } = useListings();
+  const { formatCurrency, convertCurrency, fetchExchangeRates, exchangeRates } = useCurrency();
+  const { fetchProfile } = useProfile();
+
+  const { userCurrency } = useCurrency();
+
+  // Get listing currency
+  const getListingCurrency = (listing: ListingWithPhotos): CurrencyCode => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return ((listing as any).currency as CurrencyCode) || 'USD';
+  };
+
+  // Get sold/final price for a listing
+  const getSoldPrice = (listing: ListingWithPhotos): number | null => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const finalPrice = (listing as any).final_price;
+    if (finalPrice) return finalPrice;
+    return listing.price;
+  };
+
+  // Get converted price for a listing
+  const getConvertedPrice = (listing: ListingWithPhotos): number | null => {
+    const listingCurrency = getListingCurrency(listing);
+    if (!exchangeRates.value) return null;
+    if (listingCurrency === userCurrency.value) return null;
+
+    const price = getSoldPrice(listing);
+    if (!price) return null;
+    return convertCurrency(price, listingCurrency, userCurrency.value);
+  };
+
+  const { formatDisplayLocation, formatListingPrice } = useFormatters();
+
+  const displayLocation = (listing: ListingWithPhotos): string => {
+    return formatDisplayLocation(listing);
+  };
+
+  const searchQuery = ref('');
+  const sortBy = ref('newest');
+
+  const listings = ref<ListingWithPhotos[]>([]);
+  const loading = ref(false);
+  const totalCount = ref(0);
+
+  const formatSoldDate = (dateString: string | null): string => {
+    if (!dateString) return t('date.unknown');
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return t('date.today');
+    if (diffDays === 1) return t('date.yesterday');
+    if (diffDays < 7) return t('date.daysAgo', { count: diffDays });
+    if (diffDays < 30) return t('date.weeksAgo', { count: Math.floor(diffDays / 7) });
+    if (diffDays < 365) return t('date.monthsAgo', { count: Math.floor(diffDays / 30) });
+
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      year: 'numeric',
+    }).format(date);
+  };
+
+  const getPrimaryPhoto = (listing: ListingWithPhotos): string | null => {
+    if (!listing.listing_photos || listing.listing_photos.length === 0) {
+      return null;
+    }
+
+    const primaryPhoto = listing.listing_photos.find((photo) => photo.is_primary);
+    const photo = primaryPhoto || listing.listing_photos[0];
+
+    return photo ? getPhotoUrl(photo.storage_path) : null;
+  };
+
+  const performSearch = async () => {
+    loading.value = true;
+
+    try {
+      let query = supabase
+        .from('listings')
+        .select(
+          `
+          *,
+          listing_photos (
+            id,
+            storage_path,
+            display_order,
+            category,
+            is_primary
+          ),
+          profiles:public_profiles!listings_user_id_fkey (
+            id,
+            display_name,
+            username,
+            location
+          )
+        `,
+          { count: 'exact' }
+        )
+        // Include sold listings only
+        .eq('status', 'sold');
+
+      // Apply search filter
+      if (searchQuery.value) {
+        query = query.textSearch('search_vector', searchQuery.value);
+      }
+
+      // Apply sorting
+      switch (sortBy.value) {
+        case 'oldest':
+          query = query.order('sold_date', { ascending: true, nullsLast: true });
+          break;
+        case 'price_asc':
+          query = query.order('final_price', { ascending: true, nullsFirst: false });
+          break;
+        case 'price_desc':
+          query = query.order('final_price', { ascending: false, nullsFirst: false });
+          break;
+        case 'newest':
+        default:
+          query = query.order('sold_date', { ascending: false, nullsLast: true });
+          break;
+      }
+
+      query = applyPhotoOrdering(query);
+
+      const { data, error, count } = await query;
+
+      if (error) {
+        console.error('Search error:', error);
+        throw error;
+      }
+
+      listings.value = (data as ListingWithPhotos[]) || [];
+      totalCount.value = count || 0;
+    } catch (error) {
+      console.error('Failed to search sold listings:', error);
+      listings.value = [];
+      totalCount.value = 0;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const clearFilters = () => {
+    searchQuery.value = '';
+    sortBy.value = 'newest';
+  };
+
+  // Watch search and sort
+  watch([searchQuery, sortBy], () => {
+    performSearch();
+  });
+
+  // Initial load
+  onMounted(() => {
+    performSearch();
+    fetchExchangeRates();
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "seo": { "title": "Sold Listings Archive - The Mini Exchange", "description": "Browse previously sold Classic Mini listings. Research past prices for vehicles, engines, and parts." },
+    "header": { "title": "Sold Listings Archive", "subtitle": "Browse {count} sold listings for market research" },
+    "search": { "placeholder": "Search sold listings..." },
+    "results": { "searching": "Searching...", "showing": "Showing {shown} of {total} sold listings", "none": "No sold listings found" },
+    "sort": { "ariaLabel": "Sort sold listings", "newest": "Recently Sold", "oldest": "Oldest First", "priceDesc": "Highest Price", "priceAsc": "Lowest Price" },
+    "badge": { "sold": "SOLD" },
+    "price": { "about": "About {amount} in {currency}", "soldOn": "Sold {date}" },
+    "empty": { "title": "No Sold Listings Found", "body": "Try adjusting your search to see more results.", "clear": "Clear Search" },
+    "date": { "unknown": "Unknown date", "today": "Today", "yesterday": "Yesterday", "daysAgo": "{count} days ago", "weeksAgo": "{count} weeks ago", "monthsAgo": "{count} months ago" }
+  },
+  "es": {
+    "seo": { "title": "Archivo de anuncios vendidos - The Mini Exchange", "description": "Explora anuncios de Classic Mini vendidos anteriormente. Investiga precios pasados de vehículos, motores y piezas." },
+    "header": { "title": "Archivo de anuncios vendidos", "subtitle": "Explora {count} anuncios vendidos para estudios de mercado" },
+    "search": { "placeholder": "Buscar anuncios vendidos..." },
+    "results": { "searching": "Buscando...", "showing": "Mostrando {shown} de {total} anuncios vendidos", "none": "No se encontraron anuncios vendidos" },
+    "sort": { "ariaLabel": "Ordenar anuncios vendidos", "newest": "Vendidos recientemente", "oldest": "Más antiguos primero", "priceDesc": "Precio más alto", "priceAsc": "Precio más bajo" },
+    "badge": { "sold": "VENDIDO" },
+    "price": { "about": "Aproximadamente {amount} en {currency}", "soldOn": "Vendido {date}" },
+    "empty": { "title": "No se encontraron anuncios vendidos", "body": "Intenta ajustar tu búsqueda para ver más resultados.", "clear": "Borrar búsqueda" },
+    "date": { "unknown": "Fecha desconocida", "today": "Hoy", "yesterday": "Ayer", "daysAgo": "hace {count} días", "weeksAgo": "hace {count} semanas", "monthsAgo": "hace {count} meses" }
+  },
+  "fr": {
+    "seo": { "title": "Archive des annonces vendues - The Mini Exchange", "description": "Parcourez les annonces de Classic Mini déjà vendues. Recherchez les prix passés des véhicules, moteurs et pièces." },
+    "header": { "title": "Archive des annonces vendues", "subtitle": "Parcourez {count} annonces vendues pour vos études de marché" },
+    "search": { "placeholder": "Rechercher des annonces vendues..." },
+    "results": { "searching": "Recherche...", "showing": "Affichage de {shown} sur {total} annonces vendues", "none": "Aucune annonce vendue trouvée" },
+    "sort": { "ariaLabel": "Trier les annonces vendues", "newest": "Vendues récemment", "oldest": "Les plus anciennes d'abord", "priceDesc": "Prix le plus élevé", "priceAsc": "Prix le plus bas" },
+    "badge": { "sold": "VENDU" },
+    "price": { "about": "Environ {amount} en {currency}", "soldOn": "Vendu {date}" },
+    "empty": { "title": "Aucune annonce vendue trouvée", "body": "Essayez d'ajuster votre recherche pour voir plus de résultats.", "clear": "Effacer la recherche" },
+    "date": { "unknown": "Date inconnue", "today": "Aujourd'hui", "yesterday": "Hier", "daysAgo": "il y a {count} jours", "weeksAgo": "il y a {count} semaines", "monthsAgo": "il y a {count} mois" }
+  },
+  "de": {
+    "seo": { "title": "Archiv verkaufter Anzeigen - The Mini Exchange", "description": "Durchsuche zuvor verkaufte Classic-Mini-Anzeigen. Recherchiere frühere Preise für Fahrzeuge, Motoren und Teile." },
+    "header": { "title": "Archiv verkaufter Anzeigen", "subtitle": "Durchsuche {count} verkaufte Anzeigen für die Marktforschung" },
+    "search": { "placeholder": "Verkaufte Anzeigen suchen..." },
+    "results": { "searching": "Suche läuft...", "showing": "Zeige {shown} von {total} verkauften Anzeigen", "none": "Keine verkauften Anzeigen gefunden" },
+    "sort": { "ariaLabel": "Verkaufte Anzeigen sortieren", "newest": "Kürzlich verkauft", "oldest": "Älteste zuerst", "priceDesc": "Höchster Preis", "priceAsc": "Niedrigster Preis" },
+    "badge": { "sold": "VERKAUFT" },
+    "price": { "about": "Etwa {amount} in {currency}", "soldOn": "Verkauft {date}" },
+    "empty": { "title": "Keine verkauften Anzeigen gefunden", "body": "Passe deine Suche an, um mehr Ergebnisse zu sehen.", "clear": "Suche zurücksetzen" },
+    "date": { "unknown": "Unbekanntes Datum", "today": "Heute", "yesterday": "Gestern", "daysAgo": "vor {count} Tagen", "weeksAgo": "vor {count} Wochen", "monthsAgo": "vor {count} Monaten" }
+  },
+  "it": {
+    "seo": { "title": "Archivio annunci venduti - The Mini Exchange", "description": "Sfoglia gli annunci di Classic Mini venduti in precedenza. Ricerca i prezzi passati di veicoli, motori e ricambi." },
+    "header": { "title": "Archivio annunci venduti", "subtitle": "Sfoglia {count} annunci venduti per ricerche di mercato" },
+    "search": { "placeholder": "Cerca annunci venduti..." },
+    "results": { "searching": "Ricerca in corso...", "showing": "Mostrando {shown} di {total} annunci venduti", "none": "Nessun annuncio venduto trovato" },
+    "sort": { "ariaLabel": "Ordina annunci venduti", "newest": "Venduti di recente", "oldest": "Prima i più vecchi", "priceDesc": "Prezzo più alto", "priceAsc": "Prezzo più basso" },
+    "badge": { "sold": "VENDUTO" },
+    "price": { "about": "Circa {amount} in {currency}", "soldOn": "Venduto {date}" },
+    "empty": { "title": "Nessun annuncio venduto trovato", "body": "Prova a modificare la ricerca per vedere più risultati.", "clear": "Cancella ricerca" },
+    "date": { "unknown": "Data sconosciuta", "today": "Oggi", "yesterday": "Ieri", "daysAgo": "{count} giorni fa", "weeksAgo": "{count} settimane fa", "monthsAgo": "{count} mesi fa" }
+  },
+  "pt": {
+    "seo": { "title": "Arquivo de anúncios vendidos - The Mini Exchange", "description": "Navegue por anúncios de Classic Mini vendidos anteriormente. Pesquise preços passados de veículos, motores e peças." },
+    "header": { "title": "Arquivo de anúncios vendidos", "subtitle": "Navegue por {count} anúncios vendidos para pesquisa de mercado" },
+    "search": { "placeholder": "Pesquisar anúncios vendidos..." },
+    "results": { "searching": "Pesquisando...", "showing": "Mostrando {shown} de {total} anúncios vendidos", "none": "Nenhum anúncio vendido encontrado" },
+    "sort": { "ariaLabel": "Ordenar anúncios vendidos", "newest": "Vendidos recentemente", "oldest": "Mais antigos primeiro", "priceDesc": "Maior preço", "priceAsc": "Menor preço" },
+    "badge": { "sold": "VENDIDO" },
+    "price": { "about": "Cerca de {amount} em {currency}", "soldOn": "Vendido {date}" },
+    "empty": { "title": "Nenhum anúncio vendido encontrado", "body": "Tente ajustar sua pesquisa para ver mais resultados.", "clear": "Limpar pesquisa" },
+    "date": { "unknown": "Data desconhecida", "today": "Hoje", "yesterday": "Ontem", "daysAgo": "há {count} dias", "weeksAgo": "há {count} semanas", "monthsAgo": "há {count} meses" }
+  },
+  "ru": {
+    "seo": { "title": "Архив проданных объявлений - The Mini Exchange", "description": "Просматривайте ранее проданные объявления Classic Mini. Изучайте прошлые цены на автомобили, двигатели и запчасти." },
+    "header": { "title": "Архив проданных объявлений", "subtitle": "Просмотрите {count} проданных объявлений для анализа рынка" },
+    "search": { "placeholder": "Поиск проданных объявлений..." },
+    "results": { "searching": "Поиск...", "showing": "Показано {shown} из {total} проданных объявлений", "none": "Проданные объявления не найдены" },
+    "sort": { "ariaLabel": "Сортировать проданные объявления", "newest": "Недавно проданные", "oldest": "Сначала старые", "priceDesc": "Сначала дорогие", "priceAsc": "Сначала дешёвые" },
+    "badge": { "sold": "ПРОДАНО" },
+    "price": { "about": "Около {amount} в {currency}", "soldOn": "Продано {date}" },
+    "empty": { "title": "Проданные объявления не найдены", "body": "Попробуйте изменить запрос, чтобы увидеть больше результатов.", "clear": "Очистить поиск" },
+    "date": { "unknown": "Дата неизвестна", "today": "Сегодня", "yesterday": "Вчера", "daysAgo": "{count} дн. назад", "weeksAgo": "{count} нед. назад", "monthsAgo": "{count} мес. назад" }
+  },
+  "ja": {
+    "seo": { "title": "売却済み出品アーカイブ - The Mini Exchange", "description": "過去に売却されたクラシックミニの出品を閲覧。車両、エンジン、パーツの過去価格を調べられます。" },
+    "header": { "title": "売却済み出品アーカイブ", "subtitle": "市場調査向けに {count} 件の売却済み出品を閲覧" },
+    "search": { "placeholder": "売却済み出品を検索..." },
+    "results": { "searching": "検索中...", "showing": "{total} 件中 {shown} 件の売却済み出品を表示", "none": "売却済み出品が見つかりません" },
+    "sort": { "ariaLabel": "売却済み出品を並べ替え", "newest": "最近売却", "oldest": "古い順", "priceDesc": "価格が高い順", "priceAsc": "価格が安い順" },
+    "badge": { "sold": "売却済み" },
+    "price": { "about": "約 {amount}（{currency}）", "soldOn": "{date} に売却" },
+    "empty": { "title": "売却済み出品が見つかりません", "body": "検索条件を変更すると、より多くの結果が表示されます。", "clear": "検索をクリア" },
+    "date": { "unknown": "日付不明", "today": "今日", "yesterday": "昨日", "daysAgo": "{count} 日前", "weeksAgo": "{count} 週間前", "monthsAgo": "{count} か月前" }
+  },
+  "zh": {
+    "seo": { "title": "已售刊登存档 - The Mini Exchange", "description": "浏览以往售出的经典 Mini 刊登。研究车辆、发动机和零件的历史价格。" },
+    "header": { "title": "已售刊登存档", "subtitle": "浏览 {count} 条已售刊登用于市场调研" },
+    "search": { "placeholder": "搜索已售刊登..." },
+    "results": { "searching": "搜索中...", "showing": "显示 {total} 条已售刊登中的 {shown} 条", "none": "未找到已售刊登" },
+    "sort": { "ariaLabel": "排序已售刊登", "newest": "最近售出", "oldest": "最早优先", "priceDesc": "价格从高到低", "priceAsc": "价格从低到高" },
+    "badge": { "sold": "已售" },
+    "price": { "about": "约 {amount}（{currency}）", "soldOn": "售于 {date}" },
+    "empty": { "title": "未找到已售刊登", "body": "尝试调整搜索条件以查看更多结果。", "clear": "清除搜索" },
+    "date": { "unknown": "日期未知", "today": "今天", "yesterday": "昨天", "daysAgo": "{count} 天前", "weeksAgo": "{count} 周前", "monthsAgo": "{count} 个月前" }
+  },
+  "ko": {
+    "seo": { "title": "판매 완료 매물 아카이브 - The Mini Exchange", "description": "이전에 판매된 클래식 미니 매물을 둘러보세요. 차량, 엔진, 부품의 과거 가격을 조사할 수 있습니다." },
+    "header": { "title": "판매 완료 매물 아카이브", "subtitle": "시장 조사를 위해 {count}개의 판매 완료 매물 둘러보기" },
+    "search": { "placeholder": "판매 완료 매물 검색..." },
+    "results": { "searching": "검색 중...", "showing": "판매 완료 매물 {total}개 중 {shown}개 표시", "none": "판매 완료 매물을 찾을 수 없습니다" },
+    "sort": { "ariaLabel": "판매 완료 매물 정렬", "newest": "최근 판매순", "oldest": "오래된 순", "priceDesc": "높은 가격순", "priceAsc": "낮은 가격순" },
+    "badge": { "sold": "판매됨" },
+    "price": { "about": "약 {amount} ({currency})", "soldOn": "{date} 판매" },
+    "empty": { "title": "판매 완료 매물을 찾을 수 없습니다", "body": "검색 조건을 조정하면 더 많은 결과를 볼 수 있습니다.", "clear": "검색 지우기" },
+    "date": { "unknown": "날짜 불명", "today": "오늘", "yesterday": "어제", "daysAgo": "{count}일 전", "weeksAgo": "{count}주 전", "monthsAgo": "{count}개월 전" }
+  }
+}
+</i18n>

--- a/app/pages/exchange/sold/index.vue
+++ b/app/pages/exchange/sold/index.vue
@@ -142,10 +142,8 @@
   });
 
   const supabase = useSupabase();
-  const { user } = useAuth();
   const { getPhotoUrl } = useListings();
   const { formatCurrency, convertCurrency, fetchExchangeRates, exchangeRates } = useCurrency();
-  const { fetchProfile } = useProfile();
 
   const { userCurrency } = useCurrency();
 
@@ -159,7 +157,7 @@
   const getSoldPrice = (listing: ListingWithPhotos): number | null => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const finalPrice = (listing as any).final_price;
-    if (finalPrice) return finalPrice;
+    if (finalPrice !== null && finalPrice !== undefined) return finalPrice;
     return listing.price;
   };
 
@@ -170,7 +168,7 @@
     if (listingCurrency === userCurrency.value) return null;
 
     const price = getSoldPrice(listing);
-    if (!price) return null;
+    if (price === null || price === undefined) return null;
     return convertCurrency(price, listingCurrency, userCurrency.value);
   };
 
@@ -291,9 +289,23 @@
     sortBy.value = 'newest';
   };
 
-  // Watch search and sort
-  watch([searchQuery, sortBy], () => {
+  // Debounce searchQuery-driven searches; run sortBy changes immediately.
+  let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  watch(searchQuery, () => {
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+      performSearch();
+    }, 300);
+  });
+
+  watch(sortBy, () => {
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
     performSearch();
+  });
+
+  onBeforeUnmount(() => {
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
   });
 
   // Initial load

--- a/app/pages/exchange/wanted/[id].vue
+++ b/app/pages/exchange/wanted/[id].vue
@@ -1,0 +1,958 @@
+<template>
+  <div>
+    <!-- Loading State -->
+    <div v-if="loading" class="py-12">
+      <div class="container">
+        <!-- Breadcrumb skeleton -->
+        <div class="skeleton h-4 w-48 mb-6"></div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <!-- Main content skeleton -->
+          <div class="lg:col-span-2 space-y-6">
+            <div class="skeleton h-10 w-3/4"></div>
+            <div class="flex gap-2">
+              <div class="skeleton h-6 w-20"></div>
+              <div class="skeleton h-6 w-24"></div>
+            </div>
+            <div class="skeleton h-48 w-full"></div>
+            <div class="skeleton h-24 w-full"></div>
+          </div>
+
+          <!-- Sidebar skeleton -->
+          <div class="space-y-4">
+            <div class="skeleton h-48 w-full"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Post Content -->
+    <div v-else-if="currentPost" class="py-8">
+      <div class="container">
+        <!-- Breadcrumb -->
+        <div class="breadcrumbs text-sm mb-6">
+          <ul>
+            <li><NuxtLink to="/exchange/wanted">{{ t('breadcrumb.wanted') }}</NuxtLink></li>
+            <li>{{ currentPost.title }}</li>
+          </ul>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <!-- Main Content (2 cols) -->
+          <div class="lg:col-span-2 space-y-6">
+            <!-- Header -->
+            <div>
+              <div class="flex flex-wrap items-start gap-3 mb-2">
+                <h1 class="text-3xl sm:text-4xl font-bold flex-1">{{ currentPost.title }}</h1>
+                <!-- Status badge for non-active posts -->
+                <span v-if="currentPost.status !== 'active'" class="badge badge-lg" :class="statusBadgeClass">
+                  {{ formatWantedStatus(currentPost.status) }}
+                </span>
+              </div>
+
+              <!-- Category + Condition badges -->
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge" :class="categoryBadgeClass(currentPost.category)">
+                  {{ formatCategory(currentPost.category) }}
+                </span>
+                <span v-if="currentPost.parts_subcategory" class="badge badge-outline badge-sm">
+                  {{ formatPartsSubcategory(currentPost.parts_subcategory) }}
+                </span>
+                <span
+                  v-if="currentPost.condition_preference && currentPost.condition_preference !== 'any'"
+                  class="badge badge-ghost"
+                >
+                  {{ formatConditionPreference(currentPost.condition_preference) }}
+                </span>
+              </div>
+            </div>
+
+            <!-- Posted By Section -->
+            <div class="flex items-center gap-3 p-4 bg-base-200 rounded-lg">
+              <NuxtLink v-if="currentPost.profiles" :to="`/users/${currentPost.user_id}`" class="avatar shrink-0">
+                <div class="w-12 h-12 rounded-full bg-base-300">
+                  <img
+                    v-if="currentPost.profiles.avatar_url"
+                    :src="currentPost.profiles.avatar_url"
+                    :alt="currentPost.profiles.display_name || t('user')"
+                    loading="lazy"
+                  />
+                  <div
+                    v-else
+                    class="flex items-center justify-center h-full text-lg font-semibold text-base-content/70"
+                  >
+                    {{ getInitials(currentPost.profiles.display_name || currentPost.profiles.username || t('anonymous')) }}
+                  </div>
+                </div>
+              </NuxtLink>
+              <div class="flex-1 min-w-0">
+                <NuxtLink
+                  v-if="currentPost.profiles"
+                  :to="`/users/${currentPost.user_id}`"
+                  class="font-medium hover:text-primary transition-colors"
+                >
+                  {{ currentPost.profiles.display_name || currentPost.profiles.username || t('anonymous') }}
+                </NuxtLink>
+                <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-base-content/60">
+                  <span>{{ t('postedAgo', { time: timeAgo(currentPost.created_at) }) }}</span>
+                  <span class="flex items-center gap-1">
+                    <i class="fas fa-clock"></i>
+                    {{ t('expiresOn', { date: formatDate(currentPost.expires_at) }) }}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Description -->
+            <div>
+              <h2 class="text-2xl font-semibold mb-3">{{ t('section.description') }}</h2>
+              <p class="text-base-content/80 whitespace-pre-wrap">{{ currentPost.description }}</p>
+            </div>
+
+            <!-- Budget -->
+            <div v-if="formattedBudget">
+              <h2 class="text-2xl font-semibold mb-3">{{ t('section.budget') }}</h2>
+              <div class="flex items-center gap-2 text-xl font-bold text-primary">
+                <i class="fas fa-money-bill-wave text-2xl"></i>
+                {{ formattedBudget }}
+              </div>
+            </div>
+
+            <!-- Location -->
+            <div v-if="formattedLocation">
+              <h2 class="text-2xl font-semibold mb-3">{{ t('section.location') }}</h2>
+              <div class="flex items-center gap-2 text-base-content/80">
+                <template v-if="countryFlag">
+                  <span class="text-lg">{{ countryFlag }}</span>
+                </template>
+                <i v-else class="fas fa-location-dot text-xl text-base-content/50"></i>
+                <span>{{ formattedLocation }}</span>
+              </div>
+            </div>
+
+            <!-- Dates -->
+            <div class="grid sm:grid-cols-2 gap-4">
+              <div class="flex items-center gap-3 p-4 bg-base-200 rounded-lg">
+                <i class="fas fa-calendar text-2xl text-base-content/60"></i>
+                <div>
+                  <div class="text-sm text-base-content/60">{{ t('label.posted') }}</div>
+                  <div class="font-medium">{{ formatDate(currentPost.created_at) }}</div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 p-4 bg-base-200 rounded-lg">
+                <i class="fas fa-clock text-2xl text-base-content/60"></i>
+                <div>
+                  <div class="text-sm text-base-content/60">{{ t('label.expires') }}</div>
+                  <div class="font-medium" :class="isExpired ? 'text-error' : ''">
+                    {{ formatDate(currentPost.expires_at) }}
+                    <span v-if="isExpired" class="text-xs">{{ t('expiredSuffix') }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Sidebar (1 col) -->
+          <div class="lg:col-span-1">
+            <div class="lg:sticky lg:top-20">
+              <div class="card bg-base-100 shadow-sm">
+                <div class="card-body">
+                  <!-- Budget summary at top of sidebar -->
+                  <div v-if="formattedBudget" class="mb-4 pb-4 border-b border-base-300">
+                    <div class="text-sm text-base-content/60 mb-1">{{ t('section.budget') }}</div>
+                    <div class="text-2xl font-bold text-primary">{{ formattedBudget }}</div>
+                  </div>
+
+                  <!-- Quick info -->
+                  <div class="space-y-2 mb-6 text-sm">
+                    <div class="flex items-center gap-2">
+                      <i :class="categoryIcon" class="text-base-content/50 shrink-0"></i>
+                      <span>{{ formatCategory(currentPost.category) }}</span>
+                    </div>
+                    <div v-if="currentPost.condition_preference !== 'any'" class="flex items-center gap-2">
+                      <i class="far fa-star text-base-content/50 shrink-0"></i>
+                      <span>{{ formatConditionPreference(currentPost.condition_preference) }}</span>
+                    </div>
+                    <div v-if="formattedLocation" class="flex items-center gap-2">
+                      <template v-if="countryFlag">
+                        <span class="shrink-0">{{ countryFlag }}</span>
+                      </template>
+                      <i v-else class="fas fa-location-dot text-base-content/50 shrink-0"></i>
+                      <span class="truncate">{{ formattedLocation }}</span>
+                    </div>
+                  </div>
+
+                  <!-- Action Buttons -->
+                  <div class="space-y-3">
+                    <!-- Visitor Actions: "I Have This" button -->
+                    <template v-if="!isOwner">
+                      <button class="btn btn-primary btn-block" :disabled="contactLoading" @click="handleContact">
+                        <span v-if="contactLoading" class="loading loading-spinner loading-sm"></span>
+                        <i v-else class="fas fa-envelope text-xl"></i>
+                        {{ t('action.iHaveThis') }}
+                      </button>
+                      <p class="text-xs text-base-content/50 text-center">
+                        {{ t('action.iHaveThisHint') }}
+                      </p>
+                    </template>
+
+                    <!-- Owner Actions -->
+                    <template v-if="isOwner">
+                      <!-- Edit -->
+                      <NuxtLink
+                        v-if="currentPost.status !== 'fulfilled'"
+                        :to="`/exchange/wanted/${currentPost.id}/edit`"
+                        class="btn btn-primary btn-block"
+                      >
+                        <i class="fas fa-pen-to-square text-xl"></i>
+                        {{ t('action.editPost') }}
+                      </NuxtLink>
+
+                      <!-- Mark Fulfilled -->
+                      <button
+                        v-if="currentPost.status === 'active'"
+                        class="btn btn-outline btn-success btn-block"
+                        :disabled="fulfilling"
+                        @click="handleMarkFulfilled"
+                      >
+                        <span v-if="fulfilling" class="loading loading-spinner loading-sm"></span>
+                        <i v-else class="fas fa-circle-check text-xl"></i>
+                        {{ t('action.markFulfilled') }}
+                      </button>
+
+                      <!-- Renew (if expired) -->
+                      <button
+                        v-if="currentPost.status === 'expired'"
+                        class="btn btn-outline btn-info btn-block"
+                        :disabled="renewing"
+                        @click="handleRenew"
+                      >
+                        <span v-if="renewing" class="loading loading-spinner loading-sm"></span>
+                        <i v-else class="fas fa-arrows-rotate text-xl"></i>
+                        {{ t('action.renewPost') }}
+                      </button>
+
+                      <!-- Delete -->
+                      <button class="btn btn-outline btn-error btn-block" @click="handleDeleteClick">
+                        <i class="fas fa-trash text-xl"></i>
+                        {{ t('action.deletePost') }}
+                      </button>
+
+                      <!-- Dashboard link -->
+                      <NuxtLink to="/dashboard/wanted" class="btn btn-ghost btn-block">
+                        <i class="fas fa-arrow-left text-xl"></i>
+                        {{ t('action.backToMyPosts') }}
+                      </NuxtLink>
+                    </template>
+                  </div>
+
+                  <!-- Posted / Updated Date -->
+                  <div class="mt-6 pt-6 border-t border-base-300 text-sm text-base-content/60 flex items-center gap-2">
+                    <i class="fas fa-calendar shrink-0"></i>
+                    <span>
+                      {{ t('postedDate', { date: formatDate(currentPost.created_at) }) }}
+                      <template v-if="currentPost.updated_at !== currentPost.created_at">
+                        {{ t('updatedDate', { date: formatDate(currentPost.updated_at) }) }}
+                      </template>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Not Found State -->
+    <div v-else class="py-20">
+      <div class="container">
+        <div class="text-center">
+          <i class="fas fa-triangle-exclamation text-6xl mx-auto mb-4 text-base-content/30"></i>
+          <h1 class="text-3xl font-bold mb-2">{{ t('notFound.title') }}</h1>
+          <p class="text-base-content/70 mb-6">{{ t('notFound.body') }}</p>
+          <NuxtLink to="/exchange/wanted" class="btn btn-primary btn-lg">{{ t('notFound.browse') }}</NuxtLink>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete Confirmation Dialog -->
+    <dialog ref="deleteDialogRef" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">{{ t('deleteDialog.title') }}</h3>
+        <p class="py-4">{{ t('deleteDialog.body') }}</p>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="deleteDialogRef?.close()">{{ t('deleteDialog.cancel') }}</button>
+          <button class="btn btn-error" @click="confirmDelete">{{ t('deleteDialog.confirm') }}</button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>{{ t('deleteDialog.close') }}</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { getCountryFlag } from '~/utils/countryFlags';
+  import {
+    categoryBadgeClass,
+    formatCategory,
+    formatWantedStatus,
+    wantedStatusBadgeClass,
+    formatBudget,
+    formatLocation,
+    timeAgo,
+  } from '~/utils/wantedFormatters';
+
+  const { t } = useI18n();
+  const route = useRoute();
+  const router = useRouter();
+  const toast = useToast();
+  const { user } = useAuth();
+  const { currentPost, loading, fetchWantedPost, deleteWantedPost, markFulfilled, renewWantedPost } = useWantedPosts();
+  const { startConversation } = useMessages();
+  const { capture } = usePostHog();
+
+  const postId = route.params.id as string;
+
+  // UI state
+  const contactLoading = ref(false);
+  const fulfilling = ref(false);
+  const renewing = ref(false);
+  const deleteDialogRef = ref<HTMLDialogElement | null>(null);
+
+  // Whether current user owns this post
+  const isOwner = computed(() => {
+    return user.value?.id === currentPost.value?.user_id;
+  });
+
+  // Whether the post has expired
+  const isExpired = computed(() => {
+    if (!currentPost.value) return false;
+    return new Date(currentPost.value.expires_at) < new Date();
+  });
+
+  // Category icon (Font Awesome 6 classes)
+  const categoryIcon = computed(() => {
+    switch (currentPost.value?.category) {
+      case 'vehicle':
+        return 'fas fa-truck';
+      case 'engine':
+        return 'fas fa-gear';
+      case 'parts':
+        return 'fas fa-screwdriver-wrench';
+      default:
+        return 'fas fa-tag';
+    }
+  });
+
+  // Status badge styling
+  const statusBadgeClass = computed(() => wantedStatusBadgeClass(currentPost.value?.status ?? ''));
+
+  // Country flag emoji
+  const countryFlag = computed(() => {
+    return currentPost.value?.country ? getCountryFlag(currentPost.value.country) : '';
+  });
+
+  // Formatted budget display
+  const formattedBudget = computed(() => {
+    if (!currentPost.value) return null;
+    return formatBudget(currentPost.value.budget_min, currentPost.value.budget_max, currentPost.value.currency);
+  });
+
+  // Formatted location display
+  const formattedLocation = computed(() => {
+    if (!currentPost.value) return null;
+    return formatLocation(currentPost.value.city, currentPost.value.state_province, currentPost.value.country);
+  });
+
+  // --- Helper functions ---
+
+  function formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  function formatPartsSubcategory(subcategory: string): string {
+    return subcategory
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  }
+
+  function getInitials(name: string): string {
+    return name
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+  }
+
+  function formatConditionPreference(condition: string): string {
+    const labels: Record<string, string> = {
+      any: 'Any Condition',
+      new: 'New',
+      used: 'Used',
+      excellent: 'Excellent',
+      good: 'Good',
+      fair: 'Fair',
+      project: 'Project',
+      rebuilt: 'Rebuilt',
+      running: 'Running',
+      not_running: 'Not Running',
+    };
+    return labels[condition] || condition.charAt(0).toUpperCase() + condition.slice(1).replace(/_/g, ' ');
+  }
+
+  // --- Actions ---
+
+  /**
+   * Handle "I Have This" button click.
+   * Requires auth - redirects to login (via ?login=required) if not authenticated.
+   * Starts a conversation with the post owner.
+   */
+  async function handleContact() {
+    if (!currentPost.value) return;
+
+    // Check auth
+    if (!user.value) {
+      router.push({ query: { ...route.query, login: 'required' } });
+      return;
+    }
+
+    contactLoading.value = true;
+
+    try {
+      // Track analytics
+      capture('wanted_post_contact_clicked', {
+        wanted_post_id: currentPost.value.id,
+        poster_id: currentPost.value.user_id,
+      });
+
+      const conversationId = await startConversation({
+        wantedPostId: currentPost.value.id,
+        recipientId: currentPost.value.user_id,
+      });
+
+      if (conversationId) {
+        navigateTo(`/exchange/messages/${conversationId}`);
+      }
+    } catch (error) {
+      toast.add({
+        title: t('toast.errorTitle'),
+        description: t('toast.contactError'),
+        color: 'error',
+      });
+    } finally {
+      contactLoading.value = false;
+    }
+  }
+
+  /**
+   * Mark the wanted post as fulfilled.
+   */
+  async function handleMarkFulfilled() {
+    if (!currentPost.value) return;
+
+    fulfilling.value = true;
+    try {
+      await markFulfilled(currentPost.value.id);
+    } finally {
+      fulfilling.value = false;
+    }
+  }
+
+  /**
+   * Renew an expired wanted post.
+   */
+  async function handleRenew() {
+    if (!currentPost.value) return;
+
+    renewing.value = true;
+    try {
+      await renewWantedPost(currentPost.value.id);
+    } finally {
+      renewing.value = false;
+    }
+  }
+
+  /**
+   * Show the delete confirmation dialog.
+   */
+  function handleDeleteClick() {
+    deleteDialogRef.value?.showModal();
+  }
+
+  /**
+   * Confirm and execute deletion, then navigate to dashboard.
+   */
+  async function confirmDelete() {
+    if (!currentPost.value) return;
+
+    const success = await deleteWantedPost(currentPost.value.id);
+    if (success) {
+      navigateTo('/dashboard/wanted');
+    }
+  }
+
+  // --- Data Fetching ---
+
+  // Fetch post data (SSR-compatible for SEO)
+  const { data: fetchedPost } = await useAsyncData(`wanted-post-${postId}`, () => fetchWantedPost(postId));
+
+  // If useAsyncData resolved, set the loading state accordingly
+  if (fetchedPost.value) {
+    loading.value = false;
+  } else {
+    loading.value = false;
+  }
+
+  // --- SEO ---
+
+  const config = useRuntimeConfig();
+  const siteUrl = config.public.siteUrl || 'https://www.classicminidiy.com';
+  const canonicalUrl = `${siteUrl}/exchange/wanted/${postId}`;
+
+  const ogDescription = computed(() => {
+    if (!currentPost.value) return '';
+    const desc = currentPost.value.description;
+    if (desc.length <= 160) return desc;
+    const truncated = desc.substring(0, 160);
+    const lastSpace = truncated.lastIndexOf(' ');
+    return (lastSpace > 0 ? truncated.substring(0, lastSpace) : truncated) + '...';
+  });
+
+  useSeoMeta({
+    title: () =>
+      currentPost.value ? t('seo.titleWithName', { name: currentPost.value.title }) : t('seo.titleDefault'),
+    description: () => ogDescription.value,
+    ogTitle: () => currentPost.value?.title || t('seo.ogTitleDefault'),
+    ogDescription: () => ogDescription.value,
+    ogType: 'website',
+    ogUrl: canonicalUrl,
+    ogSiteName: 'Classic Mini DIY',
+  });
+
+  useHead({
+    link: [{ rel: 'canonical', href: canonicalUrl }],
+  });
+
+  // --- Analytics ---
+
+  // Track page view when post loads (client-side only)
+  const hasTrackedView = ref(false);
+
+  watch(
+    () => currentPost.value,
+    (post) => {
+      if (post && !hasTrackedView.value && import.meta.client) {
+        hasTrackedView.value = true;
+        capture('wanted_post_viewed', {
+          wanted_post_id: post.id,
+          category: post.category,
+        });
+      }
+    },
+    { immediate: true }
+  );
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "breadcrumb": { "wanted": "Wanted Posts" },
+    "user": "User",
+    "anonymous": "Anonymous",
+    "postedAgo": "Posted {time}",
+    "expiresOn": "Expires {date}",
+    "section": { "description": "Description", "budget": "Budget", "location": "Location" },
+    "label": { "posted": "Posted", "expires": "Expires" },
+    "expiredSuffix": "(Expired)",
+    "action": {
+      "iHaveThis": "I Have This",
+      "iHaveThisHint": "Send a message to let them know you have what they are looking for",
+      "editPost": "Edit Post",
+      "markFulfilled": "Mark as Fulfilled",
+      "renewPost": "Renew Post",
+      "deletePost": "Delete Post",
+      "backToMyPosts": "Back to My Wanted Posts"
+    },
+    "postedDate": "Posted {date}",
+    "updatedDate": "· Updated {date}",
+    "notFound": {
+      "title": "Wanted Post Not Found",
+      "body": "This wanted post doesn't exist or has been removed.",
+      "browse": "Browse Wanted Posts"
+    },
+    "deleteDialog": {
+      "title": "Delete Wanted Post",
+      "body": "Are you sure you want to delete this wanted post? This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete",
+      "close": "close"
+    },
+    "toast": { "errorTitle": "Error", "contactError": "Failed to start conversation. Please try again." },
+    "seo": {
+      "titleWithName": "{name} - Wanted - Classic Mini DIY",
+      "titleDefault": "Wanted Post - Classic Mini DIY",
+      "ogTitleDefault": "Wanted Post"
+    }
+  },
+  "es": {
+    "breadcrumb": { "wanted": "Anuncios de búsqueda" },
+    "user": "Usuario",
+    "anonymous": "Anónimo",
+    "postedAgo": "Publicado {time}",
+    "expiresOn": "Expira {date}",
+    "section": { "description": "Descripción", "budget": "Presupuesto", "location": "Ubicación" },
+    "label": { "posted": "Publicado", "expires": "Expira" },
+    "expiredSuffix": "(Expirado)",
+    "action": {
+      "iHaveThis": "Yo tengo esto",
+      "iHaveThisHint": "Envía un mensaje para avisarles de que tienes lo que buscan",
+      "editPost": "Editar anuncio",
+      "markFulfilled": "Marcar como completado",
+      "renewPost": "Renovar anuncio",
+      "deletePost": "Eliminar anuncio",
+      "backToMyPosts": "Volver a mis anuncios de búsqueda"
+    },
+    "postedDate": "Publicado {date}",
+    "updatedDate": "· Actualizado {date}",
+    "notFound": {
+      "title": "Anuncio de búsqueda no encontrado",
+      "body": "Este anuncio de búsqueda no existe o ha sido eliminado.",
+      "browse": "Explorar anuncios de búsqueda"
+    },
+    "deleteDialog": {
+      "title": "Eliminar anuncio de búsqueda",
+      "body": "¿Seguro que quieres eliminar este anuncio de búsqueda? Esta acción no se puede deshacer.",
+      "cancel": "Cancelar",
+      "confirm": "Eliminar",
+      "close": "cerrar"
+    },
+    "toast": { "errorTitle": "Error", "contactError": "No se pudo iniciar la conversación. Inténtalo de nuevo." },
+    "seo": {
+      "titleWithName": "{name} - Buscado - Classic Mini DIY",
+      "titleDefault": "Anuncio de búsqueda - Classic Mini DIY",
+      "ogTitleDefault": "Anuncio de búsqueda"
+    }
+  },
+  "fr": {
+    "breadcrumb": { "wanted": "Annonces de recherche" },
+    "user": "Utilisateur",
+    "anonymous": "Anonyme",
+    "postedAgo": "Publié {time}",
+    "expiresOn": "Expire le {date}",
+    "section": { "description": "Description", "budget": "Budget", "location": "Lieu" },
+    "label": { "posted": "Publié", "expires": "Expire" },
+    "expiredSuffix": "(Expiré)",
+    "action": {
+      "iHaveThis": "Je l'ai",
+      "iHaveThisHint": "Envoyez un message pour leur faire savoir que vous avez ce qu'ils cherchent",
+      "editPost": "Modifier l'annonce",
+      "markFulfilled": "Marquer comme satisfait",
+      "renewPost": "Renouveler l'annonce",
+      "deletePost": "Supprimer l'annonce",
+      "backToMyPosts": "Retour à mes annonces de recherche"
+    },
+    "postedDate": "Publié {date}",
+    "updatedDate": "· Mis à jour {date}",
+    "notFound": {
+      "title": "Annonce de recherche introuvable",
+      "body": "Cette annonce de recherche n'existe pas ou a été supprimée.",
+      "browse": "Parcourir les annonces de recherche"
+    },
+    "deleteDialog": {
+      "title": "Supprimer l'annonce de recherche",
+      "body": "Êtes-vous sûr de vouloir supprimer cette annonce de recherche ? Cette action est irréversible.",
+      "cancel": "Annuler",
+      "confirm": "Supprimer",
+      "close": "fermer"
+    },
+    "toast": { "errorTitle": "Erreur", "contactError": "Impossible de démarrer la conversation. Veuillez réessayer." },
+    "seo": {
+      "titleWithName": "{name} - Recherché - Classic Mini DIY",
+      "titleDefault": "Annonce de recherche - Classic Mini DIY",
+      "ogTitleDefault": "Annonce de recherche"
+    }
+  },
+  "de": {
+    "breadcrumb": { "wanted": "Gesucht-Anzeigen" },
+    "user": "Benutzer",
+    "anonymous": "Anonym",
+    "postedAgo": "Veröffentlicht {time}",
+    "expiresOn": "Läuft ab am {date}",
+    "section": { "description": "Beschreibung", "budget": "Budget", "location": "Standort" },
+    "label": { "posted": "Veröffentlicht", "expires": "Läuft ab" },
+    "expiredSuffix": "(Abgelaufen)",
+    "action": {
+      "iHaveThis": "Ich habe das",
+      "iHaveThisHint": "Senden Sie eine Nachricht, um mitzuteilen, dass Sie das Gesuchte haben",
+      "editPost": "Anzeige bearbeiten",
+      "markFulfilled": "Als erfüllt markieren",
+      "renewPost": "Anzeige erneuern",
+      "deletePost": "Anzeige löschen",
+      "backToMyPosts": "Zurück zu meinen Gesucht-Anzeigen"
+    },
+    "postedDate": "Veröffentlicht {date}",
+    "updatedDate": "· Aktualisiert {date}",
+    "notFound": {
+      "title": "Gesucht-Anzeige nicht gefunden",
+      "body": "Diese Gesucht-Anzeige existiert nicht oder wurde entfernt.",
+      "browse": "Gesucht-Anzeigen durchsuchen"
+    },
+    "deleteDialog": {
+      "title": "Gesucht-Anzeige löschen",
+      "body": "Möchten Sie diese Gesucht-Anzeige wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "cancel": "Abbrechen",
+      "confirm": "Löschen",
+      "close": "schließen"
+    },
+    "toast": { "errorTitle": "Fehler", "contactError": "Konversation konnte nicht gestartet werden. Bitte versuchen Sie es erneut." },
+    "seo": {
+      "titleWithName": "{name} - Gesucht - Classic Mini DIY",
+      "titleDefault": "Gesucht-Anzeige - Classic Mini DIY",
+      "ogTitleDefault": "Gesucht-Anzeige"
+    }
+  },
+  "it": {
+    "breadcrumb": { "wanted": "Annunci di ricerca" },
+    "user": "Utente",
+    "anonymous": "Anonimo",
+    "postedAgo": "Pubblicato {time}",
+    "expiresOn": "Scade il {date}",
+    "section": { "description": "Descrizione", "budget": "Budget", "location": "Posizione" },
+    "label": { "posted": "Pubblicato", "expires": "Scade" },
+    "expiredSuffix": "(Scaduto)",
+    "action": {
+      "iHaveThis": "Ce l'ho io",
+      "iHaveThisHint": "Invia un messaggio per far sapere che hai ciò che cercano",
+      "editPost": "Modifica annuncio",
+      "markFulfilled": "Segna come soddisfatto",
+      "renewPost": "Rinnova annuncio",
+      "deletePost": "Elimina annuncio",
+      "backToMyPosts": "Torna ai miei annunci di ricerca"
+    },
+    "postedDate": "Pubblicato {date}",
+    "updatedDate": "· Aggiornato {date}",
+    "notFound": {
+      "title": "Annuncio di ricerca non trovato",
+      "body": "Questo annuncio di ricerca non esiste o è stato rimosso.",
+      "browse": "Sfoglia gli annunci di ricerca"
+    },
+    "deleteDialog": {
+      "title": "Elimina annuncio di ricerca",
+      "body": "Sei sicuro di voler eliminare questo annuncio di ricerca? Questa azione non può essere annullata.",
+      "cancel": "Annulla",
+      "confirm": "Elimina",
+      "close": "chiudi"
+    },
+    "toast": { "errorTitle": "Errore", "contactError": "Impossibile avviare la conversazione. Riprova." },
+    "seo": {
+      "titleWithName": "{name} - Cercato - Classic Mini DIY",
+      "titleDefault": "Annuncio di ricerca - Classic Mini DIY",
+      "ogTitleDefault": "Annuncio di ricerca"
+    }
+  },
+  "pt": {
+    "breadcrumb": { "wanted": "Anúncios de procura" },
+    "user": "Utilizador",
+    "anonymous": "Anônimo",
+    "postedAgo": "Publicado {time}",
+    "expiresOn": "Expira em {date}",
+    "section": { "description": "Descrição", "budget": "Orçamento", "location": "Localização" },
+    "label": { "posted": "Publicado", "expires": "Expira" },
+    "expiredSuffix": "(Expirado)",
+    "action": {
+      "iHaveThis": "Eu tenho isto",
+      "iHaveThisHint": "Envie uma mensagem para avisar que tem o que eles procuram",
+      "editPost": "Editar anúncio",
+      "markFulfilled": "Marcar como atendido",
+      "renewPost": "Renovar anúncio",
+      "deletePost": "Excluir anúncio",
+      "backToMyPosts": "Voltar aos meus anúncios de procura"
+    },
+    "postedDate": "Publicado {date}",
+    "updatedDate": "· Atualizado {date}",
+    "notFound": {
+      "title": "Anúncio de procura não encontrado",
+      "body": "Este anúncio de procura não existe ou foi removido.",
+      "browse": "Explorar anúncios de procura"
+    },
+    "deleteDialog": {
+      "title": "Excluir anúncio de procura",
+      "body": "Tem certeza de que deseja excluir este anúncio de procura? Esta ação não pode ser desfeita.",
+      "cancel": "Cancelar",
+      "confirm": "Excluir",
+      "close": "fechar"
+    },
+    "toast": { "errorTitle": "Erro", "contactError": "Falha ao iniciar a conversa. Tente novamente." },
+    "seo": {
+      "titleWithName": "{name} - Procurado - Classic Mini DIY",
+      "titleDefault": "Anúncio de procura - Classic Mini DIY",
+      "ogTitleDefault": "Anúncio de procura"
+    }
+  },
+  "ru": {
+    "breadcrumb": { "wanted": "Объявления о поиске" },
+    "user": "Пользователь",
+    "anonymous": "Аноним",
+    "postedAgo": "Опубликовано {time}",
+    "expiresOn": "Истекает {date}",
+    "section": { "description": "Описание", "budget": "Бюджет", "location": "Местоположение" },
+    "label": { "posted": "Опубликовано", "expires": "Истекает" },
+    "expiredSuffix": "(Истекло)",
+    "action": {
+      "iHaveThis": "У меня это есть",
+      "iHaveThisHint": "Отправьте сообщение, чтобы сообщить, что у вас есть то, что они ищут",
+      "editPost": "Редактировать объявление",
+      "markFulfilled": "Отметить как выполненное",
+      "renewPost": "Продлить объявление",
+      "deletePost": "Удалить объявление",
+      "backToMyPosts": "Назад к моим объявлениям о поиске"
+    },
+    "postedDate": "Опубликовано {date}",
+    "updatedDate": "· Обновлено {date}",
+    "notFound": {
+      "title": "Объявление о поиске не найдено",
+      "body": "Это объявление о поиске не существует или было удалено.",
+      "browse": "Просмотреть объявления о поиске"
+    },
+    "deleteDialog": {
+      "title": "Удалить объявление о поиске",
+      "body": "Вы уверены, что хотите удалить это объявление о поиске? Это действие нельзя отменить.",
+      "cancel": "Отмена",
+      "confirm": "Удалить",
+      "close": "закрыть"
+    },
+    "toast": { "errorTitle": "Ошибка", "contactError": "Не удалось начать разговор. Пожалуйста, попробуйте снова." },
+    "seo": {
+      "titleWithName": "{name} - Поиск - Classic Mini DIY",
+      "titleDefault": "Объявление о поиске - Classic Mini DIY",
+      "ogTitleDefault": "Объявление о поиске"
+    }
+  },
+  "ja": {
+    "breadcrumb": { "wanted": "募集投稿" },
+    "user": "ユーザー",
+    "anonymous": "匿名",
+    "postedAgo": "{time}に投稿",
+    "expiresOn": "{date}に期限切れ",
+    "section": { "description": "説明", "budget": "予算", "location": "場所" },
+    "label": { "posted": "投稿日", "expires": "期限" },
+    "expiredSuffix": "(期限切れ)",
+    "action": {
+      "iHaveThis": "これを持っています",
+      "iHaveThisHint": "探しているものをお持ちであることをメッセージで知らせましょう",
+      "editPost": "投稿を編集",
+      "markFulfilled": "達成済みにする",
+      "renewPost": "投稿を更新",
+      "deletePost": "投稿を削除",
+      "backToMyPosts": "募集投稿一覧に戻る"
+    },
+    "postedDate": "{date}に投稿",
+    "updatedDate": "· {date}に更新",
+    "notFound": {
+      "title": "募集投稿が見つかりません",
+      "body": "この募集投稿は存在しないか、削除されました。",
+      "browse": "募集投稿を見る"
+    },
+    "deleteDialog": {
+      "title": "募集投稿を削除",
+      "body": "この募集投稿を削除してもよろしいですか？この操作は元に戻せません。",
+      "cancel": "キャンセル",
+      "confirm": "削除",
+      "close": "閉じる"
+    },
+    "toast": { "errorTitle": "エラー", "contactError": "会話を開始できませんでした。もう一度お試しください。" },
+    "seo": {
+      "titleWithName": "{name} - 募集 - Classic Mini DIY",
+      "titleDefault": "募集投稿 - Classic Mini DIY",
+      "ogTitleDefault": "募集投稿"
+    }
+  },
+  "zh": {
+    "breadcrumb": { "wanted": "求购信息" },
+    "user": "用户",
+    "anonymous": "匿名",
+    "postedAgo": "发布于 {time}",
+    "expiresOn": "{date} 到期",
+    "section": { "description": "描述", "budget": "预算", "location": "位置" },
+    "label": { "posted": "发布于", "expires": "到期" },
+    "expiredSuffix": "(已过期)",
+    "action": {
+      "iHaveThis": "我有这个",
+      "iHaveThisHint": "发送消息告诉他们你有他们想要的东西",
+      "editPost": "编辑信息",
+      "markFulfilled": "标记为已完成",
+      "renewPost": "续期信息",
+      "deletePost": "删除信息",
+      "backToMyPosts": "返回我的求购信息"
+    },
+    "postedDate": "发布于 {date}",
+    "updatedDate": "· 更新于 {date}",
+    "notFound": {
+      "title": "未找到求购信息",
+      "body": "此求购信息不存在或已被删除。",
+      "browse": "浏览求购信息"
+    },
+    "deleteDialog": {
+      "title": "删除求购信息",
+      "body": "确定要删除此求购信息吗？此操作无法撤销。",
+      "cancel": "取消",
+      "confirm": "删除",
+      "close": "关闭"
+    },
+    "toast": { "errorTitle": "错误", "contactError": "无法开始对话。请重试。" },
+    "seo": {
+      "titleWithName": "{name} - 求购 - Classic Mini DIY",
+      "titleDefault": "求购信息 - Classic Mini DIY",
+      "ogTitleDefault": "求购信息"
+    }
+  },
+  "ko": {
+    "breadcrumb": { "wanted": "구함 게시물" },
+    "user": "사용자",
+    "anonymous": "익명",
+    "postedAgo": "{time}에 게시됨",
+    "expiresOn": "{date}에 만료",
+    "section": { "description": "설명", "budget": "예산", "location": "위치" },
+    "label": { "posted": "게시일", "expires": "만료" },
+    "expiredSuffix": "(만료됨)",
+    "action": {
+      "iHaveThis": "제가 가지고 있어요",
+      "iHaveThisHint": "찾고 있는 물건을 가지고 있다고 메시지를 보내세요",
+      "editPost": "게시물 수정",
+      "markFulfilled": "완료로 표시",
+      "renewPost": "게시물 갱신",
+      "deletePost": "게시물 삭제",
+      "backToMyPosts": "내 구함 게시물로 돌아가기"
+    },
+    "postedDate": "{date}에 게시됨",
+    "updatedDate": "· {date}에 업데이트됨",
+    "notFound": {
+      "title": "구함 게시물을 찾을 수 없습니다",
+      "body": "이 구함 게시물은 존재하지 않거나 삭제되었습니다.",
+      "browse": "구함 게시물 둘러보기"
+    },
+    "deleteDialog": {
+      "title": "구함 게시물 삭제",
+      "body": "이 구함 게시물을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "cancel": "취소",
+      "confirm": "삭제",
+      "close": "닫기"
+    },
+    "toast": { "errorTitle": "오류", "contactError": "대화를 시작하지 못했습니다. 다시 시도해 주세요." },
+    "seo": {
+      "titleWithName": "{name} - 구함 - Classic Mini DIY",
+      "titleDefault": "구함 게시물 - Classic Mini DIY",
+      "ogTitleDefault": "구함 게시물"
+    }
+  }
+}
+</i18n>

--- a/app/pages/exchange/wanted/index.vue
+++ b/app/pages/exchange/wanted/index.vue
@@ -1,0 +1,601 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <section class="bg-base-100 border-b border-base-300 py-12">
+      <div class="container">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 class="text-4xl font-bold mb-2">{{ t('header.title') }}</h1>
+            <p class="text-base-content/70">{{ t('header.count', { count: totalCount }) }}</p>
+          </div>
+          <NuxtLink to="/exchange/wanted/new" class="btn btn-primary">
+            <i class="fas fa-plus"></i>
+            {{ t('header.postCta') }}
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <!-- Search Bar -->
+    <section class="bg-base-200 py-6 border-b border-base-300">
+      <div class="container">
+        <div class="relative">
+          <i
+            class="fas fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-base-content/40 pointer-events-none"
+          ></i>
+          <input
+            v-model="searchQuery"
+            type="text"
+            :placeholder="t('search.placeholder')"
+            class="input input-bordered w-full pl-10"
+          />
+        </div>
+      </div>
+    </section>
+
+    <!-- Main Content -->
+    <section class="py-8">
+      <div class="container">
+        <!-- Filter Bar -->
+        <ExchangeWantedFilterBar
+          v-model:category="filterCategory"
+          v-model:condition-preference="filterCondition"
+          v-model:budget-min="filterBudgetMin"
+          v-model:budget-max="filterBudgetMax"
+          v-model:country="filterCountry"
+          @clear="clearFilters"
+        />
+
+        <!-- Results Header -->
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mt-6 mb-6">
+          <div>
+            <p class="text-base-content/70">
+              <span v-if="loading">{{ t('results.searching') }}</span>
+              <span v-else-if="totalCount > 0">
+                {{ t('results.showing', { shown: wantedPosts.length, total: totalCount }) }}
+              </span>
+              <span v-else>{{ t('results.none') }}</span>
+            </p>
+          </div>
+
+          <!-- Sort Dropdown -->
+          <fieldset class="fieldset">
+            <select v-model="sortBy" class="select select-bordered select-sm" :aria-label="t('sort.ariaLabel')">
+              <option value="newest">{{ t('sort.newest') }}</option>
+              <option value="oldest">{{ t('sort.oldest') }}</option>
+              <option value="budget_high">{{ t('sort.budgetHigh') }}</option>
+              <option value="budget_low">{{ t('sort.budgetLow') }}</option>
+            </select>
+          </fieldset>
+        </div>
+
+        <!-- Loading State -->
+        <div v-if="loading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div v-for="i in 6" :key="i" class="skeleton h-64 w-full rounded-lg"></div>
+        </div>
+
+        <!-- Results -->
+        <template v-else-if="wantedPosts.length > 0">
+          <!-- Desktop View: Table -->
+          <div class="hidden md:block">
+            <ExchangeWantedTable :posts="wantedPosts" :sort-by="sortBy" show-user-column @sort="handleTableSort" />
+          </div>
+
+          <!-- Mobile View: Card Grid -->
+          <div class="md:hidden grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <ExchangeWantedCard v-for="post in wantedPosts" :key="post.id" :post="post" />
+          </div>
+
+          <!-- Pagination -->
+          <div v-if="totalPages > 1" class="flex justify-center items-center gap-2 mt-8">
+            <button
+              @click="prevPage"
+              :disabled="currentPage <= 1"
+              class="btn btn-outline btn-sm"
+              :class="{ 'btn-disabled': currentPage <= 1 }"
+            >
+              <i class="fas fa-chevron-left"></i>
+              {{ t('pagination.previous') }}
+            </button>
+
+            <span class="text-sm text-base-content/70">
+              {{ t('pagination.pageOf', { current: currentPage, total: totalPages }) }}
+            </span>
+
+            <button
+              @click="nextPage"
+              :disabled="currentPage >= totalPages"
+              class="btn btn-outline btn-sm"
+              :class="{ 'btn-disabled': currentPage >= totalPages }"
+            >
+              {{ t('pagination.next') }}
+              <i class="fas fa-chevron-right"></i>
+            </button>
+          </div>
+        </template>
+
+        <!-- Empty State -->
+        <div v-else class="text-center py-16">
+          <i class="fas fa-bullhorn text-6xl mx-auto mb-4 text-base-content/30"></i>
+          <h3 class="text-xl font-semibold mb-2">{{ t('empty.title') }}</h3>
+          <p class="text-base-content/70 mb-6">
+            {{ t('empty.body') }}
+          </p>
+          <div class="flex flex-col sm:flex-row gap-3 justify-center">
+            <button class="btn btn-outline" @click="clearFilters">{{ t('empty.clearFilters') }}</button>
+            <NuxtLink to="/exchange/wanted/new" class="btn btn-primary">
+              <i class="fas fa-plus"></i>
+              {{ t('empty.postCta') }}
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+  definePageMeta({});
+
+  const { t } = useI18n();
+  const { capture } = usePostHog();
+  const { wantedPosts, totalCount, loading, fetchWantedPosts } = useWantedPosts();
+
+  // SEO metadata
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.ogTitle'),
+    ogDescription: () => t('seo.ogDescription'),
+    ogType: 'website',
+    ogUrl: 'https://www.classicminidiy.com/exchange/wanted',
+    twitterCard: 'summary_large_image',
+  });
+
+  // Filter and search state
+  const searchQuery = ref('');
+  const filterCategory = ref('');
+  const filterCondition = ref('');
+  const filterBudgetMin = ref<number | undefined>();
+  const filterBudgetMax = ref<number | undefined>();
+  const filterCountry = ref('');
+  const currentPage = ref(1);
+  const sortBy = ref<'newest' | 'oldest' | 'budget_high' | 'budget_low'>('newest');
+  const perPage = 20;
+
+  // Computed total pages
+  const totalPages = computed(() => Math.ceil(totalCount.value / perPage));
+
+  /**
+   * Fetch wanted posts applying all current filters.
+   */
+  const loadPosts = async () => {
+    await fetchWantedPosts({
+      search: searchQuery.value || undefined,
+      category: filterCategory.value || undefined,
+      conditionPreference: filterCondition.value || undefined,
+      budgetMin: filterBudgetMin.value,
+      budgetMax: filterBudgetMax.value,
+      country: filterCountry.value || undefined,
+      page: currentPage.value,
+      perPage,
+      sortBy: sortBy.value,
+    });
+  };
+
+  /**
+   * Handle sort column clicks from WantedTable.
+   * Maps table column names to the composable's sort values.
+   */
+  const handleTableSort = (column: string) => {
+    switch (column) {
+      case 'date':
+        sortBy.value = sortBy.value === 'newest' ? 'oldest' : 'newest';
+        break;
+      case 'budget':
+        sortBy.value = sortBy.value === 'budget_high' ? 'budget_low' : 'budget_high';
+        break;
+      default:
+        break;
+    }
+  };
+
+  /**
+   * Reset all filters and search back to defaults.
+   */
+  const clearFilters = () => {
+    searchQuery.value = '';
+    filterCategory.value = '';
+    filterCondition.value = '';
+    filterBudgetMin.value = undefined;
+    filterBudgetMax.value = undefined;
+    filterCountry.value = '';
+    currentPage.value = 1;
+    sortBy.value = 'newest';
+  };
+
+  /**
+   * Navigate to the previous page.
+   */
+  const prevPage = () => {
+    if (currentPage.value > 1) {
+      currentPage.value--;
+    }
+  };
+
+  /**
+   * Navigate to the next page.
+   */
+  const nextPage = () => {
+    if (currentPage.value < totalPages.value) {
+      currentPage.value++;
+    }
+  };
+
+  // Debounce search input at 500ms
+  let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  watch(searchQuery, () => {
+    if (searchTimeout) clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(() => {
+      currentPage.value = 1;
+      loadPosts();
+    }, 500);
+  });
+
+  // Watch non-search filters: reload immediately and reset page to 1
+  watch([filterCategory, filterCondition, filterBudgetMin, filterBudgetMax, filterCountry, sortBy], () => {
+    currentPage.value = 1;
+    loadPosts();
+  });
+
+  // Watch page changes separately (no page reset needed)
+  watch(currentPage, () => {
+    loadPosts();
+  });
+
+  // Initial load and analytics
+  onMounted(() => {
+    loadPosts().then(() => {
+      capture('wanted_browse_viewed', {
+        total_results: totalCount.value,
+        page: currentPage.value,
+      });
+    });
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "seo": {
+      "title": "Wanted Posts - Classic Mini Parts & Vehicles | Classic Mini DIY",
+      "description": "Browse wanted posts from Classic Mini enthusiasts looking for vehicles, engines, and parts. Find what the community is searching for or post your own want.",
+      "ogTitle": "Wanted Posts - Classic Mini DIY",
+      "ogDescription": "Browse wanted posts from Classic Mini enthusiasts looking for vehicles, engines, and parts."
+    },
+    "header": {
+      "title": "Wanted Posts",
+      "count": "{count} wanted posts available",
+      "postCta": "Post a Want"
+    },
+    "search": { "placeholder": "Search wanted posts..." },
+    "results": {
+      "searching": "Searching...",
+      "showing": "Showing {shown} of {total} results",
+      "none": "No wanted posts found"
+    },
+    "sort": {
+      "ariaLabel": "Sort wanted posts",
+      "newest": "Newest",
+      "oldest": "Oldest",
+      "budgetHigh": "Budget: High to Low",
+      "budgetLow": "Budget: Low to High"
+    },
+    "pagination": { "previous": "Previous", "next": "Next", "pageOf": "Page {current} of {total}" },
+    "empty": {
+      "title": "No Wanted Posts Found",
+      "body": "Try adjusting your search or filters, or post what you're looking for.",
+      "clearFilters": "Clear All Filters",
+      "postCta": "Post What You Need"
+    }
+  },
+  "es": {
+    "seo": {
+      "title": "Anuncios de búsqueda - Piezas y vehículos Classic Mini | Classic Mini DIY",
+      "description": "Explora los anuncios de búsqueda de entusiastas del Classic Mini que buscan vehículos, motores y piezas. Descubre lo que busca la comunidad o publica tu propia búsqueda.",
+      "ogTitle": "Anuncios de búsqueda - Classic Mini DIY",
+      "ogDescription": "Explora los anuncios de búsqueda de entusiastas del Classic Mini que buscan vehículos, motores y piezas."
+    },
+    "header": {
+      "title": "Anuncios de búsqueda",
+      "count": "{count} anuncios de búsqueda disponibles",
+      "postCta": "Publicar una búsqueda"
+    },
+    "search": { "placeholder": "Buscar anuncios de búsqueda..." },
+    "results": {
+      "searching": "Buscando...",
+      "showing": "Mostrando {shown} de {total} resultados",
+      "none": "No se encontraron anuncios de búsqueda"
+    },
+    "sort": {
+      "ariaLabel": "Ordenar anuncios de búsqueda",
+      "newest": "Más recientes",
+      "oldest": "Más antiguos",
+      "budgetHigh": "Presupuesto: de mayor a menor",
+      "budgetLow": "Presupuesto: de menor a mayor"
+    },
+    "pagination": { "previous": "Anterior", "next": "Siguiente", "pageOf": "Página {current} de {total}" },
+    "empty": {
+      "title": "No se encontraron anuncios de búsqueda",
+      "body": "Prueba a ajustar tu búsqueda o filtros, o publica lo que estás buscando.",
+      "clearFilters": "Borrar todos los filtros",
+      "postCta": "Publica lo que necesitas"
+    }
+  },
+  "fr": {
+    "seo": {
+      "title": "Annonces de recherche - Pièces et véhicules Classic Mini | Classic Mini DIY",
+      "description": "Parcourez les annonces de recherche des passionnés de Classic Mini en quête de véhicules, moteurs et pièces. Découvrez ce que recherche la communauté ou publiez votre propre demande.",
+      "ogTitle": "Annonces de recherche - Classic Mini DIY",
+      "ogDescription": "Parcourez les annonces de recherche des passionnés de Classic Mini en quête de véhicules, moteurs et pièces."
+    },
+    "header": {
+      "title": "Annonces de recherche",
+      "count": "{count} annonces de recherche disponibles",
+      "postCta": "Publier une recherche"
+    },
+    "search": { "placeholder": "Rechercher des annonces de recherche..." },
+    "results": {
+      "searching": "Recherche en cours...",
+      "showing": "Affichage de {shown} sur {total} résultats",
+      "none": "Aucune annonce de recherche trouvée"
+    },
+    "sort": {
+      "ariaLabel": "Trier les annonces de recherche",
+      "newest": "Plus récentes",
+      "oldest": "Plus anciennes",
+      "budgetHigh": "Budget : du plus élevé au plus bas",
+      "budgetLow": "Budget : du plus bas au plus élevé"
+    },
+    "pagination": { "previous": "Précédent", "next": "Suivant", "pageOf": "Page {current} sur {total}" },
+    "empty": {
+      "title": "Aucune annonce de recherche trouvée",
+      "body": "Essayez d'ajuster votre recherche ou vos filtres, ou publiez ce que vous cherchez.",
+      "clearFilters": "Effacer tous les filtres",
+      "postCta": "Publiez ce dont vous avez besoin"
+    }
+  },
+  "de": {
+    "seo": {
+      "title": "Gesuche - Classic-Mini-Teile & Fahrzeuge | Classic Mini DIY",
+      "description": "Durchstöbern Sie Gesuche von Classic-Mini-Enthusiasten, die nach Fahrzeugen, Motoren und Teilen suchen. Finden Sie heraus, was die Community sucht, oder veröffentlichen Sie Ihr eigenes Gesuch.",
+      "ogTitle": "Gesuche - Classic Mini DIY",
+      "ogDescription": "Durchstöbern Sie Gesuche von Classic-Mini-Enthusiasten, die nach Fahrzeugen, Motoren und Teilen suchen."
+    },
+    "header": {
+      "title": "Gesuche",
+      "count": "{count} Gesuche verfügbar",
+      "postCta": "Gesuch aufgeben"
+    },
+    "search": { "placeholder": "Gesuche durchsuchen..." },
+    "results": {
+      "searching": "Suche läuft...",
+      "showing": "{shown} von {total} Ergebnissen werden angezeigt",
+      "none": "Keine Gesuche gefunden"
+    },
+    "sort": {
+      "ariaLabel": "Gesuche sortieren",
+      "newest": "Neueste",
+      "oldest": "Älteste",
+      "budgetHigh": "Budget: hoch nach niedrig",
+      "budgetLow": "Budget: niedrig nach hoch"
+    },
+    "pagination": { "previous": "Zurück", "next": "Weiter", "pageOf": "Seite {current} von {total}" },
+    "empty": {
+      "title": "Keine Gesuche gefunden",
+      "body": "Passen Sie Ihre Suche oder Filter an oder veröffentlichen Sie, wonach Sie suchen.",
+      "clearFilters": "Alle Filter zurücksetzen",
+      "postCta": "Veröffentlichen Sie, was Sie suchen"
+    }
+  },
+  "it": {
+    "seo": {
+      "title": "Annunci di ricerca - Ricambi e veicoli Classic Mini | Classic Mini DIY",
+      "description": "Sfoglia gli annunci di ricerca degli appassionati di Classic Mini in cerca di veicoli, motori e ricambi. Scopri cosa cerca la community o pubblica la tua richiesta.",
+      "ogTitle": "Annunci di ricerca - Classic Mini DIY",
+      "ogDescription": "Sfoglia gli annunci di ricerca degli appassionati di Classic Mini in cerca di veicoli, motori e ricambi."
+    },
+    "header": {
+      "title": "Annunci di ricerca",
+      "count": "{count} annunci di ricerca disponibili",
+      "postCta": "Pubblica una ricerca"
+    },
+    "search": { "placeholder": "Cerca annunci di ricerca..." },
+    "results": {
+      "searching": "Ricerca in corso...",
+      "showing": "Visualizzazione di {shown} di {total} risultati",
+      "none": "Nessun annuncio di ricerca trovato"
+    },
+    "sort": {
+      "ariaLabel": "Ordina annunci di ricerca",
+      "newest": "Più recenti",
+      "oldest": "Meno recenti",
+      "budgetHigh": "Budget: dal più alto al più basso",
+      "budgetLow": "Budget: dal più basso al più alto"
+    },
+    "pagination": { "previous": "Precedente", "next": "Successivo", "pageOf": "Pagina {current} di {total}" },
+    "empty": {
+      "title": "Nessun annuncio di ricerca trovato",
+      "body": "Prova a modificare la ricerca o i filtri, oppure pubblica ciò che stai cercando.",
+      "clearFilters": "Cancella tutti i filtri",
+      "postCta": "Pubblica ciò di cui hai bisogno"
+    }
+  },
+  "pt": {
+    "seo": {
+      "title": "Anúncios de procura - Peças e veículos Classic Mini | Classic Mini DIY",
+      "description": "Navegue pelos anúncios de procura de entusiastas do Classic Mini à procura de veículos, motores e peças. Descubra o que a comunidade procura ou publique o seu próprio pedido.",
+      "ogTitle": "Anúncios de procura - Classic Mini DIY",
+      "ogDescription": "Navegue pelos anúncios de procura de entusiastas do Classic Mini à procura de veículos, motores e peças."
+    },
+    "header": {
+      "title": "Anúncios de procura",
+      "count": "{count} anúncios de procura disponíveis",
+      "postCta": "Publicar uma procura"
+    },
+    "search": { "placeholder": "Pesquisar anúncios de procura..." },
+    "results": {
+      "searching": "A pesquisar...",
+      "showing": "A mostrar {shown} de {total} resultados",
+      "none": "Nenhum anúncio de procura encontrado"
+    },
+    "sort": {
+      "ariaLabel": "Ordenar anúncios de procura",
+      "newest": "Mais recentes",
+      "oldest": "Mais antigos",
+      "budgetHigh": "Orçamento: do maior para o menor",
+      "budgetLow": "Orçamento: do menor para o maior"
+    },
+    "pagination": { "previous": "Anterior", "next": "Seguinte", "pageOf": "Página {current} de {total}" },
+    "empty": {
+      "title": "Nenhum anúncio de procura encontrado",
+      "body": "Tente ajustar a sua pesquisa ou filtros, ou publique o que está à procura.",
+      "clearFilters": "Limpar todos os filtros",
+      "postCta": "Publique o que precisa"
+    }
+  },
+  "ru": {
+    "seo": {
+      "title": "Объявления о поиске - Запчасти и автомобили Classic Mini | Classic Mini DIY",
+      "description": "Просматривайте объявления о поиске от энтузиастов Classic Mini, которые ищут автомобили, двигатели и запчасти. Узнайте, что ищет сообщество, или разместите своё объявление.",
+      "ogTitle": "Объявления о поиске - Classic Mini DIY",
+      "ogDescription": "Просматривайте объявления о поиске от энтузиастов Classic Mini, которые ищут автомобили, двигатели и запчасти."
+    },
+    "header": {
+      "title": "Объявления о поиске",
+      "count": "Доступно объявлений о поиске: {count}",
+      "postCta": "Разместить запрос"
+    },
+    "search": { "placeholder": "Поиск объявлений о поиске..." },
+    "results": {
+      "searching": "Поиск...",
+      "showing": "Показано {shown} из {total} результатов",
+      "none": "Объявления о поиске не найдены"
+    },
+    "sort": {
+      "ariaLabel": "Сортировать объявления о поиске",
+      "newest": "Сначала новые",
+      "oldest": "Сначала старые",
+      "budgetHigh": "Бюджет: по убыванию",
+      "budgetLow": "Бюджет: по возрастанию"
+    },
+    "pagination": { "previous": "Назад", "next": "Далее", "pageOf": "Страница {current} из {total}" },
+    "empty": {
+      "title": "Объявления о поиске не найдены",
+      "body": "Попробуйте изменить поиск или фильтры либо разместите то, что вы ищете.",
+      "clearFilters": "Сбросить все фильтры",
+      "postCta": "Разместите то, что вам нужно"
+    }
+  },
+  "ja": {
+    "seo": {
+      "title": "求む投稿 - クラシックミニ部品＆車両 | Classic Mini DIY",
+      "description": "車両、エンジン、部品を探しているクラシックミニ愛好家の求む投稿を閲覧できます。コミュニティが探しているものを見つけたり、自分の求む投稿を掲載したりできます。",
+      "ogTitle": "求む投稿 - Classic Mini DIY",
+      "ogDescription": "車両、エンジン、部品を探しているクラシックミニ愛好家の求む投稿を閲覧できます。"
+    },
+    "header": {
+      "title": "求む投稿",
+      "count": "求む投稿 {count} 件が掲載中",
+      "postCta": "求む投稿を掲載"
+    },
+    "search": { "placeholder": "求む投稿を検索..." },
+    "results": {
+      "searching": "検索中...",
+      "showing": "{total} 件中 {shown} 件を表示",
+      "none": "求む投稿が見つかりませんでした"
+    },
+    "sort": {
+      "ariaLabel": "求む投稿を並べ替え",
+      "newest": "新しい順",
+      "oldest": "古い順",
+      "budgetHigh": "予算: 高い順",
+      "budgetLow": "予算: 低い順"
+    },
+    "pagination": { "previous": "前へ", "next": "次へ", "pageOf": "{total} ページ中 {current} ページ" },
+    "empty": {
+      "title": "求む投稿が見つかりませんでした",
+      "body": "検索条件やフィルターを調整するか、探しているものを掲載してみてください。",
+      "clearFilters": "すべてのフィルターをクリア",
+      "postCta": "必要なものを掲載"
+    }
+  },
+  "zh": {
+    "seo": {
+      "title": "求购信息 - 经典 Mini 零件与车辆 | Classic Mini DIY",
+      "description": "浏览经典 Mini 爱好者寻找车辆、发动机和零件的求购信息。了解社区在寻找什么，或发布你自己的求购信息。",
+      "ogTitle": "求购信息 - Classic Mini DIY",
+      "ogDescription": "浏览经典 Mini 爱好者寻找车辆、发动机和零件的求购信息。"
+    },
+    "header": {
+      "title": "求购信息",
+      "count": "共有 {count} 条求购信息",
+      "postCta": "发布求购"
+    },
+    "search": { "placeholder": "搜索求购信息..." },
+    "results": {
+      "searching": "搜索中...",
+      "showing": "显示 {total} 条结果中的 {shown} 条",
+      "none": "未找到求购信息"
+    },
+    "sort": {
+      "ariaLabel": "排序求购信息",
+      "newest": "最新",
+      "oldest": "最早",
+      "budgetHigh": "预算：从高到低",
+      "budgetLow": "预算：从低到高"
+    },
+    "pagination": { "previous": "上一页", "next": "下一页", "pageOf": "第 {current} 页，共 {total} 页" },
+    "empty": {
+      "title": "未找到求购信息",
+      "body": "请尝试调整搜索或筛选条件，或发布你想要寻找的内容。",
+      "clearFilters": "清除所有筛选",
+      "postCta": "发布你需要的内容"
+    }
+  },
+  "ko": {
+    "seo": {
+      "title": "구함 게시물 - 클래식 미니 부품 & 차량 | Classic Mini DIY",
+      "description": "차량, 엔진, 부품을 찾는 클래식 미니 애호가들의 구함 게시물을 둘러보세요. 커뮤니티가 찾고 있는 것을 확인하거나 직접 구함 게시물을 올려 보세요.",
+      "ogTitle": "구함 게시물 - Classic Mini DIY",
+      "ogDescription": "차량, 엔진, 부품을 찾는 클래식 미니 애호가들의 구함 게시물을 둘러보세요."
+    },
+    "header": {
+      "title": "구함 게시물",
+      "count": "구함 게시물 {count}개 있음",
+      "postCta": "구함 게시물 올리기"
+    },
+    "search": { "placeholder": "구함 게시물 검색..." },
+    "results": {
+      "searching": "검색 중...",
+      "showing": "{total}개 중 {shown}개 표시",
+      "none": "구함 게시물을 찾을 수 없습니다"
+    },
+    "sort": {
+      "ariaLabel": "구함 게시물 정렬",
+      "newest": "최신순",
+      "oldest": "오래된순",
+      "budgetHigh": "예산: 높은 순",
+      "budgetLow": "예산: 낮은 순"
+    },
+    "pagination": { "previous": "이전", "next": "다음", "pageOf": "{total} 페이지 중 {current} 페이지" },
+    "empty": {
+      "title": "구함 게시물을 찾을 수 없습니다",
+      "body": "검색이나 필터를 조정하거나 찾고 있는 것을 올려 보세요.",
+      "clearFilters": "모든 필터 지우기",
+      "postCta": "필요한 것을 올리기"
+    }
+  }
+}
+</i18n>

--- a/app/utils/filterLabels.ts
+++ b/app/utils/filterLabels.ts
@@ -91,8 +91,8 @@ export function formatFilterSummary(filters: Record<string, any>): string {
   const parts: string[] = [];
 
   for (const [key, value] of Object.entries(filters)) {
-    if (value && labelMap[key]) {
-      parts.push(labelMap[key](value));
+    if (value !== null && value !== undefined && value !== '' && labelMap[key]) {
+      parts.push(labelMap[key](String(value)));
     }
   }
 

--- a/app/utils/filterLabels.ts
+++ b/app/utils/filterLabels.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared filter label mappings used across the application.
+ * Single source of truth for converting filter values to human-readable labels.
+ */
+
+export const categoryLabels: Record<string, string> = {
+  vehicle: 'Vehicles',
+  engine: 'Engines',
+  parts: 'Parts',
+};
+
+export const partsSubcategoryLabels: Record<string, string> = {
+  body_exterior: 'Body & Exterior',
+  interior: 'Interior',
+  wheels_tires: 'Wheels & Tires',
+  engine_internals: 'Engine Internals',
+  suspension: 'Suspension',
+  electrical: 'Electrical',
+  other: 'Other',
+};
+
+export const yearRangeLabels: Record<string, string> = {
+  '1960s': '1959-1969',
+  '1970s': '1970-1979',
+  '1980s': '1980-1989',
+  '1990s': '1990-2000',
+};
+
+export const priceRangeLabels: Record<string, string> = {
+  free: 'Free',
+  'under-10k': 'Under $10k',
+  '10k-20k': '$10k-$20k',
+  '20k-30k': '$20k-$30k',
+  '30k-50k': '$30k-$50k',
+  'over-50k': 'Over $50k',
+};
+
+export const transmissionLabels: Record<string, string> = {
+  magic_wand: 'Magic Wand',
+  '3_synchro_remote': '3-Synchro Remote',
+  '4_synchro_remote': '4-Synchro Remote',
+  rod_change: 'Rod Change',
+  automatic: 'Automatic',
+};
+
+export function getCategoryLabel(category: string): string {
+  return categoryLabels[category] || category;
+}
+
+export function getPartsSubcategoryLabel(subcategory: string): string {
+  return partsSubcategoryLabels[subcategory] || subcategory;
+}
+
+export function getYearRangeLabel(range: string): string {
+  return yearRangeLabels[range] || range;
+}
+
+export function getPriceRangeLabel(range: string): string {
+  return priceRangeLabels[range] || range;
+}
+
+export function getTransmissionLabel(type: string): string {
+  return transmissionLabels[type] || type;
+}
+
+export function getManufacturerLabel(manufacturer: string): string {
+  return manufacturer.charAt(0).toUpperCase() + manufacturer.slice(1);
+}
+
+export function getConditionLabel(condition: string): string {
+  return condition.charAt(0).toUpperCase() + condition.slice(1);
+}
+
+/**
+ * Format a filters object into a human-readable summary string.
+ * Used by saved-searches page and FilterSidebar summary.
+ */
+export function formatFilterSummary(filters: Record<string, any>): string {
+  const labelMap: Record<string, (val: string) => string> = {
+    listing_category: getCategoryLabel,
+    parts_subcategory: getPartsSubcategoryLabel,
+    model: (val) => val,
+    year_range: getYearRangeLabel,
+    price_range: getPriceRangeLabel,
+    condition: getConditionLabel,
+    transmission: getTransmissionLabel,
+    manufacturer: getManufacturerLabel,
+    location: (val) => val,
+  };
+
+  const parts: string[] = [];
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value && labelMap[key]) {
+      parts.push(labelMap[key](value));
+    }
+  }
+
+  return parts.length > 0 ? parts.join(' \u00B7 ') : 'All listings';
+}

--- a/app/utils/wantedFormatters.ts
+++ b/app/utils/wantedFormatters.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared formatting utilities for Wanted Posts.
+ * Used by WantedCard, WantedTable, and the detail page.
+ */
+
+export function getCurrencySymbol(currency: string): string {
+  const symbols: Record<string, string> = {
+    USD: '$',
+    GBP: '\u00A3',
+    EUR: '\u20AC',
+    AUD: 'A$',
+    CAD: 'C$',
+    NZD: 'NZ$',
+    JPY: '\u00A5',
+  };
+  return symbols[currency] || `${currency} `;
+}
+
+export function formatBudget(
+  min: number | null | undefined,
+  max: number | null | undefined,
+  currency: string
+): string | null {
+  const currencySymbol = getCurrencySymbol(currency);
+
+  if (min && max) {
+    return `${currencySymbol}${min.toLocaleString()} - ${currencySymbol}${max.toLocaleString()}`;
+  }
+  if (max) {
+    return `Up to ${currencySymbol}${max.toLocaleString()}`;
+  }
+  if (min) {
+    return `From ${currencySymbol}${min.toLocaleString()}`;
+  }
+  return null;
+}
+
+export function formatLocation(
+  city: string | null | undefined,
+  stateProvince: string | null | undefined,
+  country: string | null | undefined
+): string | null {
+  const parts = [city, stateProvince, country].filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
+export function timeAgo(dateString: string): string {
+  const now = new Date();
+  const date = new Date(dateString);
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  if (seconds < 60) return 'Just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+export function formatCategory(category: string): string {
+  const labels: Record<string, string> = {
+    vehicle: 'Vehicle',
+    engine: 'Engine',
+    parts: 'Parts',
+  };
+  return labels[category] || category;
+}
+
+export function categoryBadgeClass(category: string): string {
+  switch (category) {
+    case 'vehicle':
+      return 'badge-primary';
+    case 'engine':
+      return 'badge-secondary';
+    case 'parts':
+      return 'badge-accent';
+    default:
+      return 'badge-ghost';
+  }
+}
+
+export function wantedStatusBadgeClass(status: string): string {
+  switch (status) {
+    case 'fulfilled':
+      return 'badge-success';
+    case 'expired':
+      return 'badge-error';
+    case 'flagged':
+      return 'badge-warning';
+    case 'cancelled':
+    default:
+      return 'badge-ghost';
+  }
+}
+
+export function formatWantedStatus(status: string): string {
+  const labels: Record<string, string> = {
+    active: 'Active',
+    fulfilled: 'Fulfilled',
+    expired: 'Expired',
+    flagged: 'Under Review',
+    cancelled: 'Cancelled',
+    removed: 'Removed',
+  };
+  return labels[status] || status;
+}

--- a/app/utils/wantedFormatters.ts
+++ b/app/utils/wantedFormatters.ts
@@ -23,13 +23,13 @@ export function formatBudget(
 ): string | null {
   const currencySymbol = getCurrencySymbol(currency);
 
-  if (min && max) {
+  if (min != null && max != null) {
     return `${currencySymbol}${min.toLocaleString()} - ${currencySymbol}${max.toLocaleString()}`;
   }
-  if (max) {
+  if (max != null) {
     return `Up to ${currencySymbol}${max.toLocaleString()}`;
   }
-  if (min) {
+  if (min != null) {
     return `From ${currencySymbol}${min.toLocaleString()}`;
   }
   return null;
@@ -44,30 +44,29 @@ export function formatLocation(
   return parts.length > 0 ? parts.join(', ') : null;
 }
 
-export function timeAgo(dateString: string): string {
-  const now = new Date();
+export function timeAgo(dateString: string, locale: string = 'en'): string {
   const date = new Date(dateString);
-  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
 
-  if (seconds < 60) return 'Just now';
+  if (seconds < 60) return rtf.format(0, 'second');
 
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 60) return rtf.format(-minutes, 'minute');
 
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) return rtf.format(-hours, 'hour');
 
   const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
+  if (days < 7) return rtf.format(-days, 'day');
 
   const weeks = Math.floor(days / 7);
-  if (weeks < 5) return `${weeks}w ago`;
+  if (weeks < 5) return rtf.format(-weeks, 'week');
 
   const months = Math.floor(days / 30);
-  if (months < 12) return `${months}mo ago`;
+  if (months < 12) return rtf.format(-months, 'month');
 
-  const years = Math.floor(days / 365);
-  return `${years}y ago`;
+  return rtf.format(-Math.floor(days / 365), 'year');
 }
 
 export function formatCategory(category: string): string {


### PR DESCRIPTION
**Section 3 of ~10** of the Mini Exchange consolidation (replacing the closed #637). Builds on
sections 1–2 (now in `dev`).

This slice (~21 files / ~6.7k lines) — the remaining read-only marketplace surfaces:
- **Finds**: `/exchange/finds` index + `[slug]` detail, FindCard/FindFilters/LikeButton/SourceSiteBadge
- **Wanted**: `/exchange/wanted` index + `[id]` detail, WantedCard/WantedTable/WantedFilterBar
- **Sold**: `/exchange/sold` archive
- **Full browse**: `/exchange/listings` with FilterSidebar, SearchBar, SortDropdown, SaveSearchButton + map view
- Composables `useWantedPosts`, `useSavedSearches`; utils `filterLabels`, `wantedFormatters`

Flag-gated → invisible in prod. Full 10-locale i18n.

Includes a proactive `<ClientOnly>` wrap on the relative `timeAgo` (WantedCard/WantedTable) and the
auction countdown (FindCard) — the same SSR hydration pattern fixed in #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)