### PR TITLE
feat(exchange): messaging + realtime + Finds scraper (6/10)

### DIFF
--- a/app/components/exchange/messages/ConversationList.vue
+++ b/app/components/exchange/messages/ConversationList.vue
@@ -51,10 +51,12 @@
                   {{ getOtherParticipantName(conversation) }}
                 </h3>
 
-                <!-- Timestamp -->
-                <time class="text-xs text-base-content/60 flex-shrink-0">
-                  {{ formatTime(conversation.last_message_at) }}
-                </time>
+                <!-- Timestamp (client-only: relative time drifts vs server → hydration mismatch) -->
+                <ClientOnly>
+                  <time class="text-xs text-base-content/60 flex-shrink-0">
+                    {{ formatTime(conversation.last_message_at) }}
+                  </time>
+                </ClientOnly>
               </div>
 
               <!-- Listing title + sold badge -->

--- a/app/components/exchange/messages/ConversationList.vue
+++ b/app/components/exchange/messages/ConversationList.vue
@@ -1,0 +1,164 @@
+<template>
+  <div class="space-y-2">
+    <!-- Loading state -->
+    <div v-if="loading" class="flex justify-center py-8">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="conversations.length === 0" class="text-center py-16">
+      <i class="fas fa-inbox text-6xl mb-4 text-base-content/30"></i>
+      <h3 class="text-xl font-semibold mb-2">{{ t('emptyTitle') }}</h3>
+      <p class="text-base-content/70 mb-6">{{ t('emptyBody') }}</p>
+      <NuxtLink to="/exchange/listings" class="btn btn-primary">
+        <i class="fas fa-magnifying-glass"></i>
+        {{ t('browseListings') }}
+      </NuxtLink>
+    </div>
+
+    <!-- Conversation list -->
+    <div v-else class="space-y-2">
+      <NuxtLink
+        v-for="conversation in conversations"
+        :key="conversation.id"
+        :to="`/exchange/messages/${conversation.id}`"
+        class="card bg-base-100 hover:bg-base-200 transition-colors cursor-pointer"
+        :class="{ 'shadow-md': hasUnreadMessages(conversation) }"
+      >
+        <div class="card-body p-4">
+          <div class="flex gap-4">
+            <!-- Listing thumbnail -->
+            <div class="avatar flex-shrink-0">
+              <div class="w-16 h-16 rounded">
+                <img
+                  v-if="getListingImage(conversation)"
+                  :src="getListingImage(conversation)"
+                  :alt="conversation.listing?.title"
+                  class="object-cover w-full h-full"
+                  loading="lazy"
+                />
+                <div v-else class="w-full h-full bg-base-300 flex items-center justify-center">
+                  <i class="fas fa-image text-2xl text-base-content/30"></i>
+                </div>
+              </div>
+            </div>
+
+            <!-- Conversation details -->
+            <div class="flex-1 min-w-0">
+              <div class="flex items-start justify-between gap-2 mb-1">
+                <!-- Other participant name -->
+                <h3 class="font-semibold truncate" :class="{ 'text-primary': hasUnreadMessages(conversation) }">
+                  {{ getOtherParticipantName(conversation) }}
+                </h3>
+
+                <!-- Timestamp -->
+                <time class="text-xs text-base-content/60 flex-shrink-0">
+                  {{ formatTime(conversation.last_message_at) }}
+                </time>
+              </div>
+
+              <!-- Listing title + sold badge -->
+              <p class="text-sm text-base-content/70 truncate mb-2 flex items-center gap-2">
+                <span class="truncate">{{ conversation.listing?.title }}</span>
+                <span v-if="conversation.listing?.status === 'sold'" class="badge badge-xs badge-neutral shrink-0">
+                  {{ t('sold') }}
+                </span>
+              </p>
+
+              <!-- Price -->
+              <div class="flex items-center justify-between">
+                <span class="text-sm font-semibold text-primary">
+                  ${{ conversation.listing?.price?.toLocaleString() }}
+                </span>
+
+                <!-- Unread badge -->
+                <div v-if="hasUnreadMessages(conversation)" class="badge badge-primary badge-sm">
+                  {{ getUnreadCount(conversation) }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </NuxtLink>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { Conversation } from '~/composables/useMessages';
+  import { formatRelativeTime } from '~/utils/formatters';
+
+  const { t } = useI18n();
+
+  interface Props {
+    conversations: Conversation[];
+    loading?: boolean;
+  }
+
+  const props = defineProps<Props>();
+
+  const { user } = useAuth();
+  const { getOtherParticipant } = useMessages();
+  const { getPhotoUrl } = useListings();
+
+  // Get listing primary image
+  const getListingImage = (conversation: Conversation) => {
+    const photos = conversation.listing?.listing_photos;
+    if (!photos || photos.length === 0) return null;
+
+    const primaryPhoto = photos.find((p) => p.is_primary);
+    const photo = primaryPhoto || photos[0];
+
+    return photo ? getPhotoUrl(photo.storage_path) : null;
+  };
+
+  // Get other participant's name
+  const getOtherParticipantName = (conversation: Conversation) => {
+    const participant = getOtherParticipant(conversation);
+    return participant?.name || t('unknownUser');
+  };
+
+  // Check if conversation has unread messages
+  const hasUnreadMessages = (conversation: Conversation) => {
+    if (!user.value) return false;
+
+    if (conversation.buyer_id === user.value.id) {
+      return conversation.buyer_unread_count > 0;
+    } else if (conversation.seller_id === user.value.id) {
+      return conversation.seller_unread_count > 0;
+    }
+
+    return false;
+  };
+
+  // Get unread count for current user
+  const getUnreadCount = (conversation: Conversation) => {
+    if (!user.value) return 0;
+
+    if (conversation.buyer_id === user.value.id) {
+      return conversation.buyer_unread_count;
+    } else if (conversation.seller_id === user.value.id) {
+      return conversation.seller_unread_count;
+    }
+
+    return 0;
+  };
+
+  // Shared helper — see utils/formatters.ts
+  const formatTime = (timestamp: string) => formatRelativeTime(timestamp);
+</script>
+
+<i18n lang="json">
+{
+  "en": { "emptyTitle": "No messages yet", "emptyBody": "Start a conversation by contacting a seller on a listing", "browseListings": "Browse Listings", "sold": "Sold", "unknownUser": "Unknown User" },
+  "es": { "emptyTitle": "Aún no hay mensajes", "emptyBody": "Inicia una conversación contactando a un vendedor en un anuncio", "browseListings": "Explorar anuncios", "sold": "Vendido", "unknownUser": "Usuario desconocido" },
+  "fr": { "emptyTitle": "Aucun message pour le moment", "emptyBody": "Démarrez une conversation en contactant un vendeur sur une annonce", "browseListings": "Parcourir les annonces", "sold": "Vendu", "unknownUser": "Utilisateur inconnu" },
+  "de": { "emptyTitle": "Noch keine Nachrichten", "emptyBody": "Starten Sie ein Gespräch, indem Sie einen Verkäufer zu einer Anzeige kontaktieren", "browseListings": "Anzeigen durchsuchen", "sold": "Verkauft", "unknownUser": "Unbekannter Benutzer" },
+  "it": { "emptyTitle": "Ancora nessun messaggio", "emptyBody": "Avvia una conversazione contattando un venditore su un annuncio", "browseListings": "Sfoglia annunci", "sold": "Venduto", "unknownUser": "Utente sconosciuto" },
+  "pt": { "emptyTitle": "Ainda não há mensagens", "emptyBody": "Inicie uma conversa entrando em contato com um vendedor em um anúncio", "browseListings": "Explorar anúncios", "sold": "Vendido", "unknownUser": "Usuário desconhecido" },
+  "ru": { "emptyTitle": "Сообщений пока нет", "emptyBody": "Начните разговор, связавшись с продавцом по объявлению", "browseListings": "Просмотреть объявления", "sold": "Продано", "unknownUser": "Неизвестный пользователь" },
+  "ja": { "emptyTitle": "メッセージはまだありません", "emptyBody": "出品の出品者に連絡して会話を始めましょう", "browseListings": "出品を見る", "sold": "売却済み", "unknownUser": "不明なユーザー" },
+  "zh": { "emptyTitle": "暂无消息", "emptyBody": "通过联系刊登上的卖家开始对话", "browseListings": "浏览刊登", "sold": "已售", "unknownUser": "未知用户" },
+  "ko": { "emptyTitle": "아직 메시지가 없습니다", "emptyBody": "매물의 판매자에게 연락하여 대화를 시작하세요", "browseListings": "매물 둘러보기", "sold": "판매됨", "unknownUser": "알 수 없는 사용자" }
+}
+</i18n>

--- a/app/components/exchange/messages/ListingConversationGroup.vue
+++ b/app/components/exchange/messages/ListingConversationGroup.vue
@@ -53,9 +53,11 @@
                 : t('peopleCountPlural', { count: group.conversations.length })
             }}
           </span>
-          <span class="text-base-content/50 hidden sm:inline">
-            {{ t('lastActivity', { time: formatTime(group.latestMessageAt) }) }}
-          </span>
+          <ClientOnly>
+            <span class="text-base-content/50 hidden sm:inline">
+              {{ t('lastActivity', { time: formatTime(group.latestMessageAt) }) }}
+            </span>
+          </ClientOnly>
         </div>
       </div>
 
@@ -100,9 +102,11 @@
             >
               {{ getParticipantName(conversation) }}
             </span>
-            <time class="text-xs text-base-content/60 flex-shrink-0">
-              {{ formatTime(conversation.last_message_at) }}
-            </time>
+            <ClientOnly>
+              <time class="text-xs text-base-content/60 flex-shrink-0">
+                {{ formatTime(conversation.last_message_at) }}
+              </time>
+            </ClientOnly>
           </div>
           <div class="text-xs text-base-content/50 mt-0.5 flex items-center gap-1">
             <i class="fas fa-circle-arrow-right"></i>

--- a/app/components/exchange/messages/ListingConversationGroup.vue
+++ b/app/components/exchange/messages/ListingConversationGroup.vue
@@ -1,0 +1,197 @@
+<template>
+  <div
+    class="card bg-base-100 border border-base-200 overflow-hidden"
+    :class="{ 'ring-1 ring-primary/40': group.totalUnread > 0 }"
+  >
+    <!-- Group header (click to toggle) -->
+    <button
+      type="button"
+      class="w-full flex items-center gap-4 p-4 text-left hover:bg-base-200/60 transition-colors"
+      :aria-expanded="isOpen"
+      :aria-controls="`group-body-${group.id}`"
+      @click="$emit('toggle')"
+    >
+      <!-- Listing thumbnail -->
+      <div class="avatar flex-shrink-0">
+        <div class="w-14 h-14 rounded">
+          <img
+            v-if="group.thumbnailUrl"
+            :src="group.thumbnailUrl"
+            :alt="group.title"
+            class="object-cover w-full h-full"
+            loading="lazy"
+          />
+          <div v-else class="w-full h-full bg-base-300 flex items-center justify-center">
+            <i
+              :class="group.kind === 'wanted_post' ? 'fas fa-magnifying-glass' : 'fas fa-image'"
+              class="text-xl text-base-content/30"
+            ></i>
+          </div>
+        </div>
+      </div>
+
+      <!-- Title + meta -->
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-1">
+          <h3 class="font-semibold truncate">{{ group.title }}</h3>
+          <span
+            v-if="group.status === 'sold'"
+            class="badge badge-xs badge-neutral shrink-0"
+          >
+            {{ t('sold') }}
+          </span>
+        </div>
+        <div class="flex items-center gap-3 text-sm text-base-content/70">
+          <span v-if="group.price !== null" class="font-semibold text-primary">
+            ${{ group.price.toLocaleString() }}
+          </span>
+          <span class="flex items-center gap-1">
+            <i class="fas fa-comments"></i>
+            {{
+              group.conversations.length === 1
+                ? t('peopleCount', { count: group.conversations.length })
+                : t('peopleCountPlural', { count: group.conversations.length })
+            }}
+          </span>
+          <span class="text-base-content/50 hidden sm:inline">
+            {{ t('lastActivity', { time: formatTime(group.latestMessageAt) }) }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Unread badge + chevron -->
+      <div class="flex items-center gap-2 flex-shrink-0">
+        <span v-if="group.totalUnread > 0" class="badge badge-primary badge-sm">
+          {{ t('unreadNew', { count: group.totalUnread }) }}
+        </span>
+        <i
+          class="fas fa-chevron-down transition-transform"
+          :class="{ 'rotate-180': isOpen }"
+        ></i>
+      </div>
+    </button>
+
+    <!-- Inner conversation list -->
+    <div v-if="isOpen" :id="`group-body-${group.id}`" class="border-t border-base-200">
+      <NuxtLink
+        v-for="conversation in group.conversations"
+        :key="conversation.id"
+        :to="`/exchange/messages/${conversation.id}`"
+        class="group/row flex items-center gap-3 px-4 py-3 hover:bg-base-200/80 active:bg-base-300 transition-colors border-b border-base-200 last:border-b-0 cursor-pointer"
+      >
+        <!-- Chat bubble icon (reinforces that the row opens a chat) -->
+        <div class="flex-shrink-0 text-base-content/40 group-hover/row:text-primary transition-colors">
+          <i class="fas fa-comment-dots"></i>
+        </div>
+
+        <!-- Person initial avatar -->
+        <div class="avatar avatar-placeholder flex-shrink-0">
+          <div class="bg-base-300 text-base-content/70 w-9 rounded-full">
+            <span class="text-sm font-medium">{{ getInitial(conversation) }}</span>
+          </div>
+        </div>
+
+        <!-- Name + timestamp -->
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center justify-between gap-2">
+            <span
+              class="font-medium truncate"
+              :class="{ 'text-primary': hasUnreadMessages(conversation) }"
+            >
+              {{ getParticipantName(conversation) }}
+            </span>
+            <time class="text-xs text-base-content/60 flex-shrink-0">
+              {{ formatTime(conversation.last_message_at) }}
+            </time>
+          </div>
+          <div class="text-xs text-base-content/50 mt-0.5 flex items-center gap-1">
+            <i class="fas fa-circle-arrow-right"></i>
+            <span>{{ t('tapToOpen') }}</span>
+          </div>
+        </div>
+
+        <!-- Unread badge -->
+        <div v-if="hasUnreadMessages(conversation)" class="badge badge-primary badge-sm flex-shrink-0">
+          {{ getUnreadCount(conversation) }}
+        </div>
+
+        <!-- Chevron affordance -->
+        <i
+          class="fas fa-chevron-right text-base-content/30 group-hover/row:text-base-content/70 group-hover/row:translate-x-0.5 transition-all flex-shrink-0"
+        ></i>
+      </NuxtLink>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { Conversation } from '~/composables/useMessages';
+  import { formatRelativeTime } from '~/utils/formatters';
+
+  const { t } = useI18n();
+
+  export interface ConversationGroup {
+    kind: 'listing' | 'wanted_post' | 'orphan';
+    id: string;
+    title: string;
+    thumbnailUrl: string | null;
+    status: string | null;
+    price: number | null;
+    conversations: Conversation[];
+    totalUnread: number;
+    latestMessageAt: string;
+  }
+
+  interface Props {
+    group: ConversationGroup;
+    isOpen: boolean;
+  }
+
+  defineProps<Props>();
+  defineEmits<{ toggle: [] }>();
+
+  const { user } = useAuth();
+  const { getOtherParticipant } = useMessages();
+
+  const getParticipantName = (conversation: Conversation) => {
+    const p = getOtherParticipant(conversation);
+    return p?.name || t('unknownUser');
+  };
+
+  const getInitial = (conversation: Conversation) => {
+    const name = getParticipantName(conversation);
+    return name.charAt(0).toUpperCase() || '?';
+  };
+
+  const hasUnreadMessages = (conversation: Conversation) => {
+    if (!user.value) return false;
+    if (conversation.buyer_id === user.value.id) return conversation.buyer_unread_count > 0;
+    if (conversation.seller_id === user.value.id) return conversation.seller_unread_count > 0;
+    return false;
+  };
+
+  const getUnreadCount = (conversation: Conversation) => {
+    if (!user.value) return 0;
+    if (conversation.buyer_id === user.value.id) return conversation.buyer_unread_count;
+    if (conversation.seller_id === user.value.id) return conversation.seller_unread_count;
+    return 0;
+  };
+
+  // Shared helper — see utils/formatters.ts
+  const formatTime = (timestamp: string) => formatRelativeTime(timestamp);
+</script>
+
+<i18n lang="json">
+{
+  "en": { "sold": "Sold", "peopleCount": "{count} person", "peopleCountPlural": "{count} people", "lastActivity": "Last: {time}", "unreadNew": "{count} new", "tapToOpen": "Tap to open conversation", "unknownUser": "Unknown User" },
+  "es": { "sold": "Vendido", "peopleCount": "{count} persona", "peopleCountPlural": "{count} personas", "lastActivity": "Último: {time}", "unreadNew": "{count} nuevos", "tapToOpen": "Toca para abrir la conversación", "unknownUser": "Usuario desconocido" },
+  "fr": { "sold": "Vendu", "peopleCount": "{count} personne", "peopleCountPlural": "{count} personnes", "lastActivity": "Dernier : {time}", "unreadNew": "{count} nouveaux", "tapToOpen": "Appuyez pour ouvrir la conversation", "unknownUser": "Utilisateur inconnu" },
+  "de": { "sold": "Verkauft", "peopleCount": "{count} Person", "peopleCountPlural": "{count} Personen", "lastActivity": "Zuletzt: {time}", "unreadNew": "{count} neue", "tapToOpen": "Tippen, um die Unterhaltung zu öffnen", "unknownUser": "Unbekannter Benutzer" },
+  "it": { "sold": "Venduto", "peopleCount": "{count} persona", "peopleCountPlural": "{count} persone", "lastActivity": "Ultimo: {time}", "unreadNew": "{count} nuovi", "tapToOpen": "Tocca per aprire la conversazione", "unknownUser": "Utente sconosciuto" },
+  "pt": { "sold": "Vendido", "peopleCount": "{count} pessoa", "peopleCountPlural": "{count} pessoas", "lastActivity": "Último: {time}", "unreadNew": "{count} novos", "tapToOpen": "Toque para abrir a conversa", "unknownUser": "Usuário desconhecido" },
+  "ru": { "sold": "Продано", "peopleCount": "{count} человек", "peopleCountPlural": "{count} человек", "lastActivity": "Последнее: {time}", "unreadNew": "{count} новых", "tapToOpen": "Нажмите, чтобы открыть разговор", "unknownUser": "Неизвестный пользователь" },
+  "ja": { "sold": "売却済み", "peopleCount": "{count}人", "peopleCountPlural": "{count}人", "lastActivity": "最終: {time}", "unreadNew": "新着 {count}件", "tapToOpen": "タップして会話を開く", "unknownUser": "不明なユーザー" },
+  "zh": { "sold": "已售", "peopleCount": "{count} 人", "peopleCountPlural": "{count} 人", "lastActivity": "最近：{time}", "unreadNew": "{count} 条新消息", "tapToOpen": "点按打开对话", "unknownUser": "未知用户" },
+  "ko": { "sold": "판매됨", "peopleCount": "{count}명", "peopleCountPlural": "{count}명", "lastActivity": "마지막: {time}", "unreadNew": "새 메시지 {count}개", "tapToOpen": "탭하여 대화 열기", "unknownUser": "알 수 없는 사용자" }
+}
+</i18n>

--- a/app/components/exchange/messages/MeetingSpotSuggestions.vue
+++ b/app/components/exchange/messages/MeetingSpotSuggestions.vue
@@ -1,0 +1,322 @@
+<script setup lang="ts">
+  import type { MeetingSpot } from '~~/server/utils/exchange/meetingSpots';
+
+  const { t } = useI18n();
+
+  interface Props {
+    sellerLat: number;
+    sellerLon: number;
+    conversationId: string;
+  }
+
+  const props = defineProps<Props>();
+  const emit = defineEmits<{
+    (e: 'spotSuggested'): void;
+  }>();
+
+  const { location: buyerLocation, loading: locLoading, error: locError, requestBrowserLocation } = useBuyerLocation();
+  const { sendMessage } = useMessages();
+
+  interface MeetingSpotsResponse {
+    midpoint: { lat: number; lon: number };
+    suggestions: MeetingSpot[];
+  }
+
+  const spots = ref<MeetingSpotsResponse | null>(null);
+  const loading = ref(false);
+  const fetchError = ref(false);
+  const sendingSpotIndex = ref<number | null>(null);
+
+  async function suggestSpots() {
+    if (!buyerLocation.value) return;
+
+    loading.value = true;
+    fetchError.value = false;
+
+    try {
+      spots.value = await $fetch<MeetingSpotsResponse>('/api/exchange/camino/meeting-spots', {
+        method: 'POST',
+        body: {
+          buyerLat: buyerLocation.value.lat,
+          buyerLon: buyerLocation.value.lon,
+          sellerLat: props.sellerLat,
+          sellerLon: props.sellerLon,
+        },
+      });
+    } catch {
+      fetchError.value = true;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function sendSpotMessage(spot: MeetingSpot, index: number) {
+    sendingSpotIndex.value = index;
+    const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${spot.lat},${spot.lon}`;
+    const content = `${t('messagePrefix')}: ${spot.name}${spot.address ? `\n${spot.address}` : ''}\n${mapsUrl}`;
+
+    const success = await sendMessage(props.conversationId, content);
+    sendingSpotIndex.value = null;
+
+    if (success) {
+      emit('spotSuggested');
+    }
+  }
+
+  function getMapsUrl(spot: MeetingSpot): string {
+    return `https://www.google.com/maps/search/?api=1&query=${spot.lat},${spot.lon}`;
+  }
+</script>
+
+<template>
+  <div class="space-y-3">
+    <!-- Need location first -->
+    <div v-if="!buyerLocation && !spots" class="card bg-base-200 shadow-sm">
+      <div class="card-body py-4 items-center text-center gap-2">
+        <p class="text-sm text-base-content/70">{{ t('shareLocationPrompt') }}</p>
+        <button class="btn btn-sm btn-secondary" :disabled="locLoading" @click="requestBrowserLocation">
+          <span v-if="locLoading" class="loading loading-spinner loading-xs"></span>
+          <i v-else class="fas fa-location-dot"></i>
+          {{ t('useMyLocation') }}
+        </button>
+        <p v-if="locError" class="text-xs text-error">{{ locError }}</p>
+      </div>
+    </div>
+
+    <!-- Trigger button (location available, spots not yet loaded) -->
+    <button
+      v-else-if="buyerLocation && !spots && !loading"
+      class="btn btn-outline btn-secondary btn-block"
+      @click="suggestSpots"
+    >
+      <i class="fas fa-location-dot"></i>
+      {{ t('suggestMeetingSpot') }}
+    </button>
+
+    <!-- Loading -->
+    <div v-if="loading" class="card bg-base-200">
+      <div class="card-body py-4">
+        <div class="flex items-center gap-2">
+          <span class="loading loading-spinner loading-sm text-secondary"></span>
+          <span class="text-sm text-base-content/70">{{ t('finding') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div v-if="fetchError" class="alert alert-warning text-sm">
+      <i class="fas fa-triangle-exclamation"></i>
+      <span>{{ t('fetchError') }}</span>
+    </div>
+
+    <!-- Results -->
+    <div v-if="spots && spots.suggestions.length > 0" class="card bg-base-200 shadow-sm">
+      <div class="card-body gap-3">
+        <h3 class="card-title text-base">
+          <i class="fas fa-hand text-secondary"></i>
+          {{ t('suggestedTitle') }}
+        </h3>
+        <p class="text-xs text-base-content/60">
+          {{ t('suggestedSubtitle') }}
+        </p>
+
+        <div v-for="(spot, i) in spots.suggestions" :key="i" class="flex items-start gap-3 p-3 bg-base-100 rounded-lg">
+          <div class="badge badge-secondary badge-sm mt-1">{{ i + 1 }}</div>
+          <div class="flex-1 min-w-0">
+            <p class="font-semibold text-sm">{{ spot.name }}</p>
+            <p v-if="spot.address" class="text-xs text-base-content/60 truncate">
+              {{ spot.address }}
+            </p>
+            <p v-if="spot.buyerDriveTime || spot.sellerDriveTime" class="text-xs text-base-content/70 mt-1">
+              <i class="fas fa-clock inline"></i>
+              <template v-if="spot.buyerDriveTime">{{ t('fromYou', { time: spot.buyerDriveTime }) }}</template>
+              <template v-if="spot.buyerDriveTime && spot.sellerDriveTime"> · </template>
+              <template v-if="spot.sellerDriveTime">{{ t('fromSeller', { time: spot.sellerDriveTime }) }}</template>
+            </p>
+          </div>
+          <div class="flex flex-col gap-1 shrink-0">
+            <a
+              :href="getMapsUrl(spot)"
+              target="_blank"
+              rel="noopener"
+              class="btn btn-xs btn-ghost"
+              :title="t('openInMaps')"
+            >
+              <i class="fas fa-arrow-up-right-from-square"></i>
+            </a>
+            <button
+              class="btn btn-xs btn-secondary"
+              :disabled="sendingSpotIndex === i"
+              :title="t('sendInConversation')"
+              @click="sendSpotMessage(spot, i)"
+            >
+              <span v-if="sendingSpotIndex === i" class="loading loading-spinner loading-xs"></span>
+              <i v-else class="fas fa-paper-plane"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- No results -->
+    <div v-if="spots && spots.suggestions.length === 0" class="alert alert-info text-sm">
+      <i class="fas fa-circle-info"></i>
+      <span>{{ t('noResults') }}</span>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "shareLocationPrompt": "Share your location to find a safe meeting spot",
+    "useMyLocation": "Use My Location",
+    "suggestMeetingSpot": "Suggest Meeting Spot",
+    "finding": "Finding safe meeting spots...",
+    "fetchError": "Could not find meeting spots. Try again later.",
+    "suggestedTitle": "Suggested Meeting Spots",
+    "suggestedSubtitle": "Safe, public locations roughly halfway between you and the seller. Your exact address is never shared.",
+    "fromYou": "{time} from you",
+    "fromSeller": "{time} from seller",
+    "openInMaps": "Open in Maps",
+    "sendInConversation": "Send this spot in the conversation",
+    "noResults": "No meeting spots found in this area. You may be too far apart for a halfway meeting point.",
+    "messagePrefix": "Suggested meeting spot"
+  },
+  "es": {
+    "shareLocationPrompt": "Comparte tu ubicación para encontrar un punto de encuentro seguro",
+    "useMyLocation": "Usar mi ubicación",
+    "suggestMeetingSpot": "Sugerir punto de encuentro",
+    "finding": "Buscando puntos de encuentro seguros...",
+    "fetchError": "No se pudieron encontrar puntos de encuentro. Inténtalo más tarde.",
+    "suggestedTitle": "Puntos de encuentro sugeridos",
+    "suggestedSubtitle": "Lugares públicos y seguros aproximadamente a medio camino entre tú y el vendedor. Tu dirección exacta nunca se comparte.",
+    "fromYou": "{time} desde tu ubicación",
+    "fromSeller": "{time} desde el vendedor",
+    "openInMaps": "Abrir en Maps",
+    "sendInConversation": "Enviar este punto en la conversación",
+    "noResults": "No se encontraron puntos de encuentro en esta zona. Puede que estéis demasiado lejos para un punto a medio camino.",
+    "messagePrefix": "Punto de encuentro sugerido"
+  },
+  "fr": {
+    "shareLocationPrompt": "Partagez votre position pour trouver un lieu de rendez-vous sûr",
+    "useMyLocation": "Utiliser ma position",
+    "suggestMeetingSpot": "Suggérer un lieu de rendez-vous",
+    "finding": "Recherche de lieux de rendez-vous sûrs...",
+    "fetchError": "Impossible de trouver des lieux de rendez-vous. Réessayez plus tard.",
+    "suggestedTitle": "Lieux de rendez-vous suggérés",
+    "suggestedSubtitle": "Lieux publics et sûrs à peu près à mi-chemin entre vous et le vendeur. Votre adresse exacte n'est jamais partagée.",
+    "fromYou": "{time} depuis chez vous",
+    "fromSeller": "{time} depuis le vendeur",
+    "openInMaps": "Ouvrir dans Maps",
+    "sendInConversation": "Envoyer ce lieu dans la conversation",
+    "noResults": "Aucun lieu de rendez-vous trouvé dans cette zone. Vous êtes peut-être trop éloignés pour un point à mi-chemin.",
+    "messagePrefix": "Lieu de rendez-vous suggéré"
+  },
+  "de": {
+    "shareLocationPrompt": "Teile deinen Standort, um einen sicheren Treffpunkt zu finden",
+    "useMyLocation": "Meinen Standort verwenden",
+    "suggestMeetingSpot": "Treffpunkt vorschlagen",
+    "finding": "Sichere Treffpunkte werden gesucht...",
+    "fetchError": "Es konnten keine Treffpunkte gefunden werden. Bitte später erneut versuchen.",
+    "suggestedTitle": "Vorgeschlagene Treffpunkte",
+    "suggestedSubtitle": "Sichere, öffentliche Orte ungefähr auf halbem Weg zwischen dir und dem Verkäufer. Deine genaue Adresse wird nie geteilt.",
+    "fromYou": "{time} von dir",
+    "fromSeller": "{time} vom Verkäufer",
+    "openInMaps": "In Maps öffnen",
+    "sendInConversation": "Diesen Treffpunkt in der Unterhaltung senden",
+    "noResults": "In diesem Gebiet wurden keine Treffpunkte gefunden. Ihr seid möglicherweise zu weit voneinander entfernt für einen Treffpunkt auf halbem Weg.",
+    "messagePrefix": "Vorgeschlagener Treffpunkt"
+  },
+  "it": {
+    "shareLocationPrompt": "Condividi la tua posizione per trovare un punto d'incontro sicuro",
+    "useMyLocation": "Usa la mia posizione",
+    "suggestMeetingSpot": "Suggerisci punto d'incontro",
+    "finding": "Ricerca di punti d'incontro sicuri...",
+    "fetchError": "Impossibile trovare punti d'incontro. Riprova più tardi.",
+    "suggestedTitle": "Punti d'incontro suggeriti",
+    "suggestedSubtitle": "Luoghi pubblici e sicuri all'incirca a metà strada tra te e il venditore. Il tuo indirizzo esatto non viene mai condiviso.",
+    "fromYou": "{time} da te",
+    "fromSeller": "{time} dal venditore",
+    "openInMaps": "Apri in Maps",
+    "sendInConversation": "Invia questo punto nella conversazione",
+    "noResults": "Nessun punto d'incontro trovato in questa zona. Potreste essere troppo distanti per un punto a metà strada.",
+    "messagePrefix": "Punto d'incontro suggerito"
+  },
+  "pt": {
+    "shareLocationPrompt": "Compartilhe sua localização para encontrar um ponto de encontro seguro",
+    "useMyLocation": "Usar minha localização",
+    "suggestMeetingSpot": "Sugerir ponto de encontro",
+    "finding": "Procurando pontos de encontro seguros...",
+    "fetchError": "Não foi possível encontrar pontos de encontro. Tente novamente mais tarde.",
+    "suggestedTitle": "Pontos de encontro sugeridos",
+    "suggestedSubtitle": "Locais públicos e seguros aproximadamente a meio caminho entre você e o vendedor. Seu endereço exato nunca é compartilhado.",
+    "fromYou": "{time} de você",
+    "fromSeller": "{time} do vendedor",
+    "openInMaps": "Abrir no Maps",
+    "sendInConversation": "Enviar este ponto na conversa",
+    "noResults": "Nenhum ponto de encontro encontrado nesta área. Vocês podem estar distantes demais para um ponto a meio caminho.",
+    "messagePrefix": "Ponto de encontro sugerido"
+  },
+  "ru": {
+    "shareLocationPrompt": "Поделитесь своим местоположением, чтобы найти безопасное место встречи",
+    "useMyLocation": "Использовать моё местоположение",
+    "suggestMeetingSpot": "Предложить место встречи",
+    "finding": "Поиск безопасных мест встречи...",
+    "fetchError": "Не удалось найти места встречи. Повторите попытку позже.",
+    "suggestedTitle": "Предлагаемые места встречи",
+    "suggestedSubtitle": "Безопасные общественные места примерно на полпути между вами и продавцом. Ваш точный адрес никогда не передаётся.",
+    "fromYou": "{time} от вас",
+    "fromSeller": "{time} от продавца",
+    "openInMaps": "Открыть в Maps",
+    "sendInConversation": "Отправить это место в переписке",
+    "noResults": "В этом районе места встречи не найдены. Возможно, вы слишком далеко друг от друга для точки на полпути.",
+    "messagePrefix": "Предлагаемое место встречи"
+  },
+  "ja": {
+    "shareLocationPrompt": "安全な待ち合わせ場所を探すために位置情報を共有してください",
+    "useMyLocation": "現在地を使用",
+    "suggestMeetingSpot": "待ち合わせ場所を提案",
+    "finding": "安全な待ち合わせ場所を検索中...",
+    "fetchError": "待ち合わせ場所が見つかりませんでした。後でもう一度お試しください。",
+    "suggestedTitle": "おすすめの待ち合わせ場所",
+    "suggestedSubtitle": "あなたと出品者のほぼ中間にある安全で公共の場所です。正確な住所が共有されることはありません。",
+    "fromYou": "あなたから{time}",
+    "fromSeller": "出品者から{time}",
+    "openInMaps": "Mapsで開く",
+    "sendInConversation": "この場所を会話で送信",
+    "noResults": "このエリアでは待ち合わせ場所が見つかりませんでした。中間地点を取るには距離が離れすぎている可能性があります。",
+    "messagePrefix": "おすすめの待ち合わせ場所"
+  },
+  "zh": {
+    "shareLocationPrompt": "共享您的位置以寻找安全的见面地点",
+    "useMyLocation": "使用我的位置",
+    "suggestMeetingSpot": "建议见面地点",
+    "finding": "正在查找安全的见面地点...",
+    "fetchError": "未能找到见面地点。请稍后再试。",
+    "suggestedTitle": "建议的见面地点",
+    "suggestedSubtitle": "位于您和卖家之间大约中点的安全公共场所。您的确切地址绝不会被共享。",
+    "fromYou": "距您 {time}",
+    "fromSeller": "距卖家 {time}",
+    "openInMaps": "在 Maps 中打开",
+    "sendInConversation": "在对话中发送此地点",
+    "noResults": "此区域未找到见面地点。你们之间的距离可能太远，无法找到中间见面点。",
+    "messagePrefix": "建议的见面地点"
+  },
+  "ko": {
+    "shareLocationPrompt": "안전한 만남 장소를 찾으려면 위치를 공유하세요",
+    "useMyLocation": "내 위치 사용",
+    "suggestMeetingSpot": "만남 장소 제안",
+    "finding": "안전한 만남 장소를 찾는 중...",
+    "fetchError": "만남 장소를 찾을 수 없습니다. 나중에 다시 시도하세요.",
+    "suggestedTitle": "추천 만남 장소",
+    "suggestedSubtitle": "당신과 판매자 사이 대략 중간 지점에 있는 안전한 공공장소입니다. 정확한 주소는 절대 공유되지 않습니다.",
+    "fromYou": "내 위치에서 {time}",
+    "fromSeller": "판매자 위치에서 {time}",
+    "openInMaps": "Maps에서 열기",
+    "sendInConversation": "이 장소를 대화에 보내기",
+    "noResults": "이 지역에서 만남 장소를 찾지 못했습니다. 중간 지점을 잡기에는 거리가 너무 멀 수 있습니다.",
+    "messagePrefix": "추천 만남 장소"
+  }
+}
+</i18n>

--- a/app/components/exchange/messages/MeetingSpotSuggestions.vue
+++ b/app/components/exchange/messages/MeetingSpotSuggestions.vue
@@ -138,7 +138,7 @@
             <a
               :href="getMapsUrl(spot)"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
               class="btn btn-xs btn-ghost"
               :title="t('openInMaps')"
             >

--- a/app/components/exchange/messages/MessageAttachmentThumbnail.vue
+++ b/app/components/exchange/messages/MessageAttachmentThumbnail.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="relative">
+    <!-- Expired / deleted state -->
+    <div
+      v-if="state === 'expired'"
+      class="flex flex-col items-center justify-center gap-1 w-full aspect-square max-w-[180px] rounded-lg bg-base-200/80 text-base-content/70 p-2 text-center"
+    >
+      <i class="fas fa-clock text-xl"></i>
+      <p class="text-[10px] leading-tight">
+        {{ t('expired') }}
+      </p>
+    </div>
+
+    <!-- Loading state -->
+    <div
+      v-else-if="state === 'loading'"
+      class="flex items-center justify-center w-full aspect-square max-w-[180px] rounded-lg bg-base-200/60"
+    >
+      <span class="loading loading-spinner loading-sm"></span>
+    </div>
+
+    <!-- OK state -->
+    <button
+      v-else
+      type="button"
+      class="block w-full max-w-[180px] rounded-lg overflow-hidden border border-current/10 bg-base-200 focus:outline-none focus:ring-2 focus:ring-primary"
+      @click="openLightbox"
+    >
+      <img
+        :src="signedUrl!"
+        :alt="t('attachmentAlt', { id: attachment.id })"
+        class="w-full h-auto max-h-[240px] object-cover block"
+        loading="lazy"
+        @error="onImageError"
+      />
+    </button>
+
+    <!-- Lightbox modal -->
+    <dialog v-if="lightboxOpen" ref="dialogRef" class="modal modal-open">
+      <div class="modal-box max-w-4xl bg-base-100 p-2">
+        <img v-if="signedUrl" :src="signedUrl" :alt="t('attachmentAlt', { id: attachment.id })" class="w-full h-auto rounded" />
+        <div class="modal-action mt-2">
+          <button type="button" class="btn btn-sm" @click="closeLightbox">{{ t('close') }}</button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button type="button" @click="closeLightbox">{{ t('close') }}</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { MessageAttachment } from '~/composables/useMessages';
+
+  const { t } = useI18n();
+
+  interface Props {
+    attachment: MessageAttachment;
+  }
+
+  const props = defineProps<Props>();
+
+  const { getSignedUrl } = useMessageAttachments();
+
+  type State = 'loading' | 'ok' | 'expired';
+  const state = ref<State>('loading');
+  const signedUrl = ref<string | null>(null);
+  const lightboxOpen = ref(false);
+  const dialogRef = ref<HTMLDialogElement | null>(null);
+
+  const isExpiredByDate = computed(() => {
+    const expiresAt = new Date(props.attachment.expires_at).getTime();
+    return Number.isFinite(expiresAt) && expiresAt <= Date.now();
+  });
+
+  const onImageError = () => {
+    // Storage object is gone even though the DB row still exists.
+    // Treat as the end-of-life state, no error toast.
+    state.value = 'expired';
+  };
+
+  const openLightbox = () => {
+    lightboxOpen.value = true;
+  };
+
+  const closeLightbox = () => {
+    lightboxOpen.value = false;
+  };
+
+  onMounted(async () => {
+    if (isExpiredByDate.value) {
+      state.value = 'expired';
+      return;
+    }
+
+    const url = await getSignedUrl(props.attachment.storage_path);
+    if (!url) {
+      state.value = 'expired';
+      return;
+    }
+    signedUrl.value = url;
+    state.value = 'ok';
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": { "expired": "Images in chats are only stored for 1 year — this image has automatically been deleted.", "attachmentAlt": "Attachment {id}", "close": "Close" },
+  "es": { "expired": "Las imágenes en los chats solo se almacenan durante 1 año — esta imagen se ha eliminado automáticamente.", "attachmentAlt": "Adjunto {id}", "close": "Cerrar" },
+  "fr": { "expired": "Les images dans les discussions ne sont conservées qu'un an — cette image a été supprimée automatiquement.", "attachmentAlt": "Pièce jointe {id}", "close": "Fermer" },
+  "de": { "expired": "Bilder in Chats werden nur 1 Jahr gespeichert — dieses Bild wurde automatisch gelöscht.", "attachmentAlt": "Anhang {id}", "close": "Schließen" },
+  "it": { "expired": "Le immagini nelle chat vengono conservate solo per 1 anno — questa immagine è stata eliminata automaticamente.", "attachmentAlt": "Allegato {id}", "close": "Chiudi" },
+  "pt": { "expired": "As imagens nos chats são armazenadas apenas por 1 ano — esta imagem foi excluída automaticamente.", "attachmentAlt": "Anexo {id}", "close": "Fechar" },
+  "ru": { "expired": "Изображения в чатах хранятся только 1 год — это изображение было автоматически удалено.", "attachmentAlt": "Вложение {id}", "close": "Закрыть" },
+  "ja": { "expired": "チャット内の画像は1年間のみ保存されます — この画像は自動的に削除されました。", "attachmentAlt": "添付ファイル {id}", "close": "閉じる" },
+  "zh": { "expired": "聊天中的图片仅保存1年 — 此图片已被自动删除。", "attachmentAlt": "附件 {id}", "close": "关闭" },
+  "ko": { "expired": "채팅의 이미지는 1년 동안만 저장됩니다 — 이 이미지는 자동으로 삭제되었습니다.", "attachmentAlt": "첨부파일 {id}", "close": "닫기" }
+}
+</i18n>

--- a/app/components/exchange/messages/MessageComposer.vue
+++ b/app/components/exchange/messages/MessageComposer.vue
@@ -1,0 +1,417 @@
+<template>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body p-4">
+      <!-- Moderation Warning -->
+      <div v-if="moderationWarning" class="alert alert-warning mb-4">
+        <i class="fas fa-triangle-exclamation"></i>
+        <span>{{ moderationWarning }}</span>
+      </div>
+
+      <!-- Staged attachment previews -->
+      <div v-if="stagedAttachments.length > 0" class="flex flex-wrap gap-2 mb-3">
+        <div
+          v-for="(staged, index) in stagedAttachments"
+          :key="staged.id"
+          class="relative w-20 h-20 rounded-lg overflow-hidden border border-base-300 bg-base-200"
+        >
+          <img :src="staged.previewUrl" :alt="staged.file.name" class="w-full h-full object-cover" />
+          <button
+            type="button"
+            class="btn btn-circle btn-xs absolute top-1 right-1 bg-base-100/90 border-none"
+            :aria-label="t('removeImage')"
+            @click="removeAttachment(index)"
+          >
+            <i class="fas fa-xmark"></i>
+          </button>
+        </div>
+        <div v-if="preparingAttachments" class="w-20 h-20 flex items-center justify-center">
+          <span class="loading loading-spinner loading-sm"></span>
+        </div>
+      </div>
+
+      <!-- Message Input -->
+      <div class="fieldset">
+        <label class="fieldset-legend">
+          <span class="sr-only">{{ t('messageLabel') }}</span>
+        </label>
+        <textarea
+          v-model="message"
+          :disabled="sending"
+          class="textarea textarea-bordered w-full"
+          :class="{ 'textarea-error': hasError }"
+          :placeholder="t('placeholder')"
+          rows="4"
+          maxlength="2000"
+          @input="handleInput"
+          @keydown.ctrl.enter="handleSend"
+          @keydown.meta.enter="handleSend"
+        />
+      </div>
+
+      <!-- Hidden file input -->
+      <input
+        ref="fileInputRef"
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/heic"
+        multiple
+        class="hidden"
+        @change="onFilesSelected"
+      />
+
+      <!-- Footer with character count and send button -->
+      <div class="flex items-center justify-between mt-2 gap-2">
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm btn-circle"
+            :disabled="sending || preparingAttachments || stagedAttachments.length >= MESSAGE_ATTACHMENT_MAX_COUNT"
+            :aria-label="t('attachImage')"
+            @click="fileInputRef?.click()"
+          >
+            <i class="fas fa-paperclip"></i>
+          </button>
+          <div class="text-sm" :class="characterCountColor">
+            {{ message.length }}/2000
+            <span v-if="message.length > 1900" class="ml-2 text-warning"> ({{ t('charsLeft', { count: 2000 - message.length }) }}) </span>
+          </div>
+        </div>
+
+        <button
+          class="btn btn-primary"
+          :class="{ 'btn-disabled': !canSend }"
+          :disabled="!canSend || sending || preparingAttachments"
+          @click="handleSend"
+        >
+          <i v-if="sending" class="fas fa-arrows-rotate animate-spin"></i>
+          <i v-else class="fas fa-paper-plane"></i>
+          {{ t('send') }}
+        </button>
+      </div>
+
+      <!-- Helper text -->
+      <div class="text-xs text-base-content/60 mt-2">
+        {{ t('helperShortcut.before') }} <kbd class="kbd kbd-xs">{{ t('helperShortcut.ctrl') }}</kbd> +
+        <kbd class="kbd kbd-xs">{{ t('helperShortcut.enter') }}</kbd> {{ t('helperShortcut.after') }}
+        <span class="ml-2">{{ t('helperFormatting', { count: MESSAGE_ATTACHMENT_MAX_COUNT }) }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { checkMessageContent, validateMessageLength, getModerationWarning } from '~/utils/moderation';
+
+  const { t } = useI18n();
+
+  interface Props {
+    conversationId: string;
+    disabled?: boolean;
+    listingId?: string;
+    messageCount?: number;
+  }
+
+  interface Emits {
+    (e: 'sent'): void;
+  }
+
+  const props = defineProps<Props>();
+  const emit = defineEmits<Emits>();
+
+  const { sendMessage, sending } = useMessages();
+  const { prepareAttachment, validateBatch, MESSAGE_ATTACHMENT_MAX_COUNT } = useMessageAttachments();
+  const toast = useToast();
+
+  const message = ref('');
+  const moderationWarning = ref('');
+  const hasError = ref(false);
+  const fileInputRef = ref<HTMLInputElement | null>(null);
+
+  interface StagedAttachment {
+    id: string;
+    file: File;
+    width: number;
+    height: number;
+    previewUrl: string;
+  }
+
+  const stagedAttachments = ref<StagedAttachment[]>([]);
+  const preparingAttachments = ref(false);
+
+  // Computed properties
+  const canSend = computed(() => {
+    if (props.disabled || sending.value) return false;
+
+    const trimmed = message.value.trim();
+    return trimmed.length >= 2 && trimmed.length <= 2000;
+  });
+
+  const characterCountColor = computed(() => {
+    const length = message.value.length;
+    if (length > 1950) return 'text-error';
+    if (length > 1800) return 'text-warning';
+    return 'text-base-content/60';
+  });
+
+  // Methods
+  const handleInput = () => {
+    hasError.value = false;
+    moderationWarning.value = '';
+
+    // Real-time validation
+    const validation = validateMessageLength(message.value);
+    if (!validation.valid && message.value.length > 0) {
+      hasError.value = true;
+    }
+
+    // Check for moderation issues
+    if (message.value.trim().length > 10) {
+      const moderation = checkMessageContent(message.value);
+      if (!moderation.isClean) {
+        moderationWarning.value = getModerationWarning(moderation.issues);
+      }
+    }
+  };
+
+  const onFilesSelected = async (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    const files = Array.from(input.files || []);
+    // Reset input so selecting the same file again still fires change.
+    input.value = '';
+
+    if (files.length === 0) return;
+
+    const remainingSlots = MESSAGE_ATTACHMENT_MAX_COUNT - stagedAttachments.value.length;
+    if (remainingSlots <= 0) {
+      toast.add({
+        title: t('tooManyImagesTitle'),
+        description: t('tooManyImagesDesc', { count: MESSAGE_ATTACHMENT_MAX_COUNT }),
+        color: 'warning',
+      });
+      return;
+    }
+    const filesToProcess = files.slice(0, remainingSlots);
+
+    const errors = validateBatch(filesToProcess);
+    if (errors.length > 0) {
+      for (const err of errors) {
+        toast.add({ title: t('invalidImageTitle'), description: err, color: 'error' });
+      }
+      return;
+    }
+
+    preparingAttachments.value = true;
+    try {
+      for (const file of filesToProcess) {
+        try {
+          const prepared = await prepareAttachment(file);
+          stagedAttachments.value.push({
+            id: crypto.randomUUID(),
+            file: prepared.file,
+            width: prepared.width,
+            height: prepared.height,
+            previewUrl: URL.createObjectURL(prepared.file),
+          });
+        } catch (err: any) {
+          toast.add({
+            title: t('couldNotAttachTitle'),
+            description: err?.message || t('unknownPrepareError'),
+            color: 'error',
+          });
+        }
+      }
+    } finally {
+      preparingAttachments.value = false;
+    }
+  };
+
+  const removeAttachment = (index: number) => {
+    const [removed] = stagedAttachments.value.splice(index, 1);
+    if (removed) URL.revokeObjectURL(removed.previewUrl);
+  };
+
+  const clearStaged = () => {
+    for (const s of stagedAttachments.value) URL.revokeObjectURL(s.previewUrl);
+    stagedAttachments.value = [];
+  };
+
+  const handleSend = async () => {
+    if (!canSend.value) return;
+
+    const attachments = stagedAttachments.value.map((s) => ({
+      file: s.file,
+      width: s.width,
+      height: s.height,
+    }));
+
+    const success = await sendMessage(props.conversationId, message.value, {
+      conversation: { listing_id: props.listingId },
+      existingMessageCount: props.messageCount,
+      attachments: attachments.length > 0 ? attachments : undefined,
+    });
+
+    if (success) {
+      message.value = '';
+      moderationWarning.value = '';
+      hasError.value = false;
+      clearStaged();
+      emit('sent');
+    }
+  };
+
+  onBeforeUnmount(() => clearStaged());
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "messageLabel": "Message",
+    "placeholder": "Type your message... (markdown supported)",
+    "send": "Send",
+    "attachImage": "Attach image",
+    "removeImage": "Remove image",
+    "charsLeft": "{count} left",
+    "helperShortcut": { "before": "Press", "ctrl": "Ctrl", "enter": "Enter", "after": "to send." },
+    "helperFormatting": "**bold**, *italic*, lists, and links supported. Images up to 1 MB, max {count}.",
+    "tooManyImagesTitle": "Too many images",
+    "tooManyImagesDesc": "You can attach at most {count} images per message.",
+    "invalidImageTitle": "Invalid image",
+    "couldNotAttachTitle": "Could not attach image",
+    "unknownPrepareError": "Unknown error preparing image."
+  },
+  "es": {
+    "messageLabel": "Mensaje",
+    "placeholder": "Escribe tu mensaje... (compatible con markdown)",
+    "send": "Enviar",
+    "attachImage": "Adjuntar imagen",
+    "removeImage": "Eliminar imagen",
+    "charsLeft": "quedan {count}",
+    "helperShortcut": { "before": "Pulsa", "ctrl": "Ctrl", "enter": "Intro", "after": "para enviar." },
+    "helperFormatting": "Compatible con **negrita**, *cursiva*, listas y enlaces. Imágenes de hasta 1 MB, máximo {count}.",
+    "tooManyImagesTitle": "Demasiadas imágenes",
+    "tooManyImagesDesc": "Puedes adjuntar como máximo {count} imágenes por mensaje.",
+    "invalidImageTitle": "Imagen no válida",
+    "couldNotAttachTitle": "No se pudo adjuntar la imagen",
+    "unknownPrepareError": "Error desconocido al preparar la imagen."
+  },
+  "fr": {
+    "messageLabel": "Message",
+    "placeholder": "Tapez votre message... (markdown pris en charge)",
+    "send": "Envoyer",
+    "attachImage": "Joindre une image",
+    "removeImage": "Supprimer l'image",
+    "charsLeft": "{count} restants",
+    "helperShortcut": { "before": "Appuyez sur", "ctrl": "Ctrl", "enter": "Entrée", "after": "pour envoyer." },
+    "helperFormatting": "**gras**, *italique*, listes et liens pris en charge. Images jusqu'à 1 Mo, max {count}.",
+    "tooManyImagesTitle": "Trop d'images",
+    "tooManyImagesDesc": "Vous pouvez joindre au maximum {count} images par message.",
+    "invalidImageTitle": "Image non valide",
+    "couldNotAttachTitle": "Impossible de joindre l'image",
+    "unknownPrepareError": "Erreur inconnue lors de la préparation de l'image."
+  },
+  "de": {
+    "messageLabel": "Nachricht",
+    "placeholder": "Gib deine Nachricht ein... (Markdown unterstützt)",
+    "send": "Senden",
+    "attachImage": "Bild anhängen",
+    "removeImage": "Bild entfernen",
+    "charsLeft": "{count} übrig",
+    "helperShortcut": { "before": "Drücke", "ctrl": "Strg", "enter": "Enter", "after": "zum Senden." },
+    "helperFormatting": "**fett**, *kursiv*, Listen und Links unterstützt. Bilder bis 1 MB, max. {count}.",
+    "tooManyImagesTitle": "Zu viele Bilder",
+    "tooManyImagesDesc": "Du kannst höchstens {count} Bilder pro Nachricht anhängen.",
+    "invalidImageTitle": "Ungültiges Bild",
+    "couldNotAttachTitle": "Bild konnte nicht angehängt werden",
+    "unknownPrepareError": "Unbekannter Fehler beim Vorbereiten des Bildes."
+  },
+  "it": {
+    "messageLabel": "Messaggio",
+    "placeholder": "Scrivi il tuo messaggio... (markdown supportato)",
+    "send": "Invia",
+    "attachImage": "Allega immagine",
+    "removeImage": "Rimuovi immagine",
+    "charsLeft": "{count} rimasti",
+    "helperShortcut": { "before": "Premi", "ctrl": "Ctrl", "enter": "Invio", "after": "per inviare." },
+    "helperFormatting": "**grassetto**, *corsivo*, elenchi e link supportati. Immagini fino a 1 MB, max {count}.",
+    "tooManyImagesTitle": "Troppe immagini",
+    "tooManyImagesDesc": "Puoi allegare al massimo {count} immagini per messaggio.",
+    "invalidImageTitle": "Immagine non valida",
+    "couldNotAttachTitle": "Impossibile allegare l'immagine",
+    "unknownPrepareError": "Errore sconosciuto durante la preparazione dell'immagine."
+  },
+  "pt": {
+    "messageLabel": "Mensagem",
+    "placeholder": "Digite sua mensagem... (markdown suportado)",
+    "send": "Enviar",
+    "attachImage": "Anexar imagem",
+    "removeImage": "Remover imagem",
+    "charsLeft": "{count} restantes",
+    "helperShortcut": { "before": "Pressione", "ctrl": "Ctrl", "enter": "Enter", "after": "para enviar." },
+    "helperFormatting": "**negrito**, *itálico*, listas e links suportados. Imagens de até 1 MB, máx {count}.",
+    "tooManyImagesTitle": "Imagens demais",
+    "tooManyImagesDesc": "Você pode anexar no máximo {count} imagens por mensagem.",
+    "invalidImageTitle": "Imagem inválida",
+    "couldNotAttachTitle": "Não foi possível anexar a imagem",
+    "unknownPrepareError": "Erro desconhecido ao preparar a imagem."
+  },
+  "ru": {
+    "messageLabel": "Сообщение",
+    "placeholder": "Введите ваше сообщение... (поддерживается markdown)",
+    "send": "Отправить",
+    "attachImage": "Прикрепить изображение",
+    "removeImage": "Удалить изображение",
+    "charsLeft": "осталось {count}",
+    "helperShortcut": { "before": "Нажмите", "ctrl": "Ctrl", "enter": "Enter", "after": "для отправки." },
+    "helperFormatting": "Поддерживаются **жирный**, *курсив*, списки и ссылки. Изображения до 1 МБ, максимум {count}.",
+    "tooManyImagesTitle": "Слишком много изображений",
+    "tooManyImagesDesc": "К одному сообщению можно прикрепить не более {count} изображений.",
+    "invalidImageTitle": "Недопустимое изображение",
+    "couldNotAttachTitle": "Не удалось прикрепить изображение",
+    "unknownPrepareError": "Неизвестная ошибка при подготовке изображения."
+  },
+  "ja": {
+    "messageLabel": "メッセージ",
+    "placeholder": "メッセージを入力...（マークダウン対応）",
+    "send": "送信",
+    "attachImage": "画像を添付",
+    "removeImage": "画像を削除",
+    "charsLeft": "残り {count}",
+    "helperShortcut": { "before": "", "ctrl": "Ctrl", "enter": "Enter", "after": "で送信します。" },
+    "helperFormatting": "**太字**、*斜体*、リスト、リンクに対応。画像は最大1 MB、最大{count}枚。",
+    "tooManyImagesTitle": "画像が多すぎます",
+    "tooManyImagesDesc": "1件のメッセージに添付できる画像は最大{count}枚です。",
+    "invalidImageTitle": "無効な画像",
+    "couldNotAttachTitle": "画像を添付できませんでした",
+    "unknownPrepareError": "画像の準備中に不明なエラーが発生しました。"
+  },
+  "zh": {
+    "messageLabel": "消息",
+    "placeholder": "输入您的消息...（支持 markdown）",
+    "send": "发送",
+    "attachImage": "添加图片",
+    "removeImage": "移除图片",
+    "charsLeft": "剩余 {count}",
+    "helperShortcut": { "before": "按", "ctrl": "Ctrl", "enter": "Enter", "after": "发送。" },
+    "helperFormatting": "支持 **粗体**、*斜体*、列表和链接。图片最大 1 MB，最多 {count} 张。",
+    "tooManyImagesTitle": "图片过多",
+    "tooManyImagesDesc": "每条消息最多可附加 {count} 张图片。",
+    "invalidImageTitle": "无效图片",
+    "couldNotAttachTitle": "无法附加图片",
+    "unknownPrepareError": "准备图片时发生未知错误。"
+  },
+  "ko": {
+    "messageLabel": "메시지",
+    "placeholder": "메시지를 입력하세요... (마크다운 지원)",
+    "send": "보내기",
+    "attachImage": "이미지 첨부",
+    "removeImage": "이미지 제거",
+    "charsLeft": "{count}자 남음",
+    "helperShortcut": { "before": "", "ctrl": "Ctrl", "enter": "Enter", "after": "을(를) 눌러 보냅니다." },
+    "helperFormatting": "**굵게**, *기울임*, 목록, 링크를 지원합니다. 이미지는 최대 1 MB, 최대 {count}개.",
+    "tooManyImagesTitle": "이미지가 너무 많습니다",
+    "tooManyImagesDesc": "메시지당 최대 {count}개의 이미지를 첨부할 수 있습니다.",
+    "invalidImageTitle": "잘못된 이미지",
+    "couldNotAttachTitle": "이미지를 첨부할 수 없습니다",
+    "unknownPrepareError": "이미지를 준비하는 중 알 수 없는 오류가 발생했습니다."
+  }
+}
+</i18n>

--- a/app/components/exchange/messages/MessageImageGallery.vue
+++ b/app/components/exchange/messages/MessageImageGallery.vue
@@ -1,0 +1,71 @@
+<template>
+  <aside class="card bg-base-100 shadow-sm sticky top-20">
+    <div class="card-body p-4">
+      <h3 class="card-title text-base mb-3">
+        <i class="fas fa-image"></i>
+        {{ t('sharedImages') }}
+        <span v-if="attachments.length > 0" class="badge badge-sm badge-neutral ml-auto">
+          {{ attachments.length }}
+        </span>
+      </h3>
+
+      <div v-if="attachments.length === 0" class="text-center py-8 text-base-content/60 text-sm">
+        <i class="fas fa-image text-3xl mx-auto mb-2 text-base-content/20"></i>
+        <p>{{ t('emptyTitle') }}</p>
+        <p class="text-xs mt-1">{{ t('emptyHint') }}</p>
+      </div>
+
+      <div v-else class="max-h-[70vh] overflow-y-auto pr-1">
+        <div class="grid grid-cols-2 gap-2">
+          <ExchangeMessagesMessageAttachmentThumbnail
+            v-for="attachment in attachments"
+            :key="attachment.id"
+            :attachment="attachment"
+          />
+        </div>
+      </div>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+  import type { Message, MessageAttachment } from '~/composables/useMessages';
+
+  const { t } = useI18n();
+
+  interface Props {
+    messages: Message[];
+  }
+
+  const props = defineProps<Props>();
+
+  // Flatten all attachments across every message, newest first so the most
+  // recently shared images sit at the top of the sidebar where the user
+  // is most likely looking.
+  const attachments = computed<MessageAttachment[]>(() => {
+    const all: MessageAttachment[] = [];
+    for (const m of props.messages) {
+      if (m.attachments && m.attachments.length > 0) {
+        for (const a of m.attachments) all.push(a);
+      }
+    }
+    return all.sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": { "sharedImages": "Shared Images", "emptyTitle": "No images shared yet.", "emptyHint": "Images you and the other person send will appear here." },
+  "es": { "sharedImages": "Imágenes compartidas", "emptyTitle": "Aún no se han compartido imágenes.", "emptyHint": "Las imágenes que tú y la otra persona envíen aparecerán aquí." },
+  "fr": { "sharedImages": "Images partagées", "emptyTitle": "Aucune image partagée pour l'instant.", "emptyHint": "Les images que vous et l'autre personne envoyez apparaîtront ici." },
+  "de": { "sharedImages": "Geteilte Bilder", "emptyTitle": "Noch keine Bilder geteilt.", "emptyHint": "Bilder, die du und die andere Person senden, erscheinen hier." },
+  "it": { "sharedImages": "Immagini condivise", "emptyTitle": "Nessuna immagine condivisa ancora.", "emptyHint": "Le immagini che tu e l'altra persona inviate appariranno qui." },
+  "pt": { "sharedImages": "Imagens compartilhadas", "emptyTitle": "Nenhuma imagem compartilhada ainda.", "emptyHint": "As imagens que você e a outra pessoa enviarem aparecerão aqui." },
+  "ru": { "sharedImages": "Общие изображения", "emptyTitle": "Изображения ещё не отправлялись.", "emptyHint": "Изображения, которые отправите вы и собеседник, появятся здесь." },
+  "ja": { "sharedImages": "共有画像", "emptyTitle": "まだ共有された画像はありません。", "emptyHint": "あなたと相手が送信した画像がここに表示されます。" },
+  "zh": { "sharedImages": "共享图片", "emptyTitle": "尚未共享任何图片。", "emptyHint": "您和对方发送的图片将显示在此处。" },
+  "ko": { "sharedImages": "공유된 이미지", "emptyTitle": "아직 공유된 이미지가 없습니다.", "emptyHint": "회원님과 상대방이 보낸 이미지가 여기에 표시됩니다." }
+}
+</i18n>

--- a/app/components/exchange/messages/MessageList.vue
+++ b/app/components/exchange/messages/MessageList.vue
@@ -74,7 +74,7 @@
 
               <!-- Timestamp and report button -->
               <div class="chat-footer mt-1 opacity-60 flex items-center gap-1">
-                <time class="text-xs">{{ formatMessageTime(message.created_at) }}</time>
+                <ClientOnly><time class="text-xs">{{ formatMessageTime(message.created_at) }}</time></ClientOnly>
                 <span
                   v-if="isOwnMessage(message.sender_id)"
                   class="text-xs ml-2"

--- a/app/components/exchange/messages/MessageList.vue
+++ b/app/components/exchange/messages/MessageList.vue
@@ -1,0 +1,253 @@
+<template>
+  <div class="space-y-4">
+    <!-- Loading state -->
+    <div v-if="loading" class="flex justify-center py-8">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="messages.length === 0" class="text-center py-12">
+      <i class="fas fa-comments text-6xl mx-auto text-base-content/30 mb-4 block"></i>
+      <p class="text-base-content/60">{{ t('empty') }}</p>
+    </div>
+
+    <!-- Messages -->
+    <div v-else ref="messagesContainer" class="space-y-4">
+      <div v-for="message in messages" :key="message.id">
+        <!-- System message (admin injected) -->
+        <div v-if="message.is_system_message" class="flex justify-center my-4">
+          <div class="alert alert-info max-w-md py-2 px-4">
+            <i class="fas fa-shield-halved"></i>
+            <span class="text-sm">{{ message.content }}</span>
+          </div>
+        </div>
+
+        <!-- Regular message -->
+        <div v-else class="flex group" :class="{ 'justify-end': isOwnMessage(message.sender_id) }">
+          <div class="max-w-[75%]">
+            <!-- Message bubble -->
+            <div
+              class="chat"
+              :class="{
+                'chat-end': isOwnMessage(message.sender_id),
+                'chat-start': !isOwnMessage(message.sender_id),
+              }"
+            >
+              <!-- Sender name (only for other person's messages) -->
+              <div v-if="!isOwnMessage(message.sender_id)" class="chat-header mb-1">
+                <span class="text-sm font-medium">{{ getSenderName(message) }}</span>
+              </div>
+
+              <!-- Message content -->
+              <div
+                class="chat-bubble"
+                :class="
+                  isOwnMessage(message.sender_id)
+                    ? 'chat-bubble-primary'
+                    : 'bg-base-300 text-base-content'
+                "
+              >
+                <!-- eslint-disable-next-line vue/no-v-html -->
+                <div class="prose-message break-words" v-html="renderedContent(message)"></div>
+
+                <!-- Attachments -->
+                <div
+                  v-if="message.attachments && message.attachments.length > 0"
+                  class="mt-2 grid grid-cols-2 gap-2"
+                  :class="{ 'grid-cols-1': message.attachments.length === 1 }"
+                >
+                  <ExchangeMessagesMessageAttachmentThumbnail
+                    v-for="attachment in message.attachments"
+                    :key="attachment.id"
+                    :attachment="attachment"
+                  />
+                </div>
+
+                <!-- Moderation flag -->
+                <div v-if="message.moderation_status === 'flagged'" class="mt-2 pt-2 border-t border-current/20">
+                  <div class="flex items-center gap-2 text-xs opacity-75">
+                    <i class="fas fa-triangle-exclamation"></i>
+                    <span>{{ t('flagged') }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Timestamp and report button -->
+              <div class="chat-footer mt-1 opacity-60 flex items-center gap-1">
+                <time class="text-xs">{{ formatMessageTime(message.created_at) }}</time>
+                <span
+                  v-if="isOwnMessage(message.sender_id)"
+                  class="text-xs ml-2"
+                  :title="message.is_read ? t('read') : t('sent')"
+                >
+                  {{ message.is_read ? '✓✓' : '✓' }}
+                </span>
+                <button
+                  v-if="!isOwnMessage(message.sender_id)"
+                  class="btn btn-ghost btn-xs opacity-0 group-hover:opacity-100 transition-opacity ml-1"
+                  :title="t('report')"
+                  @click="openReport(message)"
+                >
+                  <i class="fas fa-flag"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Scroll anchor -->
+      <div ref="scrollAnchor" class="h-px"></div>
+
+      <!-- Report Message Modal -->
+      <ExchangeMessagesReportMessageModal
+        v-if="reportTargetMessage"
+        ref="reportModal"
+        :message-id="reportTargetMessage.id"
+        :conversation-id="props.conversationId"
+        @reported="onMessageReported"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { Message } from '~/composables/useMessages';
+  import { renderMessageMarkdown } from '~/utils/markdown';
+  import { formatRelativeTime } from '~/utils/formatters';
+
+  const { t } = useI18n();
+
+  interface Props {
+    messages: Message[];
+    loading?: boolean;
+    conversationId: string;
+  }
+
+  const props = defineProps<Props>();
+
+  // Memoize rendered markdown per message id to avoid re-parsing on every
+  // re-render (scroll, unread-count updates, etc.).
+  const renderCache = new Map<string, string>();
+  const renderedContent = (message: Message) => {
+    const cached = renderCache.get(message.id);
+    if (cached !== undefined) return cached;
+    const html = renderMessageMarkdown(message.content);
+    renderCache.set(message.id, html);
+    return html;
+  };
+
+  const { user } = useAuth();
+  const messagesContainer = ref<HTMLElement>();
+  const scrollAnchor = ref<HTMLElement>();
+
+  // Report message state
+  const reportModal = ref<InstanceType<typeof ExchangeMessagesReportMessageModal> | null>(null);
+  const reportTargetMessage = ref<Message | null>(null);
+
+  const openReport = (message: Message) => {
+    reportTargetMessage.value = message;
+    nextTick(() => {
+      reportModal.value?.open();
+    });
+  };
+
+  const onMessageReported = () => {
+    reportTargetMessage.value = null;
+  };
+
+  // Check if message is from current user
+  const isOwnMessage = (senderId: string) => {
+    return user.value?.id === senderId;
+  };
+
+  // Get sender display name
+  const getSenderName = (message: Message) => {
+    if (message.sender) {
+      return message.sender.display_name || message.sender.username || t('anonymous');
+    }
+    return t('unknownUser');
+  };
+
+  // Format message timestamp — shared helper keeps behavior consistent
+  // across all messaging UI surfaces.
+  const formatMessageTime = (timestamp: string) => formatRelativeTime(timestamp, { includeTime: true });
+
+  // Auto-scroll to bottom when new messages arrive
+  const scrollToBottom = () => {
+    nextTick(() => {
+      scrollAnchor.value?.scrollIntoView({ behavior: 'smooth' });
+    });
+  };
+
+  // Watch for new messages and scroll
+  watch(
+    () => props.messages.length,
+    () => {
+      scrollToBottom();
+    },
+    { immediate: true }
+  );
+
+  // Scroll to bottom on mount
+  onMounted(() => {
+    scrollToBottom();
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": { "empty": "No messages yet. Start the conversation!", "flagged": "Message flagged for review", "report": "Report message", "sent": "Sent", "read": "Read", "anonymous": "Anonymous", "unknownUser": "Unknown User" },
+  "es": { "empty": "Aún no hay mensajes. ¡Inicia la conversación!", "flagged": "Mensaje marcado para revisión", "report": "Reportar mensaje", "sent": "Enviado", "read": "Leído", "anonymous": "Anónimo", "unknownUser": "Usuario desconocido" },
+  "fr": { "empty": "Aucun message pour le moment. Lancez la conversation !", "flagged": "Message signalé pour examen", "report": "Signaler le message", "sent": "Envoyé", "read": "Lu", "anonymous": "Anonyme", "unknownUser": "Utilisateur inconnu" },
+  "de": { "empty": "Noch keine Nachrichten. Starte die Unterhaltung!", "flagged": "Nachricht zur Überprüfung gemeldet", "report": "Nachricht melden", "sent": "Gesendet", "read": "Gelesen", "anonymous": "Anonym", "unknownUser": "Unbekannter Benutzer" },
+  "it": { "empty": "Ancora nessun messaggio. Inizia la conversazione!", "flagged": "Messaggio segnalato per revisione", "report": "Segnala messaggio", "sent": "Inviato", "read": "Letto", "anonymous": "Anonimo", "unknownUser": "Utente sconosciuto" },
+  "pt": { "empty": "Ainda não há mensagens. Inicie a conversa!", "flagged": "Mensagem sinalizada para revisão", "report": "Denunciar mensagem", "sent": "Enviado", "read": "Lido", "anonymous": "Anônimo", "unknownUser": "Usuário desconhecido" },
+  "ru": { "empty": "Сообщений пока нет. Начните разговор!", "flagged": "Сообщение отмечено для проверки", "report": "Пожаловаться на сообщение", "sent": "Отправлено", "read": "Прочитано", "anonymous": "Аноним", "unknownUser": "Неизвестный пользователь" },
+  "ja": { "empty": "まだメッセージはありません。会話を始めましょう！", "flagged": "メッセージが確認のため報告されました", "report": "メッセージを報告", "sent": "送信済み", "read": "既読", "anonymous": "匿名", "unknownUser": "不明なユーザー" },
+  "zh": { "empty": "还没有消息。开始对话吧！", "flagged": "消息已被举报待审核", "report": "举报消息", "sent": "已发送", "read": "已读", "anonymous": "匿名", "unknownUser": "未知用户" },
+  "ko": { "empty": "아직 메시지가 없습니다. 대화를 시작하세요!", "flagged": "메시지가 검토를 위해 신고되었습니다", "report": "메시지 신고", "sent": "전송됨", "read": "읽음", "anonymous": "익명", "unknownUser": "알 수 없는 사용자" }
+}
+</i18n>
+
+<style scoped>
+  .prose-message :deep(p) {
+    margin: 0;
+    white-space: pre-wrap;
+  }
+  .prose-message :deep(p + p) {
+    margin-top: 0.5rem;
+  }
+  .prose-message :deep(ul),
+  .prose-message :deep(ol) {
+    margin: 0.25rem 0;
+    padding-left: 1.25rem;
+  }
+  .prose-message :deep(li) {
+    margin: 0.125rem 0;
+  }
+  .prose-message :deep(code) {
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    background-color: rgba(0, 0, 0, 0.15);
+    font-size: 0.9em;
+  }
+  .prose-message :deep(pre) {
+    margin: 0.5rem 0;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    background-color: rgba(0, 0, 0, 0.2);
+    overflow-x: auto;
+  }
+  .prose-message :deep(pre code) {
+    background-color: transparent;
+    padding: 0;
+  }
+  .prose-message :deep(a) {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .prose-message :deep(strong) {
+    font-weight: 700;
+  }
+</style>

--- a/app/components/exchange/messages/ReportMessageModal.vue
+++ b/app/components/exchange/messages/ReportMessageModal.vue
@@ -1,0 +1,91 @@
+<template>
+  <dialog ref="modalEl" class="modal">
+    <div class="modal-box">
+      <h3 class="font-bold text-lg">{{ t('title') }}</h3>
+      <p class="text-base-content/70 mt-2">{{ t('prompt') }}</p>
+
+      <div class="mt-4">
+        <textarea
+          v-model="reason"
+          class="textarea textarea-bordered w-full"
+          rows="3"
+          :placeholder="t('placeholder')"
+          maxlength="500"
+        ></textarea>
+        <div class="text-xs text-base-content/50 mt-1 text-right">{{ t('charCount', { count: reason.length }) }}</div>
+      </div>
+
+      <div class="modal-action">
+        <button class="btn btn-ghost" @click="close">{{ t('cancel') }}</button>
+        <button class="btn btn-error" :disabled="!reason.trim() || submitting" @click="submit">
+          <span v-if="submitting" class="loading loading-spinner loading-sm"></span>
+          {{ t('submit') }}
+        </button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>{{ t('close') }}</button>
+    </form>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    messageId: string;
+    conversationId: string;
+  }>();
+
+  const emit = defineEmits<{
+    reported: [];
+  }>();
+
+  const { reportMessage } = useMessages();
+
+  const modalEl = ref<HTMLDialogElement | null>(null);
+  const reason = ref('');
+  const submitting = ref(false);
+
+  const open = () => {
+    reason.value = '';
+    modalEl.value?.showModal();
+  };
+
+  const close = () => {
+    modalEl.value?.close();
+    reason.value = '';
+  };
+
+  const submit = async () => {
+    if (!reason.value.trim()) return;
+
+    submitting.value = true;
+    try {
+      const success = await reportMessage(props.messageId, props.conversationId, reason.value.trim());
+      if (success) {
+        close();
+        emit('reported');
+      }
+    } finally {
+      submitting.value = false;
+    }
+  };
+
+  defineExpose({ open, close });
+</script>
+
+<i18n lang="json">
+{
+  "en": { "title": "Report Message", "prompt": "Why are you reporting this message?", "placeholder": "Describe the issue (harassment, spam, scam, etc.)...", "charCount": "{count}/500", "cancel": "Cancel", "submit": "Report Message", "close": "close" },
+  "es": { "title": "Reportar mensaje", "prompt": "¿Por qué reportas este mensaje?", "placeholder": "Describe el problema (acoso, spam, estafa, etc.)...", "charCount": "{count}/500", "cancel": "Cancelar", "submit": "Reportar mensaje", "close": "cerrar" },
+  "fr": { "title": "Signaler le message", "prompt": "Pourquoi signalez-vous ce message ?", "placeholder": "Décrivez le problème (harcèlement, spam, arnaque, etc.)...", "charCount": "{count}/500", "cancel": "Annuler", "submit": "Signaler le message", "close": "fermer" },
+  "de": { "title": "Nachricht melden", "prompt": "Warum meldest du diese Nachricht?", "placeholder": "Beschreibe das Problem (Belästigung, Spam, Betrug usw.)...", "charCount": "{count}/500", "cancel": "Abbrechen", "submit": "Nachricht melden", "close": "schließen" },
+  "it": { "title": "Segnala messaggio", "prompt": "Perché segnali questo messaggio?", "placeholder": "Descrivi il problema (molestie, spam, truffa, ecc.)...", "charCount": "{count}/500", "cancel": "Annulla", "submit": "Segnala messaggio", "close": "chiudi" },
+  "pt": { "title": "Denunciar mensagem", "prompt": "Por que você está denunciando esta mensagem?", "placeholder": "Descreva o problema (assédio, spam, golpe, etc.)...", "charCount": "{count}/500", "cancel": "Cancelar", "submit": "Denunciar mensagem", "close": "fechar" },
+  "ru": { "title": "Пожаловаться на сообщение", "prompt": "Почему вы жалуетесь на это сообщение?", "placeholder": "Опишите проблему (домогательство, спам, мошенничество и т. д.)...", "charCount": "{count}/500", "cancel": "Отмена", "submit": "Пожаловаться", "close": "закрыть" },
+  "ja": { "title": "メッセージを報告", "prompt": "このメッセージを報告する理由は何ですか？", "placeholder": "問題を説明してください（嫌がらせ、スパム、詐欺など）...", "charCount": "{count}/500", "cancel": "キャンセル", "submit": "メッセージを報告", "close": "閉じる" },
+  "zh": { "title": "举报消息", "prompt": "您为什么要举报这条消息？", "placeholder": "描述问题（骚扰、垃圾信息、诈骗等）...", "charCount": "{count}/500", "cancel": "取消", "submit": "举报消息", "close": "关闭" },
+  "ko": { "title": "메시지 신고", "prompt": "이 메시지를 신고하는 이유는 무엇인가요?", "placeholder": "문제를 설명해 주세요 (괴롭힘, 스팸, 사기 등)...", "charCount": "{count}/500", "cancel": "취소", "submit": "메시지 신고", "close": "닫기" }
+}
+</i18n>

--- a/app/components/exchange/messages/SafetyTips.vue
+++ b/app/components/exchange/messages/SafetyTips.vue
@@ -1,0 +1,87 @@
+<template>
+  <div v-if="visible" class="alert items-start bg-info/10 border border-info/20 text-sm relative pr-10">
+    <button
+      class="btn btn-ghost btn-xs btn-circle absolute top-2 right-2"
+      @click="dismiss"
+      :aria-label="t('dismiss')"
+    >
+      <i class="fas fa-xmark"></i>
+    </button>
+    <div class="flex-1">
+      <div class="flex items-center gap-2 mb-2">
+        <i class="fas fa-shield-halved text-info shrink-0"></i>
+        <span class="font-semibold text-info">{{ t('title') }}</span>
+      </div>
+      <ul class="space-y-1 text-base-content/70">
+        <li class="flex items-start gap-2">
+          <i class="fas fa-check text-success shrink-0 mt-0.5"></i>
+          <span>{{ t('tip1') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <i class="fas fa-check text-success shrink-0 mt-0.5"></i>
+          <span>{{ t('tip2') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <i class="fas fa-check text-success shrink-0 mt-0.5"></i>
+          <span>{{ t('tip3') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <i class="fas fa-check text-success shrink-0 mt-0.5"></i>
+          <span>{{ t('tip4Prefix') }}<NuxtLink to="/safety" class="link link-info">{{ t('tip4Link') }}</NuxtLink>.</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    conversationId: string;
+  }>();
+
+  // Track dismissed conversations in localStorage
+  const STORAGE_KEY = 'tme-safety-tips-dismissed';
+
+  const visible = ref(false);
+
+  onMounted(() => {
+    try {
+      const dismissed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      visible.value = !dismissed.includes(props.conversationId);
+    } catch {
+      visible.value = true;
+    }
+  });
+
+  const dismiss = () => {
+    visible.value = false;
+    try {
+      const dismissed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      if (!dismissed.includes(props.conversationId)) {
+        dismissed.push(props.conversationId);
+        // Keep only last 100 entries to avoid bloating localStorage
+        if (dismissed.length > 100) dismissed.splice(0, dismissed.length - 100);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(dismissed));
+      }
+    } catch {
+      // Ignore localStorage errors
+    }
+  };
+</script>
+
+<i18n lang="json">
+{
+  "en": { "dismiss": "Dismiss safety tips", "title": "Safety Reminder", "tip1": "Meet in a public place for in-person exchanges.", "tip2": "Use traceable payment methods (bank transfer, PayPal Goods & Services).", "tip3": "Never share personal financial details in messages.", "tip4Prefix": "If something feels off, ", "tip4Link": "read our full safety guide" },
+  "es": { "dismiss": "Descartar consejos de seguridad", "title": "Recordatorio de seguridad", "tip1": "Reúnete en un lugar público para los intercambios en persona.", "tip2": "Usa métodos de pago rastreables (transferencia bancaria, PayPal Bienes y Servicios).", "tip3": "Nunca compartas datos financieros personales en los mensajes.", "tip4Prefix": "Si algo te parece sospechoso, ", "tip4Link": "lee nuestra guía de seguridad completa" },
+  "fr": { "dismiss": "Ignorer les conseils de sécurité", "title": "Rappel de sécurité", "tip1": "Rencontrez-vous dans un lieu public pour les échanges en personne.", "tip2": "Utilisez des modes de paiement traçables (virement bancaire, PayPal Biens & Services).", "tip3": "Ne partagez jamais de coordonnées financières personnelles dans les messages.", "tip4Prefix": "Si quelque chose vous semble anormal, ", "tip4Link": "consultez notre guide de sécurité complet" },
+  "de": { "dismiss": "Sicherheitstipps ausblenden", "title": "Sicherheitshinweis", "tip1": "Treffen Sie sich für persönliche Übergaben an einem öffentlichen Ort.", "tip2": "Verwenden Sie nachvollziehbare Zahlungsmethoden (Banküberweisung, PayPal Waren & Dienstleistungen).", "tip3": "Teilen Sie niemals persönliche Finanzdaten in Nachrichten.", "tip4Prefix": "Wenn Ihnen etwas seltsam vorkommt, ", "tip4Link": "lesen Sie unseren vollständigen Sicherheitsleitfaden" },
+  "it": { "dismiss": "Ignora i consigli di sicurezza", "title": "Promemoria di sicurezza", "tip1": "Incontratevi in un luogo pubblico per gli scambi di persona.", "tip2": "Usa metodi di pagamento tracciabili (bonifico bancario, PayPal Beni e Servizi).", "tip3": "Non condividere mai dati finanziari personali nei messaggi.", "tip4Prefix": "Se qualcosa non ti convince, ", "tip4Link": "leggi la nostra guida completa alla sicurezza" },
+  "pt": { "dismiss": "Dispensar dicas de segurança", "title": "Lembrete de segurança", "tip1": "Encontre-se em um local público para trocas presenciais.", "tip2": "Use métodos de pagamento rastreáveis (transferência bancária, PayPal Bens e Serviços).", "tip3": "Nunca compartilhe dados financeiros pessoais nas mensagens.", "tip4Prefix": "Se algo parecer estranho, ", "tip4Link": "leia nosso guia completo de segurança" },
+  "ru": { "dismiss": "Скрыть советы по безопасности", "title": "Напоминание о безопасности", "tip1": "Для личных встреч выбирайте общественные места.", "tip2": "Используйте отслеживаемые способы оплаты (банковский перевод, PayPal «Товары и услуги»).", "tip3": "Никогда не сообщайте личные финансовые данные в сообщениях.", "tip4Prefix": "Если что-то кажется подозрительным, ", "tip4Link": "прочитайте наше полное руководство по безопасности" },
+  "ja": { "dismiss": "安全に関するヒントを閉じる", "title": "安全に関する注意", "tip1": "対面での取引は公共の場所で行いましょう。", "tip2": "追跡可能な支払い方法を利用しましょう（銀行振込、PayPalの商品・サービス）。", "tip3": "メッセージで個人の金融情報を共有しないでください。", "tip4Prefix": "何か不審に感じたら、", "tip4Link": "安全ガイド全文をご覧ください" },
+  "zh": { "dismiss": "关闭安全提示", "title": "安全提醒", "tip1": "当面交易请在公共场所进行。", "tip2": "使用可追溯的付款方式（银行转账、PayPal 商品与服务）。", "tip3": "切勿在消息中分享个人财务信息。", "tip4Prefix": "如果感觉有任何不对劲，", "tip4Link": "请阅读我们的完整安全指南" },
+  "ko": { "dismiss": "안전 팁 닫기", "title": "안전 알림", "tip1": "직접 거래는 공공장소에서 만나세요.", "tip2": "추적 가능한 결제 수단을 사용하세요(계좌 이체, PayPal 상품 및 서비스).", "tip3": "메시지로 개인 금융 정보를 절대 공유하지 마세요.", "tip4Prefix": "무언가 이상하다고 느껴지면 ", "tip4Link": "전체 안전 가이드를 읽어보세요" }
+}
+</i18n>

--- a/app/pages/exchange/messages/[conversationId].vue
+++ b/app/pages/exchange/messages/[conversationId].vue
@@ -24,14 +24,15 @@
         <!-- Listing Info Header -->
         <div class="card bg-base-100 shadow-sm">
           <div class="card-body p-4">
-            <div class="flex gap-4">
+            <!-- Listing-linked conversation -->
+            <div v-if="conversation.listing" class="flex gap-4">
               <!-- Listing image -->
-              <NuxtLink :to="`/exchange/listings/${conversation.listing?.slug}`" class="avatar flex-shrink-0">
+              <NuxtLink :to="`/exchange/listings/${conversation.listing.slug}`" class="avatar flex-shrink-0">
                 <div class="w-20 h-20 rounded">
                   <img
                     v-if="listingImage"
                     :src="listingImage"
-                    :alt="conversation.listing?.title"
+                    :alt="conversation.listing.title"
                     class="object-cover w-full h-full"
                     loading="lazy"
                   />
@@ -44,18 +45,34 @@
               <!-- Listing details -->
               <div class="flex-1">
                 <NuxtLink
-                  :to="`/exchange/listings/${conversation.listing?.slug}`"
+                  :to="`/exchange/listings/${conversation.listing.slug}`"
                   class="link link-hover text-lg font-semibold mb-1 block"
                 >
-                  {{ conversation.listing?.title }}
+                  {{ conversation.listing.title }}
                 </NuxtLink>
 
                 <div class="flex items-center gap-4 text-sm">
                   <span class="font-bold text-primary text-lg">
-                    ${{ conversation.listing?.price?.toLocaleString() }}
+                    ${{ conversation.listing.price?.toLocaleString() }}
                   </span>
                   <span class="text-base-content/60">{{ t('chattingWith', { name: otherParticipantName }) }}</span>
                 </div>
+              </div>
+            </div>
+
+            <!-- Orphan / wanted conversation (no associated listing) -->
+            <div v-else class="flex gap-4">
+              <div class="avatar flex-shrink-0">
+                <div class="w-20 h-20 rounded">
+                  <div class="w-full h-full bg-base-300 flex items-center justify-center">
+                    <i class="fas fa-comments text-2xl text-base-content/30"></i>
+                  </div>
+                </div>
+              </div>
+
+              <div class="flex-1">
+                <p class="text-lg font-semibold mb-1">{{ t('noListing') }}</p>
+                <span class="text-base-content/60 text-sm">{{ t('chattingWith', { name: otherParticipantName }) }}</span>
               </div>
             </div>
           </div>
@@ -141,7 +158,7 @@
   const otherParticipantName = computed(() => {
     if (!conversation.value) return '';
     const participant = getOtherParticipant(conversation.value);
-    return participant?.name || 'Unknown User';
+    return participant?.name || t('unknownUser');
   });
 
   const listingImage = computed(() => {
@@ -259,7 +276,9 @@
     "notFound": "Conversation not found",
     "chattingWith": "Chatting with {name}",
     "conversation": "Conversation",
-    "loadOlder": "Load Older Messages"
+    "loadOlder": "Load Older Messages",
+    "unknownUser": "Unknown User",
+    "noListing": "No associated listing"
   },
   "es": {
     "seo": { "title": "Conversación - The Mini Exchange | Classic Mini DIY" },
@@ -267,7 +286,9 @@
     "notFound": "Conversación no encontrada",
     "chattingWith": "Chateando con {name}",
     "conversation": "Conversación",
-    "loadOlder": "Cargar mensajes anteriores"
+    "loadOlder": "Cargar mensajes anteriores",
+    "unknownUser": "Usuario desconocido",
+    "noListing": "Sin anuncio asociado"
   },
   "fr": {
     "seo": { "title": "Conversation - The Mini Exchange | Classic Mini DIY" },
@@ -275,7 +296,9 @@
     "notFound": "Conversation introuvable",
     "chattingWith": "Discussion avec {name}",
     "conversation": "Conversation",
-    "loadOlder": "Charger les messages plus anciens"
+    "loadOlder": "Charger les messages plus anciens",
+    "unknownUser": "Utilisateur inconnu",
+    "noListing": "Aucune annonce associée"
   },
   "de": {
     "seo": { "title": "Konversation - The Mini Exchange | Classic Mini DIY" },
@@ -283,7 +306,9 @@
     "notFound": "Konversation nicht gefunden",
     "chattingWith": "Chat mit {name}",
     "conversation": "Konversation",
-    "loadOlder": "Ältere Nachrichten laden"
+    "loadOlder": "Ältere Nachrichten laden",
+    "unknownUser": "Unbekannter Benutzer",
+    "noListing": "Kein zugehöriges Angebot"
   },
   "it": {
     "seo": { "title": "Conversazione - The Mini Exchange | Classic Mini DIY" },
@@ -291,7 +316,9 @@
     "notFound": "Conversazione non trovata",
     "chattingWith": "Stai chattando con {name}",
     "conversation": "Conversazione",
-    "loadOlder": "Carica messaggi precedenti"
+    "loadOlder": "Carica messaggi precedenti",
+    "unknownUser": "Utente sconosciuto",
+    "noListing": "Nessun annuncio associato"
   },
   "pt": {
     "seo": { "title": "Conversa - The Mini Exchange | Classic Mini DIY" },
@@ -299,7 +326,9 @@
     "notFound": "Conversa não encontrada",
     "chattingWith": "A conversar com {name}",
     "conversation": "Conversa",
-    "loadOlder": "Carregar mensagens anteriores"
+    "loadOlder": "Carregar mensagens anteriores",
+    "unknownUser": "Utilizador desconhecido",
+    "noListing": "Sem anúncio associado"
   },
   "ru": {
     "seo": { "title": "Переписка - The Mini Exchange | Classic Mini DIY" },
@@ -307,7 +336,9 @@
     "notFound": "Переписка не найдена",
     "chattingWith": "Переписка с {name}",
     "conversation": "Переписка",
-    "loadOlder": "Загрузить более старые сообщения"
+    "loadOlder": "Загрузить более старые сообщения",
+    "unknownUser": "Неизвестный пользователь",
+    "noListing": "Нет связанного объявления"
   },
   "ja": {
     "seo": { "title": "会話 - The Mini Exchange | Classic Mini DIY" },
@@ -315,7 +346,9 @@
     "notFound": "会話が見つかりません",
     "chattingWith": "{name} とチャット中",
     "conversation": "会話",
-    "loadOlder": "過去のメッセージを読み込む"
+    "loadOlder": "過去のメッセージを読み込む",
+    "unknownUser": "不明なユーザー",
+    "noListing": "関連する出品はありません"
   },
   "zh": {
     "seo": { "title": "会话 - The Mini Exchange | Classic Mini DIY" },
@@ -323,7 +356,9 @@
     "notFound": "未找到会话",
     "chattingWith": "正在与 {name} 聊天",
     "conversation": "会话",
-    "loadOlder": "加载更早的消息"
+    "loadOlder": "加载更早的消息",
+    "unknownUser": "未知用户",
+    "noListing": "无关联商品"
   },
   "ko": {
     "seo": { "title": "대화 - The Mini Exchange | Classic Mini DIY" },
@@ -331,7 +366,9 @@
     "notFound": "대화를 찾을 수 없습니다",
     "chattingWith": "{name} 님과 대화 중",
     "conversation": "대화",
-    "loadOlder": "이전 메시지 불러오기"
+    "loadOlder": "이전 메시지 불러오기",
+    "unknownUser": "알 수 없는 사용자",
+    "noListing": "연결된 매물 없음"
   }
 }
 </i18n>

--- a/app/pages/exchange/messages/[conversationId].vue
+++ b/app/pages/exchange/messages/[conversationId].vue
@@ -1,0 +1,337 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <div class="max-w-6xl mx-auto">
+      <!-- Back button -->
+      <NuxtLink to="/exchange/messages" class="btn btn-ghost btn-sm mb-4">
+        <i class="fas fa-arrow-left"></i>
+        {{ t('back') }}
+      </NuxtLink>
+
+      <!-- Loading state -->
+      <div v-if="loading || !initialLoadComplete" class="flex justify-center py-12">
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
+
+      <!-- Error state -->
+      <div v-else-if="!conversation" class="alert alert-error">
+        <i class="fas fa-triangle-exclamation text-xl"></i>
+        <span>{{ t('notFound') }}</span>
+      </div>
+
+      <!-- Conversation -->
+      <div v-else class="flex flex-col lg:flex-row lg:gap-6">
+        <div class="space-y-6 min-w-0 flex-1">
+        <!-- Listing Info Header -->
+        <div class="card bg-base-100 shadow-sm">
+          <div class="card-body p-4">
+            <div class="flex gap-4">
+              <!-- Listing image -->
+              <NuxtLink :to="`/exchange/listings/${conversation.listing?.slug}`" class="avatar flex-shrink-0">
+                <div class="w-20 h-20 rounded">
+                  <img
+                    v-if="listingImage"
+                    :src="listingImage"
+                    :alt="conversation.listing?.title"
+                    class="object-cover w-full h-full"
+                    loading="lazy"
+                  />
+                  <div v-else class="w-full h-full bg-base-300 flex items-center justify-center">
+                    <i class="fas fa-image text-2xl text-base-content/30"></i>
+                  </div>
+                </div>
+              </NuxtLink>
+
+              <!-- Listing details -->
+              <div class="flex-1">
+                <NuxtLink
+                  :to="`/exchange/listings/${conversation.listing?.slug}`"
+                  class="link link-hover text-lg font-semibold mb-1 block"
+                >
+                  {{ conversation.listing?.title }}
+                </NuxtLink>
+
+                <div class="flex items-center gap-4 text-sm">
+                  <span class="font-bold text-primary text-lg">
+                    ${{ conversation.listing?.price?.toLocaleString() }}
+                  </span>
+                  <span class="text-base-content/60">{{ t('chattingWith', { name: otherParticipantName }) }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Safety Tips (dismissible) -->
+        <ExchangeMessagesSafetyTips :conversation-id="conversationId" />
+
+        <!-- Meeting Spot Suggestions -->
+        <ExchangeMessagesMeetingSpotSuggestions
+          v-if="conversation.listing?.latitude && conversation.listing?.longitude"
+          :seller-lat="Number(conversation.listing.latitude)"
+          :seller-lon="Number(conversation.listing.longitude)"
+          :conversation-id="conversationId"
+          @spot-suggested="handleMessageSent"
+        />
+
+        <!-- Messages -->
+        <div class="card bg-base-100 shadow-sm">
+          <div class="card-body p-6">
+            <h2 class="card-title mb-4">
+              <i class="fas fa-comments text-xl"></i>
+              {{ t('conversation') }}
+            </h2>
+
+            <div class="max-h-[500px] overflow-y-auto mb-6">
+              <div v-if="hasOlderMessages" class="text-center py-2">
+                <button class="btn btn-ghost btn-sm" @click="loadOlderMessages" :disabled="loadingOlder">
+                  <span v-if="loadingOlder" class="loading loading-spinner loading-xs"></span>
+                  {{ t('loadOlder') }}
+                </button>
+              </div>
+              <ExchangeMessagesMessageList :messages="messages" :loading="messagesLoading" :conversation-id="conversationId" />
+            </div>
+
+            <!-- Message Composer -->
+            <ExchangeMessagesMessageComposer
+              :conversation-id="conversationId"
+              :listing-id="conversation.listing?.id"
+              :message-count="messages.length"
+              @sent="handleMessageSent"
+            />
+          </div>
+        </div>
+        </div>
+
+        <!-- Desktop-only shared images sidebar -->
+        <div class="hidden lg:block lg:w-[300px] lg:flex-shrink-0">
+          <ExchangeMessagesMessageImageGallery :messages="messages" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  definePageMeta({
+    middleware: 'exchange-auth',
+  });
+
+  useSeoMeta({
+    title: t('seo.title'),
+    robots: 'noindex, nofollow',
+  });
+
+  const route = useRoute();
+  const conversationId = computed(() => route.params.conversationId as string);
+
+  const { fetchConversation, fetchMessages, markAsRead, getOtherParticipant, loading } = useMessages();
+  const { getPhotoUrl } = useListings();
+  const { capture } = usePostHog();
+  const { user } = useAuth();
+
+  const conversation = ref<any>(null);
+  const messages = ref<any[]>([]);
+  const messagesLoading = ref(false);
+  const hasOlderMessages = ref(false);
+  const loadingOlder = ref(false);
+  const initialLoadComplete = ref(false);
+
+  const otherParticipantName = computed(() => {
+    if (!conversation.value) return '';
+    const participant = getOtherParticipant(conversation.value);
+    return participant?.name || 'Unknown User';
+  });
+
+  const listingImage = computed(() => {
+    const photos = conversation.value?.listing?.listing_photos;
+    if (!photos || photos.length === 0) return null;
+
+    const primaryPhoto = photos.find((p: any) => p.is_primary);
+    const photo = primaryPhoto || photos[0];
+
+    return photo ? getPhotoUrl(photo.storage_path) : null;
+  });
+
+  // Load conversation and messages
+  const loadConversation = async () => {
+    conversation.value = await fetchConversation(conversationId.value);
+
+    if (conversation.value) {
+      messagesLoading.value = true;
+      const result = await fetchMessages(conversationId.value);
+      messages.value = result.messages;
+      hasOlderMessages.value = result.hasMore;
+      messagesLoading.value = false;
+
+      // Track conversation opened with unread count
+      const unreadCount =
+        user.value?.id === conversation.value.buyer_id
+          ? conversation.value.buyer_unread_count || 0
+          : conversation.value.seller_unread_count || 0;
+
+      capture('conversation_opened', {
+        conversation_id: conversationId.value,
+        unread_count: unreadCount,
+      });
+
+      // Mark messages as read (fire-and-forget, don't block UI)
+      markAsRead(conversationId.value);
+    }
+    initialLoadComplete.value = true;
+  };
+
+  // Handle new message sent
+  const handleMessageSent = async () => {
+    // Fetch latest page to pick up the new message with sender data
+    const result = await fetchMessages(conversationId.value);
+    messages.value = result.messages;
+    hasOlderMessages.value = result.hasMore;
+  };
+
+  // Load older messages (cursor-based pagination)
+  const loadOlderMessages = async () => {
+    if (!messages.value.length || loadingOlder.value) return;
+    loadingOlder.value = true;
+    try {
+      const oldestMessage = messages.value[0];
+      const result = await fetchMessages(conversationId.value, {
+        before: oldestMessage.created_at,
+      });
+      messages.value = [...result.messages, ...messages.value];
+      hasOlderMessages.value = result.hasMore;
+    } finally {
+      loadingOlder.value = false;
+    }
+  };
+
+  // Load on mount
+  onMounted(async () => {
+    await loadConversation();
+  });
+
+  // Set up real-time subscription for new messages
+  const supabase = useSupabase();
+
+  onMounted(() => {
+    const channel = supabase
+      .channel(`conversation_${conversationId.value}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'messages',
+          filter: `conversation_id=eq.${conversationId.value}`,
+        },
+        async (payload: any) => {
+          const newMessage = payload.new;
+          // Only append if this message isn't already in our list
+          if (newMessage && !messages.value.some((m: any) => m.id === newMessage.id)) {
+            // Attach sender info from conversation participants
+            if (conversation.value) {
+              const sender =
+                newMessage.sender_id === conversation.value.buyer_id
+                  ? conversation.value.buyer
+                  : conversation.value.seller;
+              newMessage.sender = sender || null;
+            }
+            messages.value = [...messages.value, newMessage];
+          }
+          await markAsRead(conversationId.value);
+        }
+      )
+      .subscribe();
+
+    // Cleanup on unmount
+    onBeforeUnmount(() => {
+      supabase.removeChannel(channel);
+    });
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "seo": { "title": "Conversation - The Mini Exchange | Classic Mini DIY" },
+    "back": "Back to Messages",
+    "notFound": "Conversation not found",
+    "chattingWith": "Chatting with {name}",
+    "conversation": "Conversation",
+    "loadOlder": "Load Older Messages"
+  },
+  "es": {
+    "seo": { "title": "Conversación - The Mini Exchange | Classic Mini DIY" },
+    "back": "Volver a Mensajes",
+    "notFound": "Conversación no encontrada",
+    "chattingWith": "Chateando con {name}",
+    "conversation": "Conversación",
+    "loadOlder": "Cargar mensajes anteriores"
+  },
+  "fr": {
+    "seo": { "title": "Conversation - The Mini Exchange | Classic Mini DIY" },
+    "back": "Retour aux messages",
+    "notFound": "Conversation introuvable",
+    "chattingWith": "Discussion avec {name}",
+    "conversation": "Conversation",
+    "loadOlder": "Charger les messages plus anciens"
+  },
+  "de": {
+    "seo": { "title": "Konversation - The Mini Exchange | Classic Mini DIY" },
+    "back": "Zurück zu Nachrichten",
+    "notFound": "Konversation nicht gefunden",
+    "chattingWith": "Chat mit {name}",
+    "conversation": "Konversation",
+    "loadOlder": "Ältere Nachrichten laden"
+  },
+  "it": {
+    "seo": { "title": "Conversazione - The Mini Exchange | Classic Mini DIY" },
+    "back": "Torna ai messaggi",
+    "notFound": "Conversazione non trovata",
+    "chattingWith": "Stai chattando con {name}",
+    "conversation": "Conversazione",
+    "loadOlder": "Carica messaggi precedenti"
+  },
+  "pt": {
+    "seo": { "title": "Conversa - The Mini Exchange | Classic Mini DIY" },
+    "back": "Voltar às mensagens",
+    "notFound": "Conversa não encontrada",
+    "chattingWith": "A conversar com {name}",
+    "conversation": "Conversa",
+    "loadOlder": "Carregar mensagens anteriores"
+  },
+  "ru": {
+    "seo": { "title": "Переписка - The Mini Exchange | Classic Mini DIY" },
+    "back": "Назад к сообщениям",
+    "notFound": "Переписка не найдена",
+    "chattingWith": "Переписка с {name}",
+    "conversation": "Переписка",
+    "loadOlder": "Загрузить более старые сообщения"
+  },
+  "ja": {
+    "seo": { "title": "会話 - The Mini Exchange | Classic Mini DIY" },
+    "back": "メッセージに戻る",
+    "notFound": "会話が見つかりません",
+    "chattingWith": "{name} とチャット中",
+    "conversation": "会話",
+    "loadOlder": "過去のメッセージを読み込む"
+  },
+  "zh": {
+    "seo": { "title": "会话 - The Mini Exchange | Classic Mini DIY" },
+    "back": "返回消息",
+    "notFound": "未找到会话",
+    "chattingWith": "正在与 {name} 聊天",
+    "conversation": "会话",
+    "loadOlder": "加载更早的消息"
+  },
+  "ko": {
+    "seo": { "title": "대화 - The Mini Exchange | Classic Mini DIY" },
+    "back": "메시지로 돌아가기",
+    "notFound": "대화를 찾을 수 없습니다",
+    "chattingWith": "{name} 님과 대화 중",
+    "conversation": "대화",
+    "loadOlder": "이전 메시지 불러오기"
+  }
+}
+</i18n>

--- a/app/pages/exchange/messages/index.vue
+++ b/app/pages/exchange/messages/index.vue
@@ -1,0 +1,462 @@
+<template>
+  <div class="container py-8">
+    <div class="max-w-4xl mx-auto">
+      <!-- Header -->
+      <div class="mb-6">
+        <h1 class="text-3xl font-bold mb-2">{{ t('header.title') }}</h1>
+        <p class="text-base-content/70">{{ t('header.subtitle') }}</p>
+      </div>
+
+      <!-- Error State -->
+      <div v-if="error" class="alert alert-error">
+        <i class="fas fa-triangle-exclamation text-xl"></i>
+        <div>
+          <h3 class="font-bold">{{ t('error.title') }}</h3>
+          <p>{{ t('error.body') }}</p>
+        </div>
+        <button class="btn btn-sm" @click="retryFetch">{{ t('error.retry') }}</button>
+      </div>
+
+      <template v-else>
+        <!-- Search -->
+        <div class="mb-4">
+          <label class="input input-bordered flex items-center gap-2">
+            <i class="fas fa-magnifying-glass opacity-70"></i>
+            <input
+              v-model="searchQuery"
+              type="search"
+              class="grow"
+              :placeholder="t('search.placeholder')"
+              :aria-label="t('search.ariaLabel')"
+            />
+            <button
+              v-if="searchQuery"
+              type="button"
+              class="btn btn-ghost btn-xs btn-circle"
+              :aria-label="t('search.clear')"
+              @click="searchQuery = ''"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </label>
+        </div>
+
+        <!-- Tabs -->
+        <div role="tablist" class="tabs tabs-bordered mb-4">
+          <button
+            v-for="tab in tabs"
+            :key="tab.key"
+            role="tab"
+            type="button"
+            class="tab"
+            :class="{ 'tab-active font-semibold': activeTab === tab.key }"
+            @click="activeTab = tab.key"
+          >
+            {{ tab.label }}
+            <span
+              v-if="tab.count > 0"
+              class="badge badge-sm ml-2"
+              :class="tab.key === activeTab ? 'badge-primary' : 'badge-ghost'"
+            >
+              {{ tab.count }}
+            </span>
+          </button>
+        </div>
+
+        <!-- Loading -->
+        <div v-if="loading" class="flex justify-center py-12">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+
+        <!-- Empty (no conversations at all) -->
+        <div v-else-if="conversations.length === 0" class="text-center py-16">
+          <i class="fas fa-inbox text-6xl mx-auto mb-4 text-base-content/30"></i>
+          <h3 class="text-xl font-semibold mb-2">{{ t('empty.title') }}</h3>
+          <p class="text-base-content/70 mb-6">{{ t('empty.body') }}</p>
+          <NuxtLink to="/exchange/listings" class="btn btn-primary">
+            <i class="fas fa-magnifying-glass"></i>
+            {{ t('empty.browse') }}
+          </NuxtLink>
+        </div>
+
+        <!-- Empty search / empty tab -->
+        <div v-else-if="visibleGroups.length === 0" class="text-center py-12">
+          <i
+            class="fas mx-auto mb-3 text-base-content/30 text-5xl"
+            :class="searchQuery ? 'fa-magnifying-glass' : 'fa-inbox'"
+          ></i>
+          <p class="text-base-content/70">
+            <template v-if="searchQuery">{{ t('emptySearch.noMatch', { query: searchQuery }) }}</template>
+            <template v-else>{{ t('emptySearch.noTab') }}</template>
+          </p>
+        </div>
+
+        <!-- Grouped conversation list -->
+        <div v-else class="space-y-3">
+          <ExchangeMessagesListingConversationGroup
+            v-for="group in visibleGroups"
+            :key="group.id"
+            :group="group"
+            :is-open="isGroupOpen(group.id)"
+            @toggle="toggleGroup(group.id)"
+          />
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { Conversation } from '~/composables/useMessages';
+  import type { ConversationGroup } from '~/components/exchange/messages/ListingConversationGroup.vue';
+
+  const { t } = useI18n();
+
+  definePageMeta({
+    middleware: 'exchange-auth',
+  });
+
+  useSeoMeta({
+    title: t('seo.title'),
+    robots: 'noindex, nofollow',
+  });
+
+  const { fetchConversations, getOtherParticipant, loading } = useMessages();
+  const { getPhotoUrl } = useListings();
+  const { capture } = usePostHog();
+  const { user } = useAuth();
+
+  const conversations = ref<Conversation[]>([]);
+  const error = ref(false);
+  const searchQuery = ref('');
+  type TabKey = 'active' | 'sold' | 'all';
+  const activeTab = ref<TabKey>('active');
+
+  // --- Helpers ---
+
+  const getUnreadCount = (c: Conversation): number => {
+    if (!user.value) return 0;
+    if (c.buyer_id === user.value.id) return c.buyer_unread_count || 0;
+    if (c.seller_id === user.value.id) return c.seller_unread_count || 0;
+    return 0;
+  };
+
+  const getListingImage = (c: Conversation): string | null => {
+    const photos = c.listing?.listing_photos;
+    if (!photos || photos.length === 0) return null;
+    const photo = photos.find((p) => p.is_primary) || photos[0];
+    return photo ? getPhotoUrl(photo.storage_path) : null;
+  };
+
+  // --- Grouping: collapse conversations by listing / wanted post ---
+
+  const allGroups = computed<ConversationGroup[]>(() => {
+    const map = new Map<string, ConversationGroup>();
+
+    for (const c of conversations.value) {
+      let key: string;
+      let group: ConversationGroup;
+
+      if (c.listing) {
+        key = `l:${c.listing.id}`;
+        if (!map.has(key)) {
+          group = {
+            kind: 'listing',
+            id: key,
+            title: c.listing.title,
+            thumbnailUrl: getListingImage(c),
+            status: c.listing.status || null,
+            price: c.listing.price ?? null,
+            conversations: [],
+            totalUnread: 0,
+            latestMessageAt: c.last_message_at,
+          };
+          map.set(key, group);
+        }
+      } else if (c.wanted_post) {
+        key = `w:${c.wanted_post.id}`;
+        if (!map.has(key)) {
+          group = {
+            kind: 'wanted_post',
+            id: key,
+            title: `Wanted: ${c.wanted_post.title}`,
+            thumbnailUrl: null,
+            status: null,
+            price: null,
+            conversations: [],
+            totalUnread: 0,
+            latestMessageAt: c.last_message_at,
+          };
+          map.set(key, group);
+        }
+      } else {
+        key = `o:${c.id}`;
+        if (!map.has(key)) {
+          group = {
+            kind: 'orphan',
+            id: key,
+            title: 'Conversation',
+            thumbnailUrl: null,
+            status: null,
+            price: null,
+            conversations: [],
+            totalUnread: 0,
+            latestMessageAt: c.last_message_at,
+          };
+          map.set(key, group);
+        }
+      }
+
+      const g = map.get(key)!;
+      g.conversations.push(c);
+      g.totalUnread += getUnreadCount(c);
+      if (new Date(c.last_message_at).getTime() > new Date(g.latestMessageAt).getTime()) {
+        g.latestMessageAt = c.last_message_at;
+      }
+    }
+
+    // Sort groups by latest message, and sort inner conversations the same way
+    const list = Array.from(map.values());
+    list.sort(
+      (a, b) => new Date(b.latestMessageAt).getTime() - new Date(a.latestMessageAt).getTime()
+    );
+    for (const g of list) {
+      g.conversations.sort(
+        (a, b) => new Date(b.last_message_at).getTime() - new Date(a.last_message_at).getTime()
+      );
+    }
+    return list;
+  });
+
+  // --- Tab filtering (sold/active/all) ---
+
+  const tabGroups = (key: TabKey) => {
+    if (key === 'all') return allGroups.value;
+    if (key === 'sold') return allGroups.value.filter((g) => g.status === 'sold');
+    // active = everything that isn't sold (includes wanted posts / orphans)
+    return allGroups.value.filter((g) => g.status !== 'sold');
+  };
+
+  const tabs = computed(() => [
+    { key: 'active' as TabKey, label: t('tabs.active'), count: tabGroups('active').length },
+    { key: 'sold' as TabKey, label: t('tabs.sold'), count: tabGroups('sold').length },
+    { key: 'all' as TabKey, label: t('tabs.all'), count: allGroups.value.length },
+  ]);
+
+  // --- Search ---
+  // A group appears if (a) its title matches, OR (b) at least one of its
+  // conversations has a matching participant name. Within a shown group,
+  // if the title didn't match, only matching conversations are rendered.
+
+  const matchesTitle = (group: ConversationGroup, q: string) =>
+    group.title.toLowerCase().includes(q);
+
+  const matchesParticipant = (c: Conversation, q: string) => {
+    const p = getOtherParticipant(c);
+    return (p?.name || '').toLowerCase().includes(q);
+  };
+
+  const visibleGroups = computed<ConversationGroup[]>(() => {
+    const base = tabGroups(activeTab.value);
+    const q = searchQuery.value.trim().toLowerCase();
+    if (!q) return base;
+
+    const result: ConversationGroup[] = [];
+    for (const g of base) {
+      if (matchesTitle(g, q)) {
+        // Title matches — keep the whole group
+        result.push(g);
+        continue;
+      }
+      const matchingConvos = g.conversations.filter((c) => matchesParticipant(c, q));
+      if (matchingConvos.length > 0) {
+        result.push({
+          ...g,
+          conversations: matchingConvos,
+          totalUnread: matchingConvos.reduce((sum, c) => sum + getUnreadCount(c), 0),
+        });
+      }
+    }
+    return result;
+  });
+
+  // --- Group open/close state ---
+  // Default open: groups with unread messages, or all groups when searching.
+  const manuallyToggled = ref<Record<string, boolean>>({});
+
+  const isGroupOpen = (groupId: string) => {
+    if (groupId in manuallyToggled.value) return manuallyToggled.value[groupId];
+    if (searchQuery.value.trim()) return true;
+    const g = allGroups.value.find((x) => x.id === groupId);
+    return !!g && g.totalUnread > 0;
+  };
+
+  const toggleGroup = (groupId: string) => {
+    manuallyToggled.value = {
+      ...manuallyToggled.value,
+      [groupId]: !isGroupOpen(groupId),
+    };
+  };
+
+  // --- Data loading ---
+
+  const retryFetch = async () => {
+    error.value = false;
+    try {
+      conversations.value = await fetchConversations();
+    } catch {
+      error.value = true;
+    }
+  };
+
+  onMounted(async () => {
+    try {
+      conversations.value = await fetchConversations();
+    } catch {
+      error.value = true;
+      return;
+    }
+
+    capture('inbox_viewed', {
+      conversation_count: conversations.value.length,
+      unread_total: conversations.value.reduce(
+        (sum, c) => sum + (c.buyer_unread_count || 0) + (c.seller_unread_count || 0),
+        0
+      ),
+    });
+  });
+
+  // Real-time subscription for new/updated conversations
+  const supabase = useSupabase();
+
+  onMounted(() => {
+    if (!user.value) return;
+
+    const channel = supabase
+      .channel('conversations')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'conversations',
+          filter: `buyer_id=eq.${user.value.id}`,
+        },
+        async () => {
+          conversations.value = await fetchConversations();
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'conversations',
+          filter: `seller_id=eq.${user.value.id}`,
+        },
+        async () => {
+          conversations.value = await fetchConversations();
+        }
+      )
+      .subscribe();
+
+    onBeforeUnmount(() => {
+      supabase.removeChannel(channel);
+    });
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "seo": { "title": "Messages - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "Messages", "subtitle": "Grouped by listing — click a listing to see everyone who messaged you about it" },
+    "error": { "title": "Failed to load messages", "body": "Something went wrong. Please try again.", "retry": "Try Again" },
+    "search": { "placeholder": "Search by listing title or person...", "ariaLabel": "Search conversations", "clear": "Clear search" },
+    "tabs": { "active": "Active", "sold": "Sold", "all": "All" },
+    "empty": { "title": "No messages yet", "body": "Start a conversation by contacting a seller on a listing", "browse": "Browse Listings" },
+    "emptySearch": { "noMatch": "No conversations match \"{query}\"", "noTab": "No conversations in this tab" }
+  },
+  "es": {
+    "seo": { "title": "Mensajes - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "Mensajes", "subtitle": "Agrupados por anuncio — haz clic en un anuncio para ver a todos los que te escribieron sobre él" },
+    "error": { "title": "Error al cargar los mensajes", "body": "Algo salió mal. Inténtalo de nuevo.", "retry": "Reintentar" },
+    "search": { "placeholder": "Buscar por título de anuncio o persona...", "ariaLabel": "Buscar conversaciones", "clear": "Borrar búsqueda" },
+    "tabs": { "active": "Activos", "sold": "Vendidos", "all": "Todos" },
+    "empty": { "title": "Aún no hay mensajes", "body": "Inicia una conversación contactando a un vendedor en un anuncio", "browse": "Explorar anuncios" },
+    "emptySearch": { "noMatch": "Ninguna conversación coincide con \"{query}\"", "noTab": "No hay conversaciones en esta pestaña" }
+  },
+  "fr": {
+    "seo": { "title": "Messages - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "Messages", "subtitle": "Regroupés par annonce — cliquez sur une annonce pour voir tous ceux qui vous ont écrit à son sujet" },
+    "error": { "title": "Échec du chargement des messages", "body": "Une erreur s'est produite. Veuillez réessayer.", "retry": "Réessayer" },
+    "search": { "placeholder": "Rechercher par titre d'annonce ou personne...", "ariaLabel": "Rechercher des conversations", "clear": "Effacer la recherche" },
+    "tabs": { "active": "Actives", "sold": "Vendues", "all": "Toutes" },
+    "empty": { "title": "Aucun message pour l'instant", "body": "Démarrez une conversation en contactant un vendeur sur une annonce", "browse": "Parcourir les annonces" },
+    "emptySearch": { "noMatch": "Aucune conversation ne correspond à \"{query}\"", "noTab": "Aucune conversation dans cet onglet" }
+  },
+  "de": {
+    "seo": { "title": "Nachrichten - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "Nachrichten", "subtitle": "Nach Anzeige gruppiert — klicken Sie auf eine Anzeige, um alle zu sehen, die Ihnen dazu geschrieben haben" },
+    "error": { "title": "Nachrichten konnten nicht geladen werden", "body": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.", "retry": "Erneut versuchen" },
+    "search": { "placeholder": "Nach Anzeigentitel oder Person suchen...", "ariaLabel": "Konversationen durchsuchen", "clear": "Suche löschen" },
+    "tabs": { "active": "Aktiv", "sold": "Verkauft", "all": "Alle" },
+    "empty": { "title": "Noch keine Nachrichten", "body": "Starten Sie eine Konversation, indem Sie einen Verkäufer zu einer Anzeige kontaktieren", "browse": "Anzeigen durchsuchen" },
+    "emptySearch": { "noMatch": "Keine Konversationen passen zu \"{query}\"", "noTab": "Keine Konversationen in diesem Tab" }
+  },
+  "it": {
+    "seo": { "title": "Messaggi - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "Messaggi", "subtitle": "Raggruppati per annuncio — clicca su un annuncio per vedere tutti quelli che ti hanno scritto al riguardo" },
+    "error": { "title": "Impossibile caricare i messaggi", "body": "Qualcosa è andato storto. Riprova.", "retry": "Riprova" },
+    "search": { "placeholder": "Cerca per titolo annuncio o persona...", "ariaLabel": "Cerca conversazioni", "clear": "Cancella ricerca" },
+    "tabs": { "active": "Attivi", "sold": "Venduti", "all": "Tutti" },
+    "empty": { "title": "Ancora nessun messaggio", "body": "Avvia una conversazione contattando un venditore su un annuncio", "browse": "Sfoglia annunci" },
+    "emptySearch": { "noMatch": "Nessuna conversazione corrisponde a \"{query}\"", "noTab": "Nessuna conversazione in questa scheda" }
+  },
+  "pt": {
+    "seo": { "title": "Mensagens - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "Mensagens", "subtitle": "Agrupadas por anúncio — clique num anúncio para ver todos que lhe enviaram mensagem sobre ele" },
+    "error": { "title": "Falha ao carregar as mensagens", "body": "Algo correu mal. Tente novamente.", "retry": "Tentar novamente" },
+    "search": { "placeholder": "Pesquisar por título do anúncio ou pessoa...", "ariaLabel": "Pesquisar conversas", "clear": "Limpar pesquisa" },
+    "tabs": { "active": "Ativas", "sold": "Vendidas", "all": "Todas" },
+    "empty": { "title": "Ainda não há mensagens", "body": "Inicie uma conversa contactando um vendedor num anúncio", "browse": "Explorar anúncios" },
+    "emptySearch": { "noMatch": "Nenhuma conversa corresponde a \"{query}\"", "noTab": "Nenhuma conversa neste separador" }
+  },
+  "ru": {
+    "seo": { "title": "Сообщения - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "Сообщения", "subtitle": "Сгруппированы по объявлению — нажмите на объявление, чтобы увидеть всех, кто вам по нему написал" },
+    "error": { "title": "Не удалось загрузить сообщения", "body": "Что-то пошло не так. Пожалуйста, попробуйте снова.", "retry": "Повторить" },
+    "search": { "placeholder": "Поиск по названию объявления или человеку...", "ariaLabel": "Поиск по переписке", "clear": "Очистить поиск" },
+    "tabs": { "active": "Активные", "sold": "Проданные", "all": "Все" },
+    "empty": { "title": "Сообщений пока нет", "body": "Начните переписку, связавшись с продавцом по объявлению", "browse": "Просмотреть объявления" },
+    "emptySearch": { "noMatch": "Нет переписок, соответствующих \"{query}\"", "noTab": "Нет переписок на этой вкладке" }
+  },
+  "ja": {
+    "seo": { "title": "メッセージ - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "メッセージ", "subtitle": "出品ごとにグループ化 — 出品をクリックすると、その件であなたに連絡した全員を確認できます" },
+    "error": { "title": "メッセージの読み込みに失敗しました", "body": "問題が発生しました。もう一度お試しください。", "retry": "再試行" },
+    "search": { "placeholder": "出品タイトルまたは人物で検索...", "ariaLabel": "会話を検索", "clear": "検索をクリア" },
+    "tabs": { "active": "アクティブ", "sold": "売却済み", "all": "すべて" },
+    "empty": { "title": "まだメッセージはありません", "body": "出品の販売者に連絡して会話を始めましょう", "browse": "出品を見る" },
+    "emptySearch": { "noMatch": "「{query}」に一致する会話はありません", "noTab": "このタブに会話はありません" }
+  },
+  "zh": {
+    "seo": { "title": "消息 - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "消息", "subtitle": "按刊登分组 — 点击某个刊登即可查看就此联系过你的所有人" },
+    "error": { "title": "加载消息失败", "body": "出了点问题，请重试。", "retry": "重试" },
+    "search": { "placeholder": "按刊登标题或人员搜索...", "ariaLabel": "搜索会话", "clear": "清除搜索" },
+    "tabs": { "active": "进行中", "sold": "已售", "all": "全部" },
+    "empty": { "title": "暂无消息", "body": "通过在刊登上联系卖家来开始对话", "browse": "浏览刊登" },
+    "emptySearch": { "noMatch": "没有与“{query}”匹配的会话", "noTab": "此标签下没有会话" }
+  },
+  "ko": {
+    "seo": { "title": "메시지 - The Mini Exchange | Classic Mini DIY" },
+    "header": { "title": "메시지", "subtitle": "매물별로 그룹화 — 매물을 클릭하면 그 건에 대해 당신에게 메시지를 보낸 모든 사람을 볼 수 있습니다" },
+    "error": { "title": "메시지를 불러오지 못했습니다", "body": "문제가 발생했습니다. 다시 시도해 주세요.", "retry": "다시 시도" },
+    "search": { "placeholder": "매물 제목 또는 사람으로 검색...", "ariaLabel": "대화 검색", "clear": "검색 지우기" },
+    "tabs": { "active": "활성", "sold": "판매됨", "all": "전체" },
+    "empty": { "title": "아직 메시지가 없습니다", "body": "매물에서 판매자에게 연락하여 대화를 시작하세요", "browse": "매물 둘러보기" },
+    "emptySearch": { "noMatch": "\"{query}\"와 일치하는 대화가 없습니다", "noTab": "이 탭에 대화가 없습니다" }
+  }
+}
+</i18n>

--- a/app/pages/exchange/messages/index.vue
+++ b/app/pages/exchange/messages/index.vue
@@ -179,7 +179,7 @@
           group = {
             kind: 'wanted_post',
             id: key,
-            title: `Wanted: ${c.wanted_post.title}`,
+            title: t('groups.wanted', { title: c.wanted_post.title }),
             thumbnailUrl: null,
             status: null,
             price: null,
@@ -195,7 +195,7 @@
           group = {
             kind: 'orphan',
             id: key,
-            title: 'Conversation',
+            title: t('groups.orphan'),
             thumbnailUrl: null,
             status: null,
             price: null,
@@ -375,7 +375,8 @@
     "search": { "placeholder": "Search by listing title or person...", "ariaLabel": "Search conversations", "clear": "Clear search" },
     "tabs": { "active": "Active", "sold": "Sold", "all": "All" },
     "empty": { "title": "No messages yet", "body": "Start a conversation by contacting a seller on a listing", "browse": "Browse Listings" },
-    "emptySearch": { "noMatch": "No conversations match \"{query}\"", "noTab": "No conversations in this tab" }
+    "emptySearch": { "noMatch": "No conversations match \"{query}\"", "noTab": "No conversations in this tab" },
+    "groups": { "wanted": "Wanted: {title}", "orphan": "Conversation" }
   },
   "es": {
     "seo": { "title": "Mensajes - The Mini Exchange | Classic Mini DIY" },
@@ -384,7 +385,8 @@
     "search": { "placeholder": "Buscar por título de anuncio o persona...", "ariaLabel": "Buscar conversaciones", "clear": "Borrar búsqueda" },
     "tabs": { "active": "Activos", "sold": "Vendidos", "all": "Todos" },
     "empty": { "title": "Aún no hay mensajes", "body": "Inicia una conversación contactando a un vendedor en un anuncio", "browse": "Explorar anuncios" },
-    "emptySearch": { "noMatch": "Ninguna conversación coincide con \"{query}\"", "noTab": "No hay conversaciones en esta pestaña" }
+    "emptySearch": { "noMatch": "Ninguna conversación coincide con \"{query}\"", "noTab": "No hay conversaciones en esta pestaña" },
+    "groups": { "wanted": "Buscado: {title}", "orphan": "Conversación" }
   },
   "fr": {
     "seo": { "title": "Messages - The Mini Exchange | Classic Mini DIY" },
@@ -393,7 +395,8 @@
     "search": { "placeholder": "Rechercher par titre d'annonce ou personne...", "ariaLabel": "Rechercher des conversations", "clear": "Effacer la recherche" },
     "tabs": { "active": "Actives", "sold": "Vendues", "all": "Toutes" },
     "empty": { "title": "Aucun message pour l'instant", "body": "Démarrez une conversation en contactant un vendeur sur une annonce", "browse": "Parcourir les annonces" },
-    "emptySearch": { "noMatch": "Aucune conversation ne correspond à \"{query}\"", "noTab": "Aucune conversation dans cet onglet" }
+    "emptySearch": { "noMatch": "Aucune conversation ne correspond à \"{query}\"", "noTab": "Aucune conversation dans cet onglet" },
+    "groups": { "wanted": "Recherché : {title}", "orphan": "Conversation" }
   },
   "de": {
     "seo": { "title": "Nachrichten - The Mini Exchange | Classic Mini DIY" },
@@ -402,7 +405,8 @@
     "search": { "placeholder": "Nach Anzeigentitel oder Person suchen...", "ariaLabel": "Konversationen durchsuchen", "clear": "Suche löschen" },
     "tabs": { "active": "Aktiv", "sold": "Verkauft", "all": "Alle" },
     "empty": { "title": "Noch keine Nachrichten", "body": "Starten Sie eine Konversation, indem Sie einen Verkäufer zu einer Anzeige kontaktieren", "browse": "Anzeigen durchsuchen" },
-    "emptySearch": { "noMatch": "Keine Konversationen passen zu \"{query}\"", "noTab": "Keine Konversationen in diesem Tab" }
+    "emptySearch": { "noMatch": "Keine Konversationen passen zu \"{query}\"", "noTab": "Keine Konversationen in diesem Tab" },
+    "groups": { "wanted": "Gesucht: {title}", "orphan": "Konversation" }
   },
   "it": {
     "seo": { "title": "Messaggi - The Mini Exchange | Classic Mini DIY" },
@@ -411,7 +415,8 @@
     "search": { "placeholder": "Cerca per titolo annuncio o persona...", "ariaLabel": "Cerca conversazioni", "clear": "Cancella ricerca" },
     "tabs": { "active": "Attivi", "sold": "Venduti", "all": "Tutti" },
     "empty": { "title": "Ancora nessun messaggio", "body": "Avvia una conversazione contattando un venditore su un annuncio", "browse": "Sfoglia annunci" },
-    "emptySearch": { "noMatch": "Nessuna conversazione corrisponde a \"{query}\"", "noTab": "Nessuna conversazione in questa scheda" }
+    "emptySearch": { "noMatch": "Nessuna conversazione corrisponde a \"{query}\"", "noTab": "Nessuna conversazione in questa scheda" },
+    "groups": { "wanted": "Cercato: {title}", "orphan": "Conversazione" }
   },
   "pt": {
     "seo": { "title": "Mensagens - The Mini Exchange | Classic Mini DIY" },
@@ -420,7 +425,8 @@
     "search": { "placeholder": "Pesquisar por título do anúncio ou pessoa...", "ariaLabel": "Pesquisar conversas", "clear": "Limpar pesquisa" },
     "tabs": { "active": "Ativas", "sold": "Vendidas", "all": "Todas" },
     "empty": { "title": "Ainda não há mensagens", "body": "Inicie uma conversa contactando um vendedor num anúncio", "browse": "Explorar anúncios" },
-    "emptySearch": { "noMatch": "Nenhuma conversa corresponde a \"{query}\"", "noTab": "Nenhuma conversa neste separador" }
+    "emptySearch": { "noMatch": "Nenhuma conversa corresponde a \"{query}\"", "noTab": "Nenhuma conversa neste separador" },
+    "groups": { "wanted": "Procurado: {title}", "orphan": "Conversa" }
   },
   "ru": {
     "seo": { "title": "Сообщения - The Mini Exchange | Classic Mini DIY" },
@@ -429,7 +435,8 @@
     "search": { "placeholder": "Поиск по названию объявления или человеку...", "ariaLabel": "Поиск по переписке", "clear": "Очистить поиск" },
     "tabs": { "active": "Активные", "sold": "Проданные", "all": "Все" },
     "empty": { "title": "Сообщений пока нет", "body": "Начните переписку, связавшись с продавцом по объявлению", "browse": "Просмотреть объявления" },
-    "emptySearch": { "noMatch": "Нет переписок, соответствующих \"{query}\"", "noTab": "Нет переписок на этой вкладке" }
+    "emptySearch": { "noMatch": "Нет переписок, соответствующих \"{query}\"", "noTab": "Нет переписок на этой вкладке" },
+    "groups": { "wanted": "Куплю: {title}", "orphan": "Переписка" }
   },
   "ja": {
     "seo": { "title": "メッセージ - The Mini Exchange | Classic Mini DIY" },
@@ -438,7 +445,8 @@
     "search": { "placeholder": "出品タイトルまたは人物で検索...", "ariaLabel": "会話を検索", "clear": "検索をクリア" },
     "tabs": { "active": "アクティブ", "sold": "売却済み", "all": "すべて" },
     "empty": { "title": "まだメッセージはありません", "body": "出品の販売者に連絡して会話を始めましょう", "browse": "出品を見る" },
-    "emptySearch": { "noMatch": "「{query}」に一致する会話はありません", "noTab": "このタブに会話はありません" }
+    "emptySearch": { "noMatch": "「{query}」に一致する会話はありません", "noTab": "このタブに会話はありません" },
+    "groups": { "wanted": "募集中: {title}", "orphan": "会話" }
   },
   "zh": {
     "seo": { "title": "消息 - The Mini Exchange | Classic Mini DIY" },
@@ -447,7 +455,8 @@
     "search": { "placeholder": "按刊登标题或人员搜索...", "ariaLabel": "搜索会话", "clear": "清除搜索" },
     "tabs": { "active": "进行中", "sold": "已售", "all": "全部" },
     "empty": { "title": "暂无消息", "body": "通过在刊登上联系卖家来开始对话", "browse": "浏览刊登" },
-    "emptySearch": { "noMatch": "没有与“{query}”匹配的会话", "noTab": "此标签下没有会话" }
+    "emptySearch": { "noMatch": "没有与“{query}”匹配的会话", "noTab": "此标签下没有会话" },
+    "groups": { "wanted": "求购：{title}", "orphan": "会话" }
   },
   "ko": {
     "seo": { "title": "메시지 - The Mini Exchange | Classic Mini DIY" },
@@ -456,7 +465,8 @@
     "search": { "placeholder": "매물 제목 또는 사람으로 검색...", "ariaLabel": "대화 검색", "clear": "검색 지우기" },
     "tabs": { "active": "활성", "sold": "판매됨", "all": "전체" },
     "empty": { "title": "아직 메시지가 없습니다", "body": "매물에서 판매자에게 연락하여 대화를 시작하세요", "browse": "매물 둘러보기" },
-    "emptySearch": { "noMatch": "\"{query}\"와 일치하는 대화가 없습니다", "noTab": "이 탭에 대화가 없습니다" }
+    "emptySearch": { "noMatch": "\"{query}\"와 일치하는 대화가 없습니다", "noTab": "이 탭에 대화가 없습니다" },
+    "groups": { "wanted": "구함: {title}", "orphan": "대화" }
   }
 }
 </i18n>

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared date and formatting utilities
+ */
+
+/**
+ * Format a date string with full date and time
+ * Example: "Feb 10, 2026, 3:45 PM"
+ */
+export function formatDateTime(dateString: string): string {
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+/**
+ * Format a date string with date only (no time)
+ * Example: "Feb 10, 2026"
+ */
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+/**
+ * Format a timestamp as a short, messenger-style relative time.
+ *
+ * Rules:
+ *   < 1 min     → "just now"
+ *   < 1 hour    → "Nm ago"
+ *   < 24 hours  → "Nh ago"
+ *   < 7 days    → "Nd ago"
+ *   older       → "Mon D, h:mm AM" (with time) or "Mon D" (without)
+ *
+ * Used by the messaging UI (MessageList, ListingConversationGroup, etc.)
+ * where space is tight and "2h ago" is friendlier than a full timestamp.
+ */
+export function formatRelativeTime(
+  timestamp: string,
+  options: { includeTime?: boolean } = {}
+): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    ...(options.includeTime ? { hour: '2-digit', minute: '2-digit' } : {}),
+  });
+}

--- a/app/utils/markdown.ts
+++ b/app/utils/markdown.ts
@@ -1,0 +1,176 @@
+/**
+ * Markdown renderer for chat messages.
+ *
+ * Supports a deliberately narrow subset of CommonMark/GFM:
+ *   - Bold, italic, strikethrough
+ *   - Inline code and fenced code blocks
+ *   - Bulleted and numbered lists
+ *   - Links (forced to open in a new tab with noopener/noreferrer/nofollow/ugc)
+ *   - Line breaks
+ *
+ * Disallowed: headings, blockquotes, tables, images, raw HTML.
+ *
+ * On the client, output is sanitized with DOMPurify.
+ * On the server (SSR), we rely on marked's controlled renderer (raw HTML is
+ * disabled) and simple tag-stripping — the client re-sanitizes during hydration.
+ *
+ * This avoids pulling jsdom into the production server bundle, which caused
+ * ESM/CJS crashes with html-encoding-sniffer.
+ */
+
+import { Marked } from 'marked';
+
+const ALLOWED_TAGS = [
+  'p',
+  'br',
+  'strong',
+  'em',
+  'del',
+  'code',
+  'pre',
+  'ul',
+  'ol',
+  'li',
+  'a',
+];
+
+const ALLOWED_ATTR = ['href', 'target', 'rel'];
+
+// Configure a marked instance that ignores headings and blockquotes by
+// rendering them as plain paragraphs. Raw HTML is disabled by default.
+const marked = new Marked({
+  gfm: true,
+  breaks: true,
+});
+
+marked.use({
+  renderer: {
+    heading({ tokens }) {
+      // Collapse headings to paragraphs so `# big` shows as plain text.
+      return `<p>${this.parser.parseInline(tokens)}</p>`;
+    },
+    blockquote({ tokens }) {
+      return `<p>${this.parser.parse(tokens)}</p>`;
+    },
+    image() {
+      // Inline markdown images are not allowed in chat.
+      return '';
+    },
+    html() {
+      // Strip any raw HTML that slipped past marked.
+      return '';
+    },
+  },
+});
+
+// Lazy-loaded DOMPurify instance (client-only)
+let purifyInstance: typeof import('dompurify').default | null = null;
+let hooksInstalled = false;
+
+async function getPurify() {
+  if (purifyInstance) return purifyInstance;
+  const mod = await import('dompurify');
+  purifyInstance = mod.default;
+  return purifyInstance;
+}
+
+/**
+ * DOMPurify hook: force safe link attributes on every <a> tag.
+ */
+function installLinkHardening(purify: typeof import('dompurify').default) {
+  if (hooksInstalled) return;
+  purify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.nodeName === 'A') {
+      const el = node as Element;
+      el.setAttribute('target', '_blank');
+      el.setAttribute('rel', 'noopener noreferrer nofollow ugc');
+    }
+  });
+  hooksInstalled = true;
+}
+
+/**
+ * Server-side fallback: strip disallowed HTML tags.
+ * Since our marked renderer already blocks raw HTML, headings, images, etc.,
+ * this is a belt-and-suspenders measure. The client re-sanitizes with DOMPurify.
+ */
+function serverSanitize(html: string): string {
+  const allowedTagPattern = ALLOWED_TAGS.join('|');
+  // Remove any tag that isn't in our allowed list
+  return html.replace(/<\/?([a-z][a-z0-9]*)\b[^>]*>/gi, (match, tag) => {
+    if (ALLOWED_TAGS.includes(tag.toLowerCase())) {
+      return match;
+    }
+    return '';
+  });
+}
+
+/**
+ * Force safe attributes on links in the server-side output.
+ * Also strips dangerous protocols (javascript:, data:, vbscript:).
+ */
+function serverHardenLinks(html: string): string {
+  return html.replace(/<a(\s+[^>]*)?>/gi, (_match, attrs = '') => {
+    // Handle double-quoted, single-quoted, or unquoted href values
+    const hrefMatch = attrs.match(/href=(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i);
+    const href = hrefMatch ? (hrefMatch[1] ?? hrefMatch[2] ?? hrefMatch[3] ?? '') : '';
+    // Strip dangerous protocols
+    const normalized = href.replace(/\s/g, '').toLowerCase();
+    if (normalized.startsWith('javascript:') || normalized.startsWith('data:') || normalized.startsWith('vbscript:')) {
+      return '<a href="" target="_blank" rel="noopener noreferrer nofollow ugc">';
+    }
+    // Escape any quotes in the href to prevent attribute injection
+    const safeHref = href.replace(/"/g, '&quot;');
+    return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer nofollow ugc">`;
+  });
+}
+
+/**
+ * Render a user-supplied message as sanitized HTML.
+ * Safe for `v-html`.
+ */
+export function renderMessageMarkdown(content: string): string {
+  if (!content) return '';
+  const rawHtml = marked.parse(content, { async: false }) as string;
+
+  // Client: full DOMPurify sanitization
+  if (import.meta.client) {
+    // DOMPurify is loaded synchronously after the first async load.
+    // On SSR-hydrated pages, the client will re-render so the first paint
+    // uses the server output, then the client takes over with full sanitization.
+    if (purifyInstance) {
+      installLinkHardening(purifyInstance);
+      return purifyInstance.sanitize(rawHtml, {
+        ALLOWED_TAGS,
+        ALLOWED_ATTR,
+        FORBID_TAGS: ['img', 'script', 'style', 'iframe'],
+      });
+    }
+    // Trigger lazy load for next render; return server-sanitized for now
+    getPurify().then((p) => installLinkHardening(p));
+  }
+
+  // Server (or client before DOMPurify loads): lightweight sanitization
+  return serverHardenLinks(serverSanitize(rawHtml));
+}
+
+/**
+ * Strip markdown formatting for plaintext contexts (email previews, notifications).
+ * Not a complete markdown-to-text converter, but covers the formatting we allow.
+ */
+export function stripMessageMarkdown(content: string): string {
+  if (!content) return '';
+  return content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/_([^_]+)_/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/^[-*+]\s+/gm, '')
+    .replace(/^\d+\.\s+/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -537,6 +537,10 @@ export default defineNuxtConfig({
     // endpoint works without it but is rate-limited (~50 req/day). Set for the
     // pro tier. Read server-side only and forwarded to renderExternalPage().
     MICROLINK_API_KEY: process.env.MICROLINK_API_KEY || '',
+    // Camino AI key for the exchange safe-meeting-spot + distance proxies
+    // (server/utils/exchange/camino.ts). Optional — the camino routes 502
+    // gracefully when unset; set CAMINO_API_KEY in prod to enable.
+    caminoApiKey: process.env.CAMINO_API_KEY || '',
     NODE_ENV: process.env.NODE_ENV || 'development',
   },
 

--- a/server/api/exchange/camino/distance.post.ts
+++ b/server/api/exchange/camino/distance.post.ts
@@ -1,0 +1,78 @@
+/**
+ * POST /api/exchange/camino/distance
+ * Distance + drive time between buyer and listing locations, proxied through the
+ * server to keep the Camino API key private. Converged from TheMiniExchange's
+ * /api/camino/distance. Public + rate-limited; cached 24h.
+ */
+import { caminoFetch, type CaminoRelationshipResponse } from '../../../utils/exchange/camino';
+import { createRateLimitMiddleware, RateLimitPresets } from '../../../utils/exchange/rateLimit';
+
+interface DistanceRequest {
+  buyerLat: number;
+  buyerLon: number;
+  listingLat: number;
+  listingLon: number;
+}
+
+export interface DistanceResponse {
+  distance_km: number;
+  distance_miles: number;
+  driving_time: string;
+  duration_seconds: number;
+  direction: string;
+  description: string;
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<DistanceRequest>(event);
+
+  if (!body.buyerLat || !body.buyerLon || !body.listingLat || !body.listingLon) {
+    throw createError({ statusCode: 400, message: 'Missing coordinates' });
+  }
+
+  if (
+    Math.abs(body.buyerLat) > 90 ||
+    Math.abs(body.listingLat) > 90 ||
+    Math.abs(body.buyerLon) > 180 ||
+    Math.abs(body.listingLon) > 180
+  ) {
+    throw createError({ statusCode: 400, message: 'Invalid coordinates' });
+  }
+
+  const rateLimitCheck = createRateLimitMiddleware({
+    ...RateLimitPresets.lenient,
+    keyPrefix: 'camino-distance',
+  });
+  await rateLimitCheck(event);
+
+  const cacheKey = `camino:distance:${Math.round(body.buyerLat * 10)}:${Math.round(body.buyerLon * 10)}:${body.listingLat}:${body.listingLon}`;
+  const cached = await useStorage('cache').getItem<DistanceResponse>(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const data = await caminoFetch<CaminoRelationshipResponse>('/relationship', {
+      method: 'POST',
+      body: {
+        start: { lat: body.buyerLat, lon: body.buyerLon },
+        end: { lat: body.listingLat, lon: body.listingLon },
+        include: ['distance', 'direction', 'travel_time', 'description'],
+      },
+    });
+
+    const distanceKm = data.actual_distance_km || 0;
+    const result: DistanceResponse = {
+      distance_km: distanceKm,
+      distance_miles: Math.round(distanceKm * 0.621371 * 10) / 10,
+      driving_time: data.driving_time || '',
+      duration_seconds: data.duration_seconds || 0,
+      direction: data.direction || '',
+      description: data.description || '',
+    };
+
+    await useStorage('cache').setItem(cacheKey, result, { ttl: 86400 });
+    return result;
+  } catch (err: any) {
+    console.error('Camino distance API error:', err?.message || err);
+    throw createError({ statusCode: 502, message: 'Failed to calculate distance' });
+  }
+});

--- a/server/api/exchange/camino/distance.post.ts
+++ b/server/api/exchange/camino/distance.post.ts
@@ -26,7 +26,7 @@ export interface DistanceResponse {
 export default defineEventHandler(async (event) => {
   const body = await readBody<DistanceRequest>(event);
 
-  if (!body.buyerLat || !body.buyerLon || !body.listingLat || !body.listingLon) {
+  if (body.buyerLat == null || body.buyerLon == null || body.listingLat == null || body.listingLon == null) {
     throw createError({ statusCode: 400, message: 'Missing coordinates' });
   }
 

--- a/server/api/exchange/camino/meeting-spots.post.ts
+++ b/server/api/exchange/camino/meeting-spots.post.ts
@@ -18,7 +18,7 @@ interface MeetingSpotsRequest {
 export default defineEventHandler(async (event) => {
   const body = await readBody<MeetingSpotsRequest>(event);
 
-  if (!body.buyerLat || !body.buyerLon || !body.sellerLat || !body.sellerLon) {
+  if (body.buyerLat == null || body.buyerLon == null || body.sellerLat == null || body.sellerLon == null) {
     throw createError({ statusCode: 400, message: 'Missing coordinates for both parties' });
   }
 

--- a/server/api/exchange/camino/meeting-spots.post.ts
+++ b/server/api/exchange/camino/meeting-spots.post.ts
@@ -1,0 +1,61 @@
+/**
+ * POST /api/exchange/camino/meeting-spots
+ * Suggests safe, public meeting locations roughly halfway between buyer and
+ * seller. Coordinates are fuzzed for privacy before computing the midpoint.
+ * Converged from TheMiniExchange's /api/camino/meeting-spots.
+ */
+import { createRateLimitMiddleware, RateLimitPresets } from '../../../utils/exchange/rateLimit';
+import { fuzzCoordinates, calculateMidpoint } from '../../../utils/exchange/geo';
+import { findMeetingSpots, enrichWithDriveTimes } from '../../../utils/exchange/meetingSpots';
+
+interface MeetingSpotsRequest {
+  buyerLat: number;
+  buyerLon: number;
+  sellerLat: number;
+  sellerLon: number;
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<MeetingSpotsRequest>(event);
+
+  if (!body.buyerLat || !body.buyerLon || !body.sellerLat || !body.sellerLon) {
+    throw createError({ statusCode: 400, message: 'Missing coordinates for both parties' });
+  }
+
+  if (
+    Math.abs(body.buyerLat) > 90 ||
+    Math.abs(body.sellerLat) > 90 ||
+    Math.abs(body.buyerLon) > 180 ||
+    Math.abs(body.sellerLon) > 180
+  ) {
+    throw createError({ statusCode: 400, message: 'Invalid coordinates' });
+  }
+
+  const rateLimitCheck = createRateLimitMiddleware({
+    ...RateLimitPresets.moderate,
+    keyPrefix: 'camino-meeting',
+  });
+  await rateLimitCheck(event);
+
+  try {
+    const fuzzedBuyer = fuzzCoordinates(body.buyerLat, body.buyerLon);
+    const fuzzedSeller = fuzzCoordinates(body.sellerLat, body.sellerLon);
+    const midpoint = calculateMidpoint(fuzzedBuyer.lat, fuzzedBuyer.lon, fuzzedSeller.lat, fuzzedSeller.lon);
+
+    const spots = await findMeetingSpots(midpoint.lat, midpoint.lon);
+    if (spots.length === 0) {
+      return { midpoint, suggestions: [] };
+    }
+
+    const enriched = await enrichWithDriveTimes(
+      spots,
+      { lat: body.buyerLat, lon: body.buyerLon },
+      { lat: body.sellerLat, lon: body.sellerLon }
+    );
+
+    return { midpoint, suggestions: enriched };
+  } catch (err: any) {
+    console.error('Meeting spot error:', err?.message || err);
+    throw createError({ statusCode: 502, message: 'Failed to find meeting spots' });
+  }
+});

--- a/server/api/exchange/external-listings/[id].delete.ts
+++ b/server/api/exchange/external-listings/[id].delete.ts
@@ -1,0 +1,53 @@
+/**
+ * DELETE /api/exchange/external-listings/[id]
+ *
+ * Delete a Find (external listing). Mirrors wanted/[id].delete auth, but a HARD
+ * delete (Finds have no conversation cascade to preserve). Submitters may delete
+ * only their own PENDING submission (matches RLS); admins may delete any.
+ */
+import { createRateLimitMiddleware, RateLimitPresets } from '../../../utils/exchange/rateLimit';
+import { requireUserClient } from '../../../utils/userAuth';
+import { getServiceClient } from '../../../utils/supabase';
+
+const rateLimitMiddleware = createRateLimitMiddleware({ ...RateLimitPresets.moderate, keyPrefix: 'finds-delete' });
+
+export default defineEventHandler(async (event) => {
+  await rateLimitMiddleware(event);
+
+  try {
+    const { user } = await requireUserClient(event);
+    const supabase = getServiceClient();
+
+    const findId = getRouterParam(event, 'id');
+    if (!findId) throw createError({ statusCode: 400, message: 'Find ID is required' });
+
+    const { data: find, error: fetchError } = await supabase
+      .from('external_listings')
+      .select('id, submitted_by, status')
+      .eq('id', findId)
+      .single();
+
+    if (fetchError || !find) throw createError({ statusCode: 404, message: 'Find not found' });
+
+    const { data: profile } = await supabase.from('profiles').select('is_admin').eq('id', user.id).single();
+    const isAdmin = profile?.is_admin === true;
+    const isOwner = find.submitted_by === user.id;
+
+    // Owner may delete only their own pending submission; admin may delete any.
+    if (!isAdmin && !(isOwner && find.status === 'pending')) {
+      throw createError({ statusCode: 403, message: 'You do not have permission to delete this find' });
+    }
+
+    const { error: deleteError } = await supabase.from('external_listings').delete().eq('id', findId);
+    if (deleteError) {
+      console.error('Error deleting find:', deleteError);
+      throw createError({ statusCode: 500, message: deleteError.message });
+    }
+
+    return { success: true };
+  } catch (error: any) {
+    if (error.statusCode) throw error;
+    console.error('Error deleting find:', error);
+    throw createError({ statusCode: 500, message: 'Failed to delete find' });
+  }
+});

--- a/server/api/exchange/external-listings/notify-submit.post.ts
+++ b/server/api/exchange/external-listings/notify-submit.post.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/exchange/external-listings/notify-submit
+ *
+ * Post-create hook: the Find row is inserted client-side (useExternalListings,
+ * RLS-gated); this re-verifies ownership server-side and (Stage 8) will notify
+ * admins of a pending Find. Converged from TME: auth verifyBearerToken →
+ * requireUserClient. Consumed fire-and-forget by useExternalListings, so a throw
+ * here never blocks submission.
+ *
+ *   body: { findId }
+ */
+import { requireUserClient } from '../../../utils/userAuth';
+import { getServiceClient } from '../../../utils/supabase';
+import { createRateLimitMiddleware, RateLimitPresets } from '../../../utils/exchange/rateLimit';
+
+const rateLimitMiddleware = createRateLimitMiddleware({ ...RateLimitPresets.moderate, keyPrefix: 'finds-notify' });
+
+export default defineEventHandler(async (event) => {
+  await rateLimitMiddleware(event);
+
+  const { user } = await requireUserClient(event);
+
+  const body = await readBody<{ findId?: string }>(event);
+  if (!body?.findId) throw createError({ statusCode: 400, message: 'findId is required' });
+
+  const supabase = getServiceClient();
+  const { data: find, error } = await supabase
+    .from('external_listings')
+    .select('id, submitted_by, title, source_url, source_site')
+    .eq('id', body.findId)
+    .single();
+
+  if (error || !find) throw createError({ statusCode: 404, message: 'Find not found' });
+  if (find.submitted_by !== user.id) {
+    throw createError({ statusCode: 403, message: 'You can only notify on your own submission' });
+  }
+
+  // TODO(Stage 8): enqueue an admin "new find pending review" notification_queue
+  // event — the finds event type + its process-notifications builder aren't
+  // defined yet (classicminidiy-supabase). Ownership/validation above stays so
+  // wiring the enqueue later is a one-liner against `find`.
+
+  return { success: true };
+});

--- a/server/api/exchange/external-listings/parse.post.ts
+++ b/server/api/exchange/external-listings/parse.post.ts
@@ -1,0 +1,242 @@
+/**
+ * POST /api/exchange/external-listings/parse
+ *
+ * "Finds" link-preview scraper, CONVERGED off TheMiniExchange's Puppeteer +
+ * per-site parsers onto CMDIY's lighter external-models pipeline: SSRF-guarded
+ * OG/JSON-LD fetch → Microlink render fallback → re-host image. No headless
+ * browser, no per-site parser dispatch — every host flows through the same
+ * pipeline; the host only drives the display badge + the price-label heuristic.
+ *
+ *   body: { url } → { success: true, metadata: { title, description, imageUrl,
+ *           sourceSite, year, model, price, priceLabel, auctionEndTime, category } }
+ *
+ * Contract: matches the legacy TME parse shape exactly (FindSubmitForm depends on
+ * it). UNAUTHENTICATED + per-IP rate-limited (preview must work pre-login; the
+ * insert is RLS-gated in useExternalListings; notify-submit/delete are the authed
+ * surfaces). NEVER throws on a blocked/empty parse — returns a minimal metadata
+ * object (title = the URL) so the form's manual-entry path engages. Only SSRF /
+ * private-address / bad-scheme hard-throws 400.
+ *
+ * Known coverage tradeoff vs the old Puppeteer scraper: bot-blocked sites
+ * (Copart's JSON API, Facebook Marketplace's login wall, BaT/eBay live bid +
+ * auction-end) yield partial/empty metadata → the user fills it in manually.
+ */
+import { fetchExternalPage, parseOpenGraph, parseJsonLd, type OgMetadata } from '../../../utils/external-models/ogParser';
+import { renderExternalPage } from '../../../utils/external-models/render';
+import { ScrapeError } from '../../../utils/external-models/errors';
+import { safeFetch, readBodyCapped, SsrfError } from '../../../utils/external-models/ssrf';
+import { getServiceClient } from '../../../utils/supabase';
+import { createRateLimitMiddleware, RateLimitPresets } from '../../../utils/exchange/rateLimit';
+
+type SourceSite = 'bat' | 'carsandbids' | 'copart' | 'craigslist' | 'facebook' | 'ebay' | 'other';
+
+const MIN_PRICE = 50;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const IMAGE_TYPES: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+const rateLimit = createRateLimitMiddleware({ ...RateLimitPresets.lenient, keyPrefix: 'finds-parse' });
+
+/** Host → SourceSite. Byte-identical to the client copy in useExternalListings so
+ *  both sides agree (parse returns 'copart' for display even though the DB CHECK
+ *  omits it — the composable downgrades to 'other' on insert). */
+function detectFindSourceSite(url: string): SourceSite {
+  try {
+    const h = new URL(url).hostname.toLowerCase();
+    if (h.includes('bringatrailer.com')) return 'bat';
+    if (h.includes('carsandbids.com')) return 'carsandbids';
+    if (h.includes('copart.com')) return 'copart';
+    if (h.includes('craigslist.org')) return 'craigslist';
+    if (h.includes('facebook.com')) return 'facebook';
+    if (h.includes('ebay.com') || h.includes('ebay.co.uk')) return 'ebay';
+    return 'other';
+  } catch {
+    return 'other';
+  }
+}
+
+/** Classic Mini year (1959–2000) + model from free text (heritage-correct terms). */
+function extractYearModel(text: string): { year: number | null; model: string | null } {
+  const yearMatch = text.match(/\b(19[5-9]\d|20[0-2]\d)\b/);
+  let year: number | null = yearMatch ? Number(yearMatch[1]) : null;
+  if (year !== null && (year < 1959 || year > 2000)) year = null;
+  const modelMatch = text.match(/\b(cooper\s*s|1275\s*gt|cooper|clubman|moke|mini|austin|morris)\b/i);
+  const model = modelMatch ? modelMatch[1].replace(/\s+/g, ' ').trim() : null;
+  return { year, model };
+}
+
+/** Price (>= MIN_PRICE) from JSON-LD offers, then a $-regex over title/desc/html. */
+function extractPrice(
+  og: OgMetadata,
+  jsonLd: unknown[],
+  html: string | null,
+  site: SourceSite
+): { price: number | null; priceLabel: string | null } {
+  let price: number | null = null;
+
+  for (const node of jsonLd) {
+    const offers = (node as any)?.offers;
+    const raw = Array.isArray(offers) ? offers[0]?.price : offers?.price;
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= MIN_PRICE) {
+      price = Math.round(n);
+      break;
+    }
+  }
+
+  const haystack = [og.title, og.description, html].filter(Boolean).join(' ');
+  if (price === null && haystack) {
+    const m = haystack.match(/\$\s?([\d,]{2,})/);
+    if (m) {
+      const n = Number(m[1].replace(/,/g, ''));
+      if (Number.isFinite(n) && n >= MIN_PRICE) price = n;
+    }
+  }
+  if (price === null) return { price: null, priceLabel: null };
+
+  const formatted = `$${price.toLocaleString('en-US')}`;
+  let priceLabel = formatted;
+  if ((site === 'bat' || site === 'carsandbids') && haystack) {
+    if (/sold\s+for/i.test(haystack)) priceLabel = `Sold for ${formatted}`;
+    else if (/current\s+bid|bid\s+to/i.test(haystack)) priceLabel = `Current Bid ${formatted}`;
+  }
+  return { price, priceLabel };
+}
+
+/** Auction end (ISO) from JSON-LD offers.priceValidUntil or Event.endDate. */
+function extractAuctionEnd(jsonLd: unknown[]): string | null {
+  for (const node of jsonLd) {
+    const n = node as any;
+    const candidate =
+      n?.offers?.priceValidUntil ||
+      (Array.isArray(n?.offers) ? n.offers[0]?.priceValidUntil : null) ||
+      (n?.['@type'] === 'Event' ? n?.endDate : null);
+    if (candidate) {
+      const d = new Date(candidate);
+      if (!Number.isNaN(d.getTime())) return d.toISOString();
+    }
+  }
+  return null;
+}
+
+/** Re-host a scraped image to Supabase Storage. SSRF-guarded (safeFetch) +
+ *  size-capped + content-type allowlisted (no SVG → avoids stored-XSS). Returns
+ *  null on ANY failure (preview still works without an image). */
+async function rehostImage(imageUrl: string): Promise<string | null> {
+  try {
+    const res = await safeFetch(imageUrl);
+    if (!res.ok) return null;
+    const contentType = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+    const ext = IMAGE_TYPES[contentType];
+    if (!ext) return null;
+    const bytes = await readBodyCapped(res, MAX_IMAGE_BYTES);
+    const path = `finds/${crypto.randomUUID()}.${ext}`;
+    const db = getServiceClient();
+    const { error } = await db.storage.from('listing-photos').upload(path, bytes, { contentType, upsert: false });
+    if (error) return null;
+    return db.storage.from('listing-photos').getPublicUrl(path).data.publicUrl;
+  } catch {
+    return null;
+  }
+}
+
+interface FindMetadata {
+  title: string;
+  description: string | null;
+  imageUrl: string | null;
+  sourceSite: SourceSite;
+  year: number | null;
+  model: string | null;
+  price: number | null;
+  priceLabel: string | null;
+  auctionEndTime: string | null;
+  category: 'vehicle' | 'engine' | 'parts' | null;
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ url?: string }>(event);
+  const url = body?.url?.trim();
+  if (!url) throw createError({ statusCode: 400, message: 'url is required' });
+
+  await rateLimit(event);
+
+  if (!/^https?:\/\//i.test(url)) {
+    throw createError({ statusCode: 400, message: 'URL must start with http:// or https://' });
+  }
+
+  const sourceSite = detectFindSourceSite(url);
+  const minimal: FindMetadata = {
+    title: url,
+    description: null,
+    imageUrl: null,
+    sourceSite,
+    year: null,
+    model: null,
+    price: null,
+    priceLabel: null,
+    auctionEndTime: null,
+    category: null,
+  };
+
+  const config = useRuntimeConfig();
+  let og: OgMetadata | null = null;
+  let jsonLd: unknown[] = [];
+  let html: string | null = null;
+
+  // 1) Direct SSRF-guarded fetch + OG/JSON-LD parse.
+  try {
+    const page = await fetchExternalPage(url);
+    if (page.status === 404) return { success: true, metadata: minimal };
+    if (page.status < 400) {
+      html = page.html;
+      jsonLd = parseJsonLd(page.html);
+      const parsed = parseOpenGraph(page.html);
+      if (parsed.title || parsed.image) og = parsed;
+    }
+  } catch (err) {
+    // SSRF / private address / bad scheme → hard 400, NEVER fall through to render.
+    if (err instanceof SsrfError || (err instanceof ScrapeError && err.statusCode === 400)) {
+      throw createError({ statusCode: 400, message: 'That URL could not be fetched' });
+    }
+    // Other ScrapeErrors (non-HTML, oversized, 4xx/5xx) → fall through to Microlink.
+  }
+
+  // 2) Microlink render fallback (Cloudflare/JS-only). No html/JSON-LD on this path.
+  if (!og) {
+    try {
+      const rendered = await renderExternalPage(url, undefined, config.MICROLINK_API_KEY as string | undefined);
+      if (rendered.title || rendered.image) og = rendered;
+    } catch {
+      og = null;
+    }
+  }
+
+  // 3) Still nothing → minimal metadata → form's manual-entry path engages.
+  if (!og) return { success: true, metadata: minimal };
+
+  // 4) Derive fields from whatever we got.
+  const title = og.title?.trim() || url;
+  const description = og.description?.trim() || null;
+  const { year, model } = extractYearModel(`${title} ${description ?? ''}`);
+  const { price, priceLabel } = extractPrice(og, jsonLd, html, sourceSite);
+  const auctionEndTime = extractAuctionEnd(jsonLd);
+  const category = year || model ? 'vehicle' : null;
+  const imageUrl = og.image ? await rehostImage(og.image) : null;
+
+  const metadata: FindMetadata = {
+    title,
+    description,
+    imageUrl,
+    sourceSite,
+    year,
+    model,
+    price,
+    priceLabel,
+    auctionEndTime,
+    category,
+  };
+  return { success: true, metadata };
+});

--- a/server/api/exchange/notifications/queue-message.post.ts
+++ b/server/api/exchange/notifications/queue-message.post.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/exchange/notifications/queue-message
+ *
+ * Called by the client after sending a message; queues a `new_message`
+ * notification for the recipient (converged onto notification_queue —
+ * new_message is a registered event type with a process-notifications builder).
+ * Converged from TheMiniExchange's /api/notifications/queue-message: auth rewired
+ * to requireUserClient; service lookups via getServiceClient.
+ *
+ * Body: { conversationId, messagePreview? }
+ */
+import { requireUserClient } from '../../../utils/userAuth';
+import { getServiceClient } from '../../../utils/supabase';
+import { queueNotification, buildBatchKey } from '../../../utils/exchange/notificationQueue';
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserClient(event);
+
+  const body = await readBody<{ conversationId?: string; messagePreview?: string }>(event);
+  const { conversationId, messagePreview } = body;
+  if (!conversationId) {
+    throw createError({ statusCode: 400, message: 'Missing required field: conversationId' });
+  }
+
+  const serviceClient = getServiceClient();
+
+  // Verify the caller is a participant and derive the recipient.
+  const { data: conversation, error: convError } = await serviceClient
+    .from('conversations')
+    .select('buyer_id, seller_id')
+    .eq('id', conversationId)
+    .single();
+
+  if (convError || !conversation) {
+    throw createError({ statusCode: 404, message: 'Conversation not found' });
+  }
+
+  const { buyer_id, seller_id } = conversation;
+  if (user.id !== buyer_id && user.id !== seller_id) {
+    throw createError({ statusCode: 403, message: 'Not a participant in this conversation' });
+  }
+
+  const recipientId = user.id === buyer_id ? seller_id : buyer_id;
+
+  const { data: senderProfile } = await serviceClient
+    .from('profiles')
+    .select('display_name')
+    .eq('id', user.id)
+    .single();
+
+  const senderName = senderProfile?.display_name || 'Someone';
+  const preview = typeof messagePreview === 'string' ? messagePreview.slice(0, 200) : '';
+
+  try {
+    await queueNotification({
+      userId: recipientId,
+      eventType: 'new_message',
+      payload: { conversationId, senderName, messagePreview: preview },
+      channel: 'both',
+      batchKey: buildBatchKey('new_message', { conversationId }),
+    });
+  } catch (err) {
+    // Log but don't fail — the message itself was already sent.
+    console.error('[QueueMessage] Failed to queue notification:', err);
+  }
+
+  return { success: true };
+});

--- a/server/utils/exchange/camino.ts
+++ b/server/utils/exchange/camino.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared Camino AI API client
+ * Proxies all requests through the server to keep the API key private
+ */
+
+const CAMINO_API_BASE = 'https://api.getcamino.ai';
+
+export interface CaminoRelationshipResponse {
+  distance: string;
+  direction: string;
+  walking_time: string;
+  actual_distance_km: number;
+  duration_seconds: number;
+  driving_time: string;
+  description: string;
+}
+
+export interface CaminoQueryResult {
+  name: string;
+  lat: number;
+  lon: number;
+  address?: string;
+  distance?: number;
+  relevance_score?: number;
+  tags?: string[];
+  type?: string;
+}
+
+export interface CaminoQueryResponse {
+  results: CaminoQueryResult[];
+  answer?: string;
+}
+
+export async function caminoFetch<T = any>(
+  endpoint: string,
+  options: {
+    method?: 'GET' | 'POST';
+    params?: Record<string, string | number | boolean>;
+    body?: Record<string, any>;
+  } = {}
+): Promise<T> {
+  const config = useRuntimeConfig();
+  const apiKey = config.caminoApiKey;
+
+  if (!apiKey) {
+    throw new Error('CAMINO_API_KEY is not configured');
+  }
+
+  const { method = 'GET', params, body } = options;
+
+  const url = new URL(`${CAMINO_API_BASE}${endpoint}`);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, String(v)));
+  }
+
+  const response = await $fetch<T>(url.toString(), {
+    method,
+    headers: { 'X-API-Key': apiKey },
+    ...(body ? { body } : {}),
+  });
+
+  return response;
+}

--- a/server/utils/exchange/geo.ts
+++ b/server/utils/exchange/geo.ts
@@ -1,0 +1,49 @@
+/**
+ * Geographic utility functions for distance calculations,
+ * coordinate fuzzing, and midpoint computation
+ */
+
+/**
+ * Calculate the haversine distance between two points in meters
+ */
+export function haversineDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371e3; // Earth radius in meters
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Convert meters to miles
+ */
+export function metersToMiles(meters: number): number {
+  return meters / 1609.344;
+}
+
+/**
+ * Calculate the geographic midpoint between two coordinates
+ */
+export function calculateMidpoint(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): { lat: number; lon: number } {
+  return {
+    lat: (lat1 + lat2) / 2,
+    lon: (lon1 + lon2) / 2,
+  };
+}
+
+/**
+ * Fuzz coordinates to a ~3 mile radius for privacy
+ * Rounds to nearest 0.05 degrees (~3.5 miles)
+ */
+export function fuzzCoordinates(lat: number, lon: number, precision = 0.05): { lat: number; lon: number } {
+  return {
+    lat: Math.round(lat / precision) * precision,
+    lon: Math.round(lon / precision) * precision,
+  };
+}

--- a/server/utils/exchange/meetingSpots.ts
+++ b/server/utils/exchange/meetingSpots.ts
@@ -1,0 +1,155 @@
+/**
+ * Meeting spot suggestion logic
+ * Finds safe, public locations near the midpoint between buyer and seller
+ */
+
+import type { CaminoQueryResult, CaminoRelationshipResponse } from './camino';
+
+const SAFE_PLACE_QUERIES = [
+  'police station',
+  'fire station',
+  'shopping center parking lot',
+  'bank with parking lot',
+  'gas station well-lit',
+];
+
+const SAFETY_BOOST: Record<string, number> = {
+  police: 50,
+  fire_station: 40,
+  fire: 40,
+  shopping: 30,
+  mall: 30,
+  bank: 25,
+  gas_station: 15,
+  gas: 15,
+  convenience: 10,
+};
+
+export interface MeetingSpot extends CaminoQueryResult {
+  distanceFromMidpoint: number;
+  score: number;
+  buyerDriveTime?: string;
+  buyerDriveMinutes?: number;
+  sellerDriveTime?: string;
+  sellerDriveMinutes?: number;
+}
+
+/**
+ * Query Camino for safe public locations near a midpoint
+ */
+export async function findMeetingSpots(midLat: number, midLon: number): Promise<MeetingSpot[]> {
+  const results = await Promise.allSettled(
+    SAFE_PLACE_QUERIES.map((query) =>
+      caminoFetch<any>('/query', {
+        params: {
+          query,
+          lat: midLat,
+          lon: midLon,
+          radius: 8000,
+          limit: 3,
+          rank: true,
+        },
+      })
+    )
+  );
+
+  const allSpots = results
+    .filter((r): r is PromiseFulfilledResult<any> => r.status === 'fulfilled')
+    .flatMap((r) => {
+      // Handle both array responses and { results: [] } responses
+      if (Array.isArray(r.value)) return r.value;
+      if (r.value?.results) return r.value.results;
+      return [];
+    });
+
+  return deduplicateAndRank(allSpots, midLat, midLon);
+}
+
+/**
+ * Deduplicate nearby results and rank by safety score
+ */
+function deduplicateAndRank(spots: any[], midLat: number, midLon: number): MeetingSpot[] {
+  const unique: any[] = [];
+  for (const spot of spots) {
+    if (!spot.lat || !spot.lon) continue;
+    const isDuplicate = unique.some((s) => haversineDistance(s.lat, s.lon, spot.lat, spot.lon) < 100);
+    if (!isDuplicate) unique.push(spot);
+  }
+
+  return unique
+    .map((spot) => {
+      const distFromMid = haversineDistance(midLat, midLon, spot.lat, spot.lon);
+      let safetyScore = 0;
+      const nameLower = (
+        (spot.name || '') +
+        ' ' +
+        (spot.tags?.join(' ') || '') +
+        ' ' +
+        (spot.type || '')
+      ).toLowerCase();
+
+      for (const [keyword, boost] of Object.entries(SAFETY_BOOST)) {
+        if (nameLower.includes(keyword)) safetyScore += boost;
+      }
+
+      return {
+        ...spot,
+        distanceFromMidpoint: distFromMid,
+        score: safetyScore - distFromMid / 100,
+      } as MeetingSpot;
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+}
+
+/**
+ * Enrich meeting spots with drive times from both parties
+ */
+export async function enrichWithDriveTimes(
+  spots: MeetingSpot[],
+  buyerLoc: { lat: number; lon: number },
+  sellerLoc: { lat: number; lon: number }
+): Promise<MeetingSpot[]> {
+  const enriched = await Promise.all(
+    spots.map(async (spot) => {
+      try {
+        const [buyerTrip, sellerTrip] = await Promise.all([
+          caminoFetch<CaminoRelationshipResponse>('/relationship', {
+            method: 'POST',
+            body: {
+              start: { lat: buyerLoc.lat, lon: buyerLoc.lon },
+              end: { lat: spot.lat, lon: spot.lon },
+              include: ['distance', 'travel_time'],
+            },
+          }),
+          caminoFetch<CaminoRelationshipResponse>('/relationship', {
+            method: 'POST',
+            body: {
+              start: { lat: sellerLoc.lat, lon: sellerLoc.lon },
+              end: { lat: spot.lat, lon: spot.lon },
+              include: ['distance', 'travel_time'],
+            },
+          }),
+        ]);
+
+        return {
+          ...spot,
+          buyerDriveTime: buyerTrip.driving_time,
+          buyerDriveMinutes: buyerTrip.duration_seconds ? Math.round(buyerTrip.duration_seconds / 60) : undefined,
+          sellerDriveTime: sellerTrip.driving_time,
+          sellerDriveMinutes: sellerTrip.duration_seconds ? Math.round(sellerTrip.duration_seconds / 60) : undefined,
+        };
+      } catch {
+        // If drive time enrichment fails for a spot, return it without times
+        return spot;
+      }
+    })
+  );
+
+  // Sort by fairness: minimize the max drive for either party
+  return enriched.sort((a, b) => {
+    const aMax = Math.max(a.buyerDriveMinutes || Infinity, a.sellerDriveMinutes || Infinity);
+    const bMax = Math.max(b.buyerDriveMinutes || Infinity, b.sellerDriveMinutes || Infinity);
+    return aMax - bMax;
+  });
+}

--- a/server/utils/exchange/meetingSpots.ts
+++ b/server/utils/exchange/meetingSpots.ts
@@ -3,7 +3,9 @@
  * Finds safe, public locations near the midpoint between buyer and seller
  */
 
+import { caminoFetch } from './camino';
 import type { CaminoQueryResult, CaminoRelationshipResponse } from './camino';
+import { haversineDistance } from './geo';
 
 const SAFE_PLACE_QUERIES = [
   'police station',
@@ -71,7 +73,7 @@ export async function findMeetingSpots(midLat: number, midLon: number): Promise<
 function deduplicateAndRank(spots: any[], midLat: number, midLon: number): MeetingSpot[] {
   const unique: any[] = [];
   for (const spot of spots) {
-    if (!spot.lat || !spot.lon) continue;
+    if (spot.lat == null || spot.lon == null) continue;
     const isDuplicate = unique.some((s) => haversineDistance(s.lat, s.lon, spot.lat, spot.lon) < 100);
     if (!isDuplicate) unique.push(spot);
   }


### PR DESCRIPTION
**Section 6 of ~10** of the Mini Exchange consolidation (replacing the closed #637). Builds on
sections 1–5 (now in `dev`).

This slice (~23 files / ~3.6k lines):
- **Messaging**: `/exchange/messages` + `[conversationId]`, ConversationList,
  ListingConversationGroup, MessageList, MessageComposer, MessageImageGallery, attachment thumbnails,
  ReportMessageModal, SafetyTips. (Realtime/subscription logic lives in `useMessages`, already in `dev`.)
- **Camino meeting spots**: `server/api/exchange/camino/{distance,meeting-spots}` + `camino`/`geo`/
  `meetingSpots` utils.
- **Finds scraper convergence**: `server/api/exchange/external-listings/{parse,notify-submit,[id].delete}`
  — OG/JSON-LD + Microlink render + SSRF guard (Puppeteer dropped).
- `notifications/queue-message` route; `formatters`/`markdown` utils.

Flag-gated → invisible in prod. Verified: messages pages 200; scraper routes register + auth-gate.
Includes a proactive `<ClientOnly>` wrap on the 4 message-timestamp render sites (relative time →
hydration), matching the pattern fixed in earlier sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)