### PR TITLE
feat(exchange): admin rest — finds/promotions/messages/newsletter (8/10)

### DIFF
--- a/app/pages/admin/exchange/announcements.vue
+++ b/app/pages/admin/exchange/announcements.vue
@@ -1,0 +1,205 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold mb-2">Site Announcement</h1>
+      <p class="text-base-content/70">Configure the announcement banner displayed on the home page</p>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="skeleton h-96 w-full rounded-lg"></div>
+
+    <!-- Announcement Form -->
+    <div v-else class="card bg-base-100 shadow-sm">
+      <div class="card-body">
+        <!-- Enable Toggle -->
+        <fieldset class="fieldset">
+          <label class="fieldset-legend">Banner Status</label>
+          <label class="label cursor-pointer justify-start gap-4">
+            <input type="checkbox" v-model="form.is_enabled" class="toggle toggle-primary" />
+            <span>{{ form.is_enabled ? 'Enabled - Banner is visible' : 'Disabled - Banner is hidden' }}</span>
+          </label>
+        </fieldset>
+
+        <!-- Type Selector -->
+        <fieldset class="fieldset">
+          <label class="fieldset-legend">Banner Type</label>
+          <select v-model="form.type" class="select select-bordered w-full">
+            <option value="info">Info (Blue)</option>
+            <option value="success">Success (Green)</option>
+            <option value="warning">Warning (Yellow)</option>
+            <option value="error">Error (Red)</option>
+          </select>
+        </fieldset>
+
+        <!-- Title (Optional) -->
+        <fieldset class="fieldset">
+          <label class="fieldset-legend">Title (Optional)</label>
+          <input
+            v-model="form.title"
+            type="text"
+            class="input input-bordered w-full"
+            placeholder="e.g., Scheduled Maintenance"
+            maxlength="100"
+          />
+          <p class="text-xs text-base-content/60 mt-1">Leave blank to show only description</p>
+        </fieldset>
+
+        <!-- Description (Optional) -->
+        <fieldset class="fieldset">
+          <label class="fieldset-legend">Description (Optional)</label>
+          <textarea
+            v-model="form.description"
+            class="textarea textarea-bordered w-full"
+            rows="3"
+            placeholder="e.g., The site will be down for maintenance on Saturday from 2-4 PM EST."
+            maxlength="500"
+          ></textarea>
+          <p class="text-xs text-base-content/60 mt-1">Leave blank to show only title</p>
+        </fieldset>
+
+        <!-- Preview -->
+        <div v-if="form.title || form.description" class="mt-6">
+          <label class="text-sm font-medium mb-2 block">Preview</label>
+          <div class="announcement-banner rounded-lg" :style="previewBannerStyle">
+            <div class="flex items-center gap-3">
+              <i :class="[previewIconClass, 'shrink-0']" :style="previewIconStyle"></i>
+              <div class="flex flex-col gap-0.5">
+                <span v-if="form.title" class="font-semibold">{{ form.title }}</span>
+                <span v-if="form.description" :class="{ 'text-sm opacity-80': form.title }">
+                  {{ form.description }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Validation Warning -->
+        <div v-if="form.is_enabled && !form.title && !form.description" class="alert alert-warning mt-4">
+          <i class="fas fa-triangle-exclamation"></i>
+          <span>Add a title or description to display the banner</span>
+        </div>
+
+        <!-- Actions -->
+        <div class="card-actions justify-end mt-6">
+          <button class="btn btn-primary" :disabled="saving" @click="saveAnnouncement">
+            <i v-if="saving" class="fas fa-arrows-rotate animate-spin"></i>
+            {{ saving ? 'Saving...' : 'Save Changes' }}
+          </button>
+        </div>
+
+        <!-- Last Updated -->
+        <div v-if="lastUpdated" class="text-xs text-base-content/50 mt-4">
+          Last updated: {{ formatDateTime(lastUpdated) }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useHead({
+    title: 'Site Announcement - Admin - The Mini Exchange',
+  });
+
+  const { getAnnouncement, updateAnnouncement } = useAnnouncement();
+  const toast = useToast();
+  const { capture: captureRaw } = usePostHog();
+
+  const loading = ref(true);
+  const saving = ref(false);
+  const lastUpdated = ref<string | null>(null);
+
+  const form = ref({
+    title: '',
+    description: '',
+    type: 'info' as 'error' | 'warning' | 'info' | 'success',
+    is_enabled: false,
+  });
+
+  const formType = computed(() => form.value.type);
+  const { bannerStyle: previewBannerStyle, iconStyle: previewIconStyle } = useAnnouncementStyles(formType);
+
+  const previewIconClass = computed((): string => {
+    const iconMap: Record<string, string> = {
+      error: 'fas fa-circle-xmark',
+      warning: 'fas fa-triangle-exclamation',
+      info: 'fas fa-circle-info',
+      success: 'fas fa-circle-check',
+    };
+    return iconMap[form.value.type] || 'fas fa-circle-info';
+  });
+
+  const loadAnnouncement = async () => {
+    try {
+      const data = await getAnnouncement();
+      if (data) {
+        form.value = {
+          title: data.title || '',
+          description: data.description || '',
+          type: data.type,
+          is_enabled: data.is_enabled,
+        };
+        lastUpdated.value = data.updated_at;
+      }
+    } catch (error: any) {
+      console.error('Failed to load announcement:', error);
+      toast.add({
+        title: 'Error',
+        description: 'Failed to load announcement settings',
+        color: 'error',
+      });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const saveAnnouncement = async () => {
+    saving.value = true;
+
+    try {
+      // updateAnnouncement returns the updated record, no need for second fetch
+      const updatedAnnouncement = await updateAnnouncement({
+        title: form.value.title || null,
+        description: form.value.description || null,
+        type: form.value.type,
+        is_enabled: form.value.is_enabled,
+      });
+
+      // Use returned data directly
+      if (updatedAnnouncement) {
+        lastUpdated.value = updatedAnnouncement.updated_at;
+      }
+
+      toast.add({
+        title: 'Success',
+        description: 'Announcement settings saved',
+        color: 'success',
+      });
+
+      captureRaw('admin_announcement_updated', {
+        type: form.value.type,
+        is_enabled: form.value.is_enabled,
+        has_title: !!form.value.title,
+        has_description: !!form.value.description,
+      });
+    } catch (error: any) {
+      console.error('Failed to save announcement:', error);
+      toast.add({
+        title: 'Error',
+        description: error.message || 'Failed to save announcement',
+        color: 'error',
+      });
+    } finally {
+      saving.value = false;
+    }
+  };
+
+  onMounted(() => {
+    loadAnnouncement();
+  });
+</script>

--- a/app/pages/admin/exchange/finds.vue
+++ b/app/pages/admin/exchange/finds.vue
@@ -1,0 +1,851 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h1 class="text-3xl font-bold mb-2">Manage Finds</h1>
+        <p class="text-base-content/70">Review and moderate community-submitted finds</p>
+      </div>
+      <button class="btn btn-ghost btn-sm" :disabled="loading" @click="refresh">
+        <i class="fas fa-arrows-rotate" :class="{ 'animate-spin': loading }"></i>
+        Refresh
+      </button>
+    </div>
+
+    <!-- Stats Row -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      <div class="stat bg-base-100 shadow-sm rounded-box p-4">
+        <div class="stat-title text-xs">Pending</div>
+        <div class="stat-value text-2xl text-warning">{{ pendingFinds.length }}</div>
+      </div>
+      <div class="stat bg-base-100 shadow-sm rounded-box p-4">
+        <div class="stat-title text-xs">Approved</div>
+        <div class="stat-value text-2xl text-success">{{ approvedCount }}</div>
+      </div>
+      <div class="stat bg-base-100 shadow-sm rounded-box p-4">
+        <div class="stat-title text-xs">Rejected</div>
+        <div class="stat-value text-2xl text-error">{{ rejectedCount }}</div>
+      </div>
+      <div class="stat bg-base-100 shadow-sm rounded-box p-4">
+        <div class="stat-title text-xs">Total</div>
+        <div class="stat-value text-2xl">{{ allTotal }}</div>
+      </div>
+    </div>
+
+    <!-- Tabs -->
+    <div class="tabs tabs-bordered mb-6">
+      <button class="tab" :class="{ 'tab-active': activeTab === 'pending' }" @click="activeTab = 'pending'">
+        Pending
+        <span v-if="pendingFinds.length > 0" class="badge badge-warning badge-sm ml-2">
+          {{ pendingFinds.length }}
+        </span>
+      </button>
+      <button class="tab" :class="{ 'tab-active': activeTab === 'all' }" @click="activeTab = 'all'">All</button>
+    </div>
+
+    <!-- Pending Tab -->
+    <div v-if="activeTab === 'pending'">
+      <!-- Loading -->
+      <div v-if="loading" class="space-y-4">
+        <div v-for="i in 3" :key="i" class="skeleton h-40 w-full"></div>
+      </div>
+
+      <!-- Pending List -->
+      <div v-else-if="pendingFinds.length > 0" class="space-y-4">
+        <div v-for="find in pendingFinds" :key="find.id" class="card bg-base-100 shadow-sm">
+          <div class="card-body p-4">
+            <div class="flex flex-col md:flex-row gap-4">
+              <!-- Thumbnail -->
+              <div class="shrink-0">
+                <div class="w-full md:w-48 aspect-video bg-base-300 rounded-lg overflow-hidden">
+                  <img
+                    v-if="find.og_image_url"
+                    :src="find.og_image_url"
+                    :alt="find.title"
+                    class="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                  <div v-else class="w-full h-full flex items-center justify-center">
+                    <i class="fas fa-link text-3xl text-base-content/30"></i>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Content -->
+              <div class="flex-1 min-w-0">
+                <!-- Title & Source -->
+                <div class="flex flex-wrap items-start gap-2 mb-2">
+                  <h3 class="font-bold text-lg">{{ find.title }}</h3>
+                  <span class="badge badge-sm" :class="getSourceBadgeClass(find.source_site)">
+                    {{ getSourceDisplayName(find.source_site) }}
+                  </span>
+                </div>
+
+                <!-- Metadata -->
+                <div class="flex flex-wrap gap-3 text-sm text-base-content/70 mb-2">
+                  <span v-if="find.year">
+                    <i class="fas fa-calendar inline"></i>
+                    {{ find.year }}
+                  </span>
+                  <span v-if="find.model">
+                    <i class="fas fa-truck inline"></i>
+                    {{ find.model }}
+                  </span>
+                  <span v-if="find.price != null || find.price_label" class="font-semibold text-primary">
+                    {{ find.price_label || formatCurrency(find.price!) }}
+                  </span>
+                  <span v-if="find.category" class="badge badge-xs badge-outline">{{ find.category }}</span>
+                </div>
+
+                <!-- Submitter & Date -->
+                <div class="text-sm text-base-content/50 mb-2">
+                  Submitted by <strong>{{ find.profiles?.display_name || 'Unknown' }}</strong> on
+                  {{ formatDate(find.created_at) }}
+                </div>
+
+                <!-- Description -->
+                <p v-if="find.description" class="text-sm text-base-content/60 line-clamp-2 mb-3">
+                  {{ find.description }}
+                </p>
+
+                <!-- Source URL -->
+                <a
+                  :href="find.source_url"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="link link-primary text-sm inline-flex items-center gap-1 mb-3"
+                >
+                  <i class="fas fa-arrow-up-right-from-square"></i>
+                  {{ truncateUrl(find.source_url) }}
+                </a>
+
+                <!-- Action Buttons -->
+                <div class="flex flex-wrap gap-2">
+                  <button class="btn btn-success btn-sm gap-1" @click="openApproveForm(find)">
+                    <i class="fas fa-circle-check"></i>
+                    Approve
+                  </button>
+                  <button class="btn btn-error btn-sm btn-outline gap-1" @click="handleReject(find.id)">
+                    <i class="fas fa-circle-xmark"></i>
+                    Reject
+                  </button>
+                  <button class="btn btn-ghost btn-sm gap-1" @click="openEditForm(find)">
+                    <i class="fas fa-pen-to-square"></i>
+                    Edit
+                  </button>
+                  <button
+                    class="btn btn-ghost btn-sm gap-1"
+                    :disabled="refetchingId === find.id"
+                    @click="handleRefetchMetadata(find.id)"
+                  >
+                    <span v-if="refetchingId === find.id" class="loading loading-spinner loading-xs"></span>
+                    <i v-else class="fas fa-arrows-rotate"></i>
+                    {{ refetchingId === find.id ? 'Fetching...' : 'Re-fetch' }}
+                  </button>
+                  <button class="btn btn-ghost btn-sm btn-error gap-1" @click="handleDelete(find.id)">
+                    <i class="fas fa-trash"></i>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Empty Pending -->
+      <div v-else class="text-center py-16 card bg-base-100 shadow-sm">
+        <i class="fas fa-circle-check text-6xl mx-auto mb-4 text-success/50"></i>
+        <h3 class="text-xl font-semibold mb-2">All Caught Up</h3>
+        <p class="text-base-content/70">No pending finds to review.</p>
+      </div>
+    </div>
+
+    <!-- All Tab -->
+    <div v-if="activeTab === 'all'">
+      <!-- Filters for All tab -->
+      <div class="card bg-base-100 shadow-sm mb-6">
+        <div class="card-body p-4">
+          <div class="flex flex-wrap gap-4 items-center">
+            <div class="form-control">
+              <label for="status-filter" class="label">
+                <span class="label-text text-xs">Status</span>
+              </label>
+              <select id="status-filter" v-model="allStatusFilter" class="select select-bordered select-sm">
+                <option value="">All Statuses</option>
+                <option value="pending">Pending</option>
+                <option value="approved">Approved</option>
+                <option value="rejected">Rejected</option>
+                <option value="expired">Expired</option>
+              </select>
+            </div>
+            <div class="form-control">
+              <label for="source-filter" class="label">
+                <span class="label-text text-xs">Source</span>
+              </label>
+              <select id="source-filter" v-model="allSourceFilter" class="select select-bordered select-sm">
+                <option value="">All Sources</option>
+                <option value="bat">Bring a Trailer</option>
+                <option value="carsandbids">Cars & Bids</option>
+                <option value="copart">Copart</option>
+                <option value="craigslist">Craigslist</option>
+                <option value="facebook">Facebook</option>
+                <option value="ebay">eBay</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+            <div class="ml-auto self-end">
+              <button
+                class="btn btn-sm btn-outline gap-1"
+                :disabled="bulkRefreshing || allFinds.length === 0"
+                @click="handleBulkRefresh"
+              >
+                <span v-if="bulkRefreshing" class="loading loading-spinner loading-xs"></span>
+                <i v-else class="fas fa-arrows-rotate"></i>
+                Refresh All Metadata
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Bulk Refresh Progress -->
+      <div v-if="bulkRefreshing" class="card bg-base-100 shadow-sm mb-6">
+        <div class="card-body p-4">
+          <div class="flex items-center gap-3 mb-2">
+            <span class="loading loading-spinner loading-sm"></span>
+            <span class="text-sm font-medium">
+              Refreshing {{ bulkProgress.completed }} / {{ bulkProgress.total }}...
+            </span>
+          </div>
+          <progress
+            class="progress progress-primary w-full"
+            :value="bulkProgress.completed"
+            :max="bulkProgress.total"
+          ></progress>
+          <p v-if="bulkProgress.currentTitle" class="text-xs text-base-content/50 mt-1 truncate">
+            {{ bulkProgress.currentTitle }}
+          </p>
+        </div>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="space-y-4">
+        <div v-for="i in 5" :key="i" class="skeleton h-20 w-full"></div>
+      </div>
+
+      <!-- All Finds Table -->
+      <div v-else-if="allFinds.length > 0" class="card bg-base-100 shadow-sm">
+        <div class="overflow-x-auto">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Find</th>
+                <th>Source</th>
+                <th>Status</th>
+                <th>Submitted</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="find in allFinds" :key="find.id">
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="avatar shrink-0">
+                      <div class="mask mask-squircle w-12 h-12">
+                        <img v-if="find.og_image_url" :src="find.og_image_url" :alt="find.title" loading="lazy" />
+                        <div v-else class="bg-base-300 w-full h-full flex items-center justify-center">
+                          <i class="fas fa-link text-base-content/30"></i>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="min-w-0">
+                      <div class="font-bold truncate max-w-[200px]">{{ find.title }}</div>
+                      <div class="text-sm text-base-content/70">
+                        {{ [find.year, find.model].filter(Boolean).join(' ') || 'No details' }}
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <span class="badge badge-sm" :class="getSourceBadgeClass(find.source_site)">
+                    {{ getSourceDisplayName(find.source_site) }}
+                  </span>
+                </td>
+                <td>
+                  <span class="badge badge-sm" :class="getStatusBadgeClass(find.status)">
+                    {{ find.status }}
+                  </span>
+                  <span v-if="find.is_editors_pick" class="badge badge-sm badge-accent ml-1 gap-1">
+                    <i class="fas fa-star"></i>
+                    Pick
+                  </span>
+                </td>
+                <td>
+                  <div class="text-sm">
+                    <div>{{ find.profiles?.display_name || 'Unknown' }}</div>
+                    <div class="text-base-content/60">{{ formatDate(find.created_at) }}</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="flex gap-1">
+                    <a
+                      :href="find.source_url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="btn btn-ghost btn-xs"
+                      title="View source"
+                    >
+                      <i class="fas fa-arrow-up-right-from-square"></i>
+                    </a>
+                    <NuxtLink
+                      v-if="find.status === 'approved'"
+                      :to="`/exchange/finds/${find.slug}`"
+                      class="btn btn-ghost btn-xs"
+                      target="_blank"
+                      title="View find page"
+                    >
+                      <i class="fas fa-eye"></i>
+                    </NuxtLink>
+                    <button class="btn btn-ghost btn-xs" title="Edit find" @click="openEditForm(find)">
+                      <i class="fas fa-pen-to-square"></i>
+                    </button>
+                    <button
+                      class="btn btn-ghost btn-xs"
+                      :title="find.is_editors_pick ? `Remove Editor's Pick` : `Set Editor's Pick`"
+                      @click="handleToggleEditorsPick(find.id)"
+                    >
+                      <i
+                        :class="[
+                          find.is_editors_pick ? 'fas fa-star' : 'far fa-star',
+                          { 'text-accent': find.is_editors_pick },
+                        ]"
+                      ></i>
+                    </button>
+                    <button
+                      class="btn btn-ghost btn-xs"
+                      :title="refetchingId === find.id ? 'Fetching metadata...' : 'Re-fetch metadata'"
+                      :disabled="refetchingId === find.id"
+                      @click="handleRefetchMetadata(find.id)"
+                    >
+                      <span v-if="refetchingId === find.id" class="loading loading-spinner loading-xs"></span>
+                      <i v-else class="fas fa-arrows-rotate"></i>
+                    </button>
+                    <button
+                      class="btn btn-ghost btn-xs text-error"
+                      title="Delete"
+                      aria-label="Delete find"
+                      @click="handleDelete(find.id)"
+                    >
+                      <i class="fas fa-trash"></i>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Empty All -->
+      <div v-else class="text-center py-16 card bg-base-100 shadow-sm">
+        <i class="fas fa-inbox text-6xl mx-auto mb-4 text-base-content/30"></i>
+        <h3 class="text-xl font-semibold mb-2">No Finds</h3>
+        <p class="text-base-content/70">No finds match the current filters.</p>
+      </div>
+    </div>
+
+    <!-- Approve Modal -->
+    <dialog ref="approveModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Approve Find</h3>
+
+        <div v-if="approvingFind" class="space-y-4">
+          <p class="text-base-content/70">
+            Approving: <strong>{{ approvingFind.title }}</strong>
+          </p>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Editor's Commentary (optional)</legend>
+            <textarea
+              v-model="approveCommentary"
+              class="textarea textarea-bordered w-full"
+              placeholder="Add a note about why this find is interesting..."
+              rows="3"
+            ></textarea>
+          </fieldset>
+
+          <label class="flex items-center gap-3 cursor-pointer">
+            <input v-model="approveEditorsPick" type="checkbox" class="checkbox checkbox-accent" />
+            <span class="label-text">
+              <i class="fas fa-star inline text-accent"></i>
+              Mark as Editor's Pick
+            </span>
+          </label>
+        </div>
+
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeApproveModal">Cancel</button>
+          <button class="btn btn-success" @click="confirmApprove">
+            <i class="fas fa-circle-check"></i>
+            Approve
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+
+    <!-- Edit Modal -->
+    <dialog ref="editModal" class="modal">
+      <div class="modal-box max-w-2xl">
+        <h3 class="font-bold text-lg mb-4">Edit Find</h3>
+
+        <div v-if="editingFind" class="space-y-4">
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Title</legend>
+            <input v-model="editForm.title" type="text" class="input input-bordered w-full" maxlength="300" />
+          </fieldset>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Description</legend>
+            <textarea
+              v-model="editForm.description"
+              class="textarea textarea-bordered w-full"
+              rows="3"
+              maxlength="2000"
+            ></textarea>
+          </fieldset>
+
+          <div class="grid grid-cols-2 gap-4">
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Year</legend>
+              <input
+                v-model.number="editForm.year"
+                type="number"
+                class="input input-bordered w-full"
+                min="1959"
+                max="2000"
+              />
+            </fieldset>
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Model</legend>
+              <input v-model="editForm.model" type="text" class="input input-bordered w-full" />
+            </fieldset>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Price</legend>
+              <input v-model.number="editForm.price" type="number" class="input input-bordered w-full" min="0" />
+            </fieldset>
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Price Label</legend>
+              <input
+                v-model="editForm.price_label"
+                type="text"
+                class="input input-bordered w-full"
+                placeholder="e.g. Current Bid, Asking Price"
+              />
+            </fieldset>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Category</legend>
+              <select v-model="editForm.category" class="select select-bordered w-full">
+                <option value="">None</option>
+                <option value="vehicle">Vehicle</option>
+                <option value="engine">Engine</option>
+                <option value="parts">Parts</option>
+              </select>
+            </fieldset>
+            <fieldset class="fieldset">
+              <legend class="fieldset-legend">Tags</legend>
+              <input
+                v-model="editForm.tags"
+                type="text"
+                class="input input-bordered w-full"
+                placeholder="comma-separated"
+              />
+            </fieldset>
+          </div>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">OG Image URL</legend>
+            <input
+              v-model="editForm.og_image_url"
+              type="url"
+              class="input input-bordered w-full"
+              placeholder="https://..."
+            />
+            <div v-if="editForm.og_image_url" class="mt-2">
+              <img :src="editForm.og_image_url" alt="Preview" class="w-32 h-20 object-cover rounded" />
+            </div>
+          </fieldset>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Editor's Commentary</legend>
+            <textarea
+              v-model="editForm.editor_commentary"
+              class="textarea textarea-bordered w-full"
+              rows="3"
+              maxlength="5000"
+              placeholder="Public commentary about this find..."
+            ></textarea>
+          </fieldset>
+        </div>
+
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeEditModal">Cancel</button>
+          <button class="btn btn-primary" :disabled="!editForm.title.trim()" @click="confirmEdit">
+            <i class="fas fa-check"></i>
+            Save Changes
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+
+    <!-- Delete Confirmation Modal -->
+    <dialog ref="deleteModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">Delete Find</h3>
+        <p class="py-4">Are you sure you want to delete this find? This action cannot be undone.</p>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeDeleteModal">Cancel</button>
+          <button class="btn btn-error" @click="confirmDelete">Delete</button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { ExternalListing } from '~/composables/useExternalListings';
+
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useHead({
+    title: 'Manage Finds - Admin - The Mini Exchange',
+    meta: [
+      {
+        name: 'robots',
+        content: 'noindex, nofollow',
+      },
+    ],
+  });
+
+  const {
+    pendingFinds,
+    allFinds,
+    loading,
+    fetchPending,
+    fetchAll,
+    approve,
+    reject,
+    refetchMetadata,
+    bulkRefetchMetadata,
+    toggleEditorsPick,
+    updateFind,
+    deleteFind,
+  } = useExternalListingAdmin();
+
+  const toast = useToast();
+  const supabase = useSupabase();
+  const { getSourceDisplayName, getSourceBadgeClass, formatCurrency, formatDate } = useFormatters();
+
+  // Tab state
+  const activeTab = ref<'pending' | 'all'>('pending');
+
+  // All tab filters
+  const allStatusFilter = ref('');
+  const allSourceFilter = ref('');
+
+  // Approve modal state
+  const approveModal = ref<HTMLDialogElement | null>(null);
+  const approvingFind = ref<ExternalListing | null>(null);
+  const approveCommentary = ref('');
+  const approveEditorsPick = ref(false);
+
+  // Edit modal state
+  const editModal = ref<HTMLDialogElement | null>(null);
+  const editingFind = ref<ExternalListing | null>(null);
+  const editForm = ref({
+    title: '',
+    description: '',
+    year: null as number | null,
+    model: '',
+    price: null as number | null,
+    price_label: '',
+    category: '' as string,
+    tags: '',
+    editor_commentary: '',
+    og_image_url: '',
+  });
+
+  // Re-fetch loading state (tracks which find ID is currently re-fetching)
+  const refetchingId = ref<string | null>(null);
+
+  // Bulk refresh state
+  const bulkRefreshing = ref(false);
+  const bulkProgress = ref({ completed: 0, total: 0, currentTitle: '' });
+
+  // Delete modal state
+  const deleteModal = ref<HTMLDialogElement | null>(null);
+  const deletingFindId = ref<string | null>(null);
+
+  // Stats
+  const approvedCount = ref(0);
+  const rejectedCount = ref(0);
+  const allTotal = ref(0);
+
+  // Status badge class
+  const getStatusBadgeClass = (status: string): string => {
+    const map: Record<string, string> = {
+      pending: 'badge-warning',
+      approved: 'badge-success',
+      rejected: 'badge-error',
+      expired: 'badge-ghost',
+    };
+    return map[status] || 'badge-ghost';
+  };
+
+  // Truncate URL for display
+  const truncateUrl = (url: string): string => {
+    try {
+      const parsed = new URL(url);
+      const path = parsed.pathname.length > 40 ? parsed.pathname.slice(0, 40) + '...' : parsed.pathname;
+      return parsed.hostname + path;
+    } catch {
+      return url.length > 60 ? url.slice(0, 60) + '...' : url;
+    }
+  };
+
+  // Open approve form modal
+  const openApproveForm = (find: ExternalListing) => {
+    approvingFind.value = find;
+    approveCommentary.value = '';
+    approveEditorsPick.value = false;
+    approveModal.value?.showModal();
+  };
+
+  const closeApproveModal = () => {
+    approveModal.value?.close();
+    approvingFind.value = null;
+  };
+
+  const confirmApprove = async () => {
+    if (!approvingFind.value) return;
+
+    await approve(
+      approvingFind.value.id,
+      approveCommentary.value.trim() || undefined,
+      approveEditorsPick.value || undefined
+    );
+
+    closeApproveModal();
+    loadStats();
+  };
+
+  // Reject handler
+  const handleReject = async (id: string) => {
+    const reason = prompt('Rejection reason (optional):');
+    if (reason === null) return; // User cancelled
+    await reject(id, reason || undefined);
+    loadStats();
+  };
+
+  // Re-fetch metadata handler
+  const handleRefetchMetadata = async (id: string) => {
+    if (refetchingId.value) return; // Prevent duplicate clicks
+    refetchingId.value = id;
+    try {
+      await refetchMetadata(id);
+      // Reload the current tab data
+      if (activeTab.value === 'pending') {
+        await fetchPending();
+      } else {
+        await loadAllFinds();
+      }
+    } finally {
+      refetchingId.value = null;
+    }
+  };
+
+  // Bulk refresh metadata for all currently displayed finds
+  const handleBulkRefresh = async () => {
+    if (bulkRefreshing.value) return;
+
+    const ids = allFinds.value.map((f) => f.id);
+    if (ids.length === 0) return;
+
+    const confirmed = confirm(`Refresh metadata for ${ids.length} finds? This may take a while.`);
+    if (!confirmed) return;
+
+    bulkRefreshing.value = true;
+    bulkProgress.value = { completed: 0, total: ids.length, currentTitle: '' };
+
+    try {
+      await bulkRefetchMetadata(ids, (completed, total, currentTitle) => {
+        bulkProgress.value = { completed, total, currentTitle };
+      });
+      // Reload the table
+      await loadAllFinds();
+    } finally {
+      bulkRefreshing.value = false;
+    }
+  };
+
+  // Toggle editor's pick
+  const handleToggleEditorsPick = async (id: string) => {
+    await toggleEditorsPick(id);
+  };
+
+  // Edit handlers
+  const openEditForm = (find: ExternalListing) => {
+    editingFind.value = find;
+    editForm.value = {
+      title: find.title,
+      description: find.description || '',
+      year: find.year,
+      model: find.model || '',
+      price: find.price,
+      price_label: find.price_label || '',
+      category: find.category || '',
+      tags: (find.tags || []).join(', '),
+      editor_commentary: find.editor_commentary || '',
+      og_image_url: find.og_image_url || '',
+    };
+    editModal.value?.showModal();
+  };
+
+  const closeEditModal = () => {
+    editModal.value?.close();
+    editingFind.value = null;
+  };
+
+  const confirmEdit = async () => {
+    if (!editingFind.value) return;
+
+    const fields: Record<string, any> = {
+      title: editForm.value.title.trim(),
+      description: editForm.value.description.trim() || null,
+      year: editForm.value.year || null,
+      model: editForm.value.model.trim() || null,
+      price: editForm.value.price ?? null,
+      price_label: editForm.value.price_label.trim() || null,
+      category: editForm.value.category || null,
+      tags: editForm.value.tags
+        .split(',')
+        .map((t: string) => t.trim().toLowerCase())
+        .filter((t: string) => t.length > 0),
+      editor_commentary: editForm.value.editor_commentary.trim() || null,
+      og_image_url: editForm.value.og_image_url.trim() || null,
+    };
+
+    await updateFind(editingFind.value.id, fields);
+    closeEditModal();
+
+    // Reload current tab data
+    if (activeTab.value === 'pending') {
+      await fetchPending();
+    } else {
+      await loadAllFinds();
+    }
+  };
+
+  // Delete handlers
+  const handleDelete = (id: string) => {
+    deletingFindId.value = id;
+    deleteModal.value?.showModal();
+  };
+
+  const closeDeleteModal = () => {
+    deleteModal.value?.close();
+    deletingFindId.value = null;
+  };
+
+  const confirmDelete = async () => {
+    if (!deletingFindId.value) return;
+
+    try {
+      await deleteFind(deletingFindId.value);
+      loadStats();
+    } catch (error: any) {
+      console.error('Error deleting find:', error);
+      toast.add({
+        title: 'Error',
+        description: 'Failed to delete find',
+        color: 'error',
+      });
+    } finally {
+      closeDeleteModal();
+    }
+  };
+
+  // Load stats (counts by status)
+  const loadStats = async () => {
+    try {
+      const [approvedResult, rejectedResult, totalResult] = await Promise.all([
+        supabase.from('external_listings').select('id', { count: 'exact', head: true }).eq('status', 'approved'),
+        supabase.from('external_listings').select('id', { count: 'exact', head: true }).eq('status', 'rejected'),
+        supabase.from('external_listings').select('id', { count: 'exact', head: true }),
+      ]);
+
+      approvedCount.value = approvedResult.count || 0;
+      rejectedCount.value = rejectedResult.count || 0;
+      allTotal.value = totalResult.count || 0;
+    } catch (error) {
+      console.error('Error loading stats:', error);
+    }
+  };
+
+  // Load all finds with filters
+  const loadAllFinds = async () => {
+    await fetchAll({
+      status: (allStatusFilter.value as any) || undefined,
+      sourceSite: allSourceFilter.value || undefined,
+    });
+  };
+
+  // Refresh current tab
+  const refresh = async () => {
+    if (activeTab.value === 'pending') {
+      await fetchPending();
+    } else {
+      await loadAllFinds();
+    }
+    await loadStats();
+  };
+
+  // Watch tab changes
+  watch(activeTab, (tab) => {
+    if (tab === 'pending') {
+      fetchPending();
+    } else {
+      loadAllFinds();
+    }
+  });
+
+  // Watch all-tab filters
+  watch([allStatusFilter, allSourceFilter], () => {
+    if (activeTab.value === 'all') {
+      loadAllFinds();
+    }
+  });
+
+  // Initial load
+  onMounted(() => {
+    fetchPending();
+    loadStats();
+  });
+</script>

--- a/app/pages/admin/exchange/finds.vue
+++ b/app/pages/admin/exchange/finds.vue
@@ -33,7 +33,7 @@
     </div>
 
     <!-- Tabs -->
-    <div class="tabs tabs-bordered mb-6">
+    <div class="tabs tabs-border mb-6">
       <button class="tab" :class="{ 'tab-active': activeTab === 'pending' }" @click="activeTab = 'pending'">
         Pending
         <span v-if="pendingFinds.length > 0" class="badge badge-warning badge-sm ml-2">

--- a/app/pages/admin/exchange/messages.vue
+++ b/app/pages/admin/exchange/messages.vue
@@ -1,0 +1,571 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h1 class="text-3xl font-bold">Message Management</h1>
+        <p class="text-base-content/70 mt-2">Review reported messages and browse conversations</p>
+      </div>
+      <button class="btn btn-ghost btn-sm" :disabled="loading" @click="refreshCurrentTab">
+        <i class="fas fa-arrows-rotate" :class="{ 'animate-spin': loading }"></i>
+        Refresh
+      </button>
+    </div>
+
+    <!-- Tabs -->
+    <div role="tablist" class="tabs tabs-border mb-6">
+      <button role="tab" class="tab" :class="{ 'tab-active': activeTab === 'queue' }" @click="activeTab = 'queue'">
+        Moderation Queue
+        <span v-if="queueCount > 0" class="badge badge-error badge-sm ml-2">{{ queueCount }}</span>
+      </button>
+      <button role="tab" class="tab" :class="{ 'tab-active': activeTab === 'browser' }" @click="activeTab = 'browser'">
+        Conversation Browser
+      </button>
+    </div>
+
+    <!-- Moderation Queue Tab -->
+    <div v-if="activeTab === 'queue'">
+      <!-- Loading -->
+      <div v-if="loading" class="space-y-4">
+        <div v-for="i in 3" :key="i" class="skeleton h-48 w-full"></div>
+      </div>
+
+      <!-- Empty state -->
+      <div v-else-if="queueItems.length === 0" class="text-center py-20 card bg-base-100 shadow-sm">
+        <i class="fas fa-circle-check text-7xl mx-auto mb-4 text-success/50"></i>
+        <h3 class="text-2xl font-semibold mb-2">All Clear</h3>
+        <p class="text-base-content/70">No messages need moderation review</p>
+      </div>
+
+      <!-- Queue Items -->
+      <div v-else class="space-y-4">
+        <div v-for="item in queueItems" :key="item.id" class="card bg-base-100 shadow-sm">
+          <div class="card-body">
+            <!-- Header: sender info + report reason -->
+            <div class="flex items-start justify-between">
+              <div class="flex items-center gap-3">
+                <div class="avatar placeholder">
+                  <div class="bg-neutral text-neutral-content w-10 rounded-full flex items-center justify-center">
+                    <span>{{ getInitials(item.sender?.display_name || item.sender?.email) }}</span>
+                  </div>
+                </div>
+                <div>
+                  <div class="font-bold">{{ item.sender?.display_name || item.sender?.email || 'Unknown' }}</div>
+                  <div class="text-sm text-base-content/70">{{ item.sender?.email }}</div>
+                  <div class="flex gap-1 mt-1">
+                    <span v-if="(item.sender?.warning_count || 0) > 0" class="badge badge-warning badge-xs">
+                      {{ item.sender?.warning_count }} warning{{ (item.sender?.warning_count || 0) > 1 ? 's' : '' }}
+                    </span>
+                    <span v-if="item.sender?.is_banned" class="badge badge-error badge-xs">Banned</span>
+                  </div>
+                </div>
+              </div>
+              <div class="text-right">
+                <div class="text-xs text-base-content/50">{{ formatDate(item.created_at) }}</div>
+                <div v-if="item.reported_at" class="text-xs text-error mt-1">
+                  Reported {{ formatDate(item.reported_at) }}
+                </div>
+              </div>
+            </div>
+
+            <!-- Report reason or auto-detection issues -->
+            <div class="mt-3">
+              <div v-if="item.report_reason" class="alert alert-error py-2">
+                <i class="fas fa-flag"></i>
+                <span class="text-sm"><strong>User report:</strong> {{ item.report_reason }}</span>
+              </div>
+              <div v-else-if="item.moderation_issues?.length" class="alert alert-warning py-2">
+                <i class="fas fa-triangle-exclamation"></i>
+                <span class="text-sm"> <strong>Auto-detected:</strong> {{ item.moderation_issues.join(', ') }} </span>
+              </div>
+            </div>
+
+            <!-- Flagged message content -->
+            <div class="bg-base-200 rounded-lg p-4 mt-2">
+              <p class="whitespace-pre-wrap break-words">{{ item.content }}</p>
+            </div>
+
+            <!-- Conversation context -->
+            <div v-if="item.conversation" class="mt-2 text-sm text-base-content/70">
+              <span>Conversation between </span>
+              <strong>{{ item.conversation.buyer?.display_name || item.conversation.buyer?.email }}</strong>
+              <span> and </span>
+              <strong>{{ item.conversation.seller?.display_name || item.conversation.seller?.email }}</strong>
+              <span v-if="item.conversation.listing"> about </span>
+              <NuxtLink
+                v-if="item.conversation.listing"
+                :to="`/exchange/listings/${item.conversation.listing.slug}`"
+                class="link link-primary"
+              >
+                {{ item.conversation.listing.title }}
+              </NuxtLink>
+            </div>
+
+            <!-- Action buttons -->
+            <div class="card-actions justify-end mt-4">
+              <button class="btn btn-ghost btn-sm" @click="handleDismiss(item.id)">
+                <i class="fas fa-check"></i>
+                Dismiss
+              </button>
+              <button class="btn btn-warning btn-sm" @click="openWarnModal(item)">
+                <i class="fas fa-triangle-exclamation"></i>
+                Warn User
+              </button>
+              <button class="btn btn-error btn-sm" @click="handleDeleteMessage(item)">
+                <i class="fas fa-trash"></i>
+                Delete Message
+              </button>
+              <button
+                v-if="!item.sender?.is_banned"
+                class="btn btn-error btn-outline btn-sm"
+                @click="handleBanUser(item.sender!)"
+              >
+                <i class="fas fa-ban"></i>
+                Ban User
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Queue Pagination -->
+      <div v-if="!loading && queueTotalPages > 1" class="flex justify-center mt-8">
+        <div class="join">
+          <button class="join-item btn" :disabled="queuePage === 1" @click="queuePage--">«</button>
+          <button class="join-item btn">Page {{ queuePage }} of {{ queueTotalPages }}</button>
+          <button class="join-item btn" :disabled="queuePage === queueTotalPages" @click="queuePage++">»</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Conversation Browser Tab -->
+    <div v-if="activeTab === 'browser'">
+      <!-- Filters -->
+      <div class="card bg-base-100 shadow-sm mb-6">
+        <div class="card-body py-4">
+          <div class="flex flex-wrap gap-4 items-end">
+            <div class="form-control flex-1">
+              <label class="label"><span class="label-text">Search</span></label>
+              <input
+                v-model="browserSearch"
+                type="text"
+                placeholder="Search by user name or email..."
+                class="input input-bordered w-full"
+              />
+            </div>
+            <div class="form-control">
+              <label class="label"><span class="label-text">Flagged Only</span></label>
+              <input v-model="browserFlaggedOnly" type="checkbox" class="toggle toggle-error" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="space-y-4">
+        <div v-for="i in 5" :key="i" class="skeleton h-20 w-full"></div>
+      </div>
+
+      <!-- Conversations list -->
+      <div v-else-if="conversations.length > 0" class="space-y-2">
+        <div
+          v-for="conv in conversations"
+          :key="conv.id"
+          class="card bg-base-100 shadow-sm cursor-pointer hover:bg-base-200 transition-colors"
+          @click="toggleConversation(conv.id)"
+        >
+          <div class="card-body py-4">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-4">
+                <div>
+                  <span class="font-medium">{{ conv.buyer?.display_name || conv.buyer?.email }}</span>
+                  <i class="fas fa-right-left mx-2 text-base-content/50"></i>
+                  <span class="font-medium">{{ conv.seller?.display_name || conv.seller?.email }}</span>
+                </div>
+                <span v-if="conv.listing" class="badge badge-ghost badge-sm">
+                  {{ conv.listing.title }}
+                </span>
+              </div>
+              <div class="flex items-center gap-2">
+                <span class="text-xs text-base-content/50">{{ formatDate(conv.last_message_at) }}</span>
+                <i :class="expandedConversation === conv.id ? 'fas fa-chevron-up' : 'fas fa-chevron-down'"></i>
+              </div>
+            </div>
+          </div>
+
+          <!-- Expanded conversation detail -->
+          <div v-if="expandedConversation === conv.id" class="border-t border-base-300" @click.stop>
+            <div class="p-4 max-h-96 overflow-y-auto space-y-3">
+              <div v-if="loadingMessages" class="flex justify-center py-4">
+                <span class="loading loading-spinner"></span>
+              </div>
+              <div v-else>
+                <div
+                  v-for="msg in expandedMessages"
+                  :key="msg.id"
+                  class="flex gap-3 p-2 rounded-lg"
+                  :class="{
+                    'bg-error/10': msg.deleted_at,
+                    'bg-warning/10': msg.moderation_status === 'flagged' && !msg.deleted_at,
+                    'bg-info/10': msg.is_system_message,
+                  }"
+                >
+                  <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                      <span class="font-medium text-sm">
+                        {{ msg.sender?.display_name || msg.sender?.email || 'Unknown' }}
+                      </span>
+                      <span class="text-xs text-base-content/50">{{ formatDate(msg.created_at) }}</span>
+                      <span v-if="msg.is_system_message" class="badge badge-info badge-xs">System</span>
+                      <span v-if="msg.moderation_status === 'flagged'" class="badge badge-warning badge-xs"
+                        >Flagged</span
+                      >
+                      <span v-if="msg.deleted_at" class="badge badge-error badge-xs">Deleted</span>
+                    </div>
+                    <p class="text-sm mt-1 whitespace-pre-wrap" :class="{ 'line-through opacity-50': msg.deleted_at }">
+                      {{ msg.content }}
+                    </p>
+                  </div>
+                  <!-- Inline actions -->
+                  <div v-if="!msg.deleted_at && !msg.is_system_message" class="flex gap-1 shrink-0">
+                    <button
+                      class="btn btn-ghost btn-xs"
+                      title="Delete message"
+                      aria-label="Delete message"
+                      @click="handleDeleteMessage(msg)"
+                    >
+                      <i class="fas fa-trash text-error"></i>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div v-else class="text-center py-20 card bg-base-100 shadow-sm">
+        <i class="fas fa-comments text-7xl mx-auto mb-4 text-base-content/30"></i>
+        <h3 class="text-2xl font-semibold mb-2">No Conversations</h3>
+        <p class="text-base-content/70">No conversations found</p>
+      </div>
+
+      <!-- Browser Pagination -->
+      <div v-if="!loading && browserTotalPages > 1" class="flex justify-center mt-8">
+        <div class="join">
+          <button class="join-item btn" :disabled="browserPage === 1" @click="browserPage--">«</button>
+          <button class="join-item btn">Page {{ browserPage }} of {{ browserTotalPages }}</button>
+          <button class="join-item btn" :disabled="browserPage === browserTotalPages" @click="browserPage++">»</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Warn User Modal -->
+    <dialog ref="warnModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">Warn User</h3>
+        <p class="py-2 text-base-content/70">
+          Send a warning to <strong>{{ warnTarget?.sender?.display_name || warnTarget?.sender?.email }}</strong
+          >. This will inject a system message into the conversation and increment their warning count.
+        </p>
+        <div class="mt-2">
+          <textarea
+            v-model="warnReason"
+            class="textarea textarea-bordered w-full"
+            rows="3"
+            placeholder="Optional: reason for the warning..."
+          ></textarea>
+        </div>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeWarnModal">Cancel</button>
+          <button class="btn btn-warning" :disabled="warningSending" @click="handleWarnUser">
+            <span v-if="warningSending" class="loading loading-spinner loading-sm"></span>
+            Send Warning
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+
+    <!-- Ban Confirmation Modal -->
+    <dialog ref="banModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">Ban User</h3>
+        <p class="py-4">
+          Are you sure you want to ban
+          <strong>{{ banTarget?.display_name || banTarget?.email }}</strong
+          >? This will prevent them from logging in and using the platform.
+        </p>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeBanModal">Cancel</button>
+          <button class="btn btn-error" @click="handleConfirmBan">Ban User</button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { MessageQueueItem, AdminConversation } from '~/composables/useAdmin';
+
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useHead({
+    title: 'Message Management - Admin - The Mini Exchange',
+  });
+
+  useSeoMeta({
+    robots: 'noindex, nofollow',
+  });
+
+  const {
+    getMessageQueue,
+    getMessageQueueCount,
+    getAdminConversations,
+    getAdminConversationMessages,
+    adminDeleteMessage,
+    adminWarnUser,
+    dismissReport,
+    toggleUserBan,
+  } = useAdmin();
+  const toast = useToast();
+
+  // Shared state
+  const loading = ref(false);
+  const activeTab = ref<'queue' | 'browser'>('queue');
+
+  // Queue state
+  const queueItems = ref<MessageQueueItem[]>([]);
+  const queueCount = ref(0);
+  const queuePage = ref(1);
+  const queueTotal = ref(0);
+  const itemsPerPage = 20;
+  const queueTotalPages = computed(() => Math.ceil(queueTotal.value / itemsPerPage));
+
+  // Browser state
+  const conversations = ref<AdminConversation[]>([]);
+  const browserPage = ref(1);
+  const browserTotal = ref(0);
+  const browserSearch = ref('');
+  const browserFlaggedOnly = ref(false);
+  const browserTotalPages = computed(() => Math.ceil(browserTotal.value / itemsPerPage));
+  const expandedConversation = ref<string | null>(null);
+  const expandedMessages = ref<any[]>([]);
+  const loadingMessages = ref(false);
+
+  // Warn modal state
+  const warnModal = ref<HTMLDialogElement | null>(null);
+  const warnTarget = ref<MessageQueueItem | null>(null);
+  const warnReason = ref('');
+  const warningSending = ref(false);
+
+  // Ban modal state
+  const banModal = ref<HTMLDialogElement | null>(null);
+  const banTarget = ref<any>(null);
+
+  let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Data loading
+  const loadQueue = async () => {
+    loading.value = true;
+    try {
+      const [result, count] = await Promise.all([
+        getMessageQueue(queuePage.value, itemsPerPage),
+        getMessageQueueCount(),
+      ]);
+      queueItems.value = result.items;
+      queueTotal.value = result.total;
+      queueCount.value = count;
+    } catch (error: any) {
+      console.error('Error loading queue:', error);
+      toast.add({ title: 'Error', description: error.message || 'Failed to load moderation queue', color: 'error' });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const loadConversations = async () => {
+    loading.value = true;
+    try {
+      const result = await getAdminConversations(browserPage.value, itemsPerPage, {
+        search: browserSearch.value || undefined,
+        flaggedOnly: browserFlaggedOnly.value,
+      });
+      conversations.value = result.conversations;
+      browserTotal.value = result.total;
+    } catch (error: any) {
+      console.error('Error loading conversations:', error);
+      toast.add({ title: 'Error', description: error.message || 'Failed to load conversations', color: 'error' });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const toggleConversation = async (conversationId: string) => {
+    if (expandedConversation.value === conversationId) {
+      expandedConversation.value = null;
+      expandedMessages.value = [];
+      return;
+    }
+
+    expandedConversation.value = conversationId;
+    loadingMessages.value = true;
+    try {
+      expandedMessages.value = await getAdminConversationMessages(conversationId);
+    } catch (error: any) {
+      console.error('Error loading messages:', error);
+      toast.add({ title: 'Error', description: 'Failed to load messages', color: 'error' });
+    } finally {
+      loadingMessages.value = false;
+    }
+  };
+
+  const refreshCurrentTab = () => {
+    if (activeTab.value === 'queue') loadQueue();
+    else loadConversations();
+  };
+
+  // Actions
+  const handleDismiss = async (messageId: string) => {
+    try {
+      await dismissReport(messageId);
+      toast.add({ title: 'Dismissed', description: 'Report has been dismissed', color: 'success' });
+      await loadQueue();
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error.message, color: 'error' });
+    }
+  };
+
+  const handleDeleteMessage = async (item: any) => {
+    try {
+      await adminDeleteMessage(item.id, item.conversation_id, item.sender_id);
+      toast.add({ title: 'Deleted', description: 'Message has been deleted', color: 'success' });
+      if (activeTab.value === 'queue') await loadQueue();
+      else if (expandedConversation.value) {
+        expandedMessages.value = await getAdminConversationMessages(expandedConversation.value);
+      }
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error.message, color: 'error' });
+    }
+  };
+
+  const openWarnModal = (item: MessageQueueItem) => {
+    warnTarget.value = item;
+    warnReason.value = '';
+    warnModal.value?.showModal();
+  };
+
+  const closeWarnModal = () => {
+    warnModal.value?.close();
+    warnTarget.value = null;
+  };
+
+  const handleWarnUser = async () => {
+    if (!warnTarget.value) return;
+
+    warningSending.value = true;
+    try {
+      await adminWarnUser(
+        warnTarget.value.sender_id,
+        warnTarget.value.conversation_id,
+        warnReason.value.trim() || undefined
+      );
+      toast.add({
+        title: 'Warning Sent',
+        description: 'User has been warned and a system message was injected',
+        color: 'success',
+      });
+      closeWarnModal();
+      await loadQueue();
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error.message, color: 'error' });
+    } finally {
+      warningSending.value = false;
+    }
+  };
+
+  const handleBanUser = (user: any) => {
+    banTarget.value = user;
+    banModal.value?.showModal();
+  };
+
+  const closeBanModal = () => {
+    banModal.value?.close();
+    banTarget.value = null;
+  };
+
+  const handleConfirmBan = async () => {
+    if (!banTarget.value) return;
+    try {
+      await toggleUserBan(banTarget.value.id, true);
+      toast.add({ title: 'User Banned', description: 'User has been banned from the platform', color: 'success' });
+      closeBanModal();
+      await loadQueue();
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error.message, color: 'error' });
+    }
+  };
+
+  // Helpers
+  const getInitials = (name: string | null | undefined) => {
+    if (!name) return '??';
+    return (
+      name
+        .split(' ')
+        .map((n) => n[0])
+        .filter(Boolean)
+        .join('')
+        .toUpperCase()
+        .slice(0, 2) || '??'
+    );
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  // Watchers
+  watch(activeTab, (tab) => {
+    if (tab === 'queue') loadQueue();
+    else loadConversations();
+  });
+
+  watch(queuePage, () => loadQueue());
+  watch(browserPage, () => loadConversations());
+  watch(browserFlaggedOnly, () => {
+    browserPage.value = 1;
+    loadConversations();
+  });
+  watch(browserSearch, () => {
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+      browserPage.value = 1;
+      loadConversations();
+    }, 300);
+  });
+
+  // Reset state on mount
+  onBeforeMount(() => {
+    queueItems.value = [];
+    conversations.value = [];
+    loading.value = true;
+  });
+
+  onMounted(() => {
+    loadQueue();
+  });
+</script>

--- a/app/pages/admin/exchange/moderation.vue
+++ b/app/pages/admin/exchange/moderation.vue
@@ -1,0 +1,734 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-3xl font-bold mb-2">Moderation Queue</h1>
+        <p class="text-base-content/70">
+          <template v-if="!loading && totalCount > 0">
+            {{ totalCount }} item{{ totalCount !== 1 ? 's' : '' }} need{{ totalCount === 1 ? 's' : '' }} review
+          </template>
+          <template v-else-if="!loading">No items pending moderation</template>
+          <template v-else>Loading moderation queue...</template>
+        </p>
+      </div>
+      <button class="btn btn-ghost btn-sm" :disabled="loading" @click="refreshAll">
+        <i class="fas fa-arrows-rotate" :class="{ 'animate-spin': loading }"></i>
+        Refresh
+      </button>
+    </div>
+
+    <!-- Tab Navigation -->
+    <div class="tabs tabs-bordered mb-6">
+      <button class="tab" :class="{ 'tab-active': activeTab === 'listings' }" @click="activeTab = 'listings'">
+        Listings
+        <span v-if="counts.listings > 0" class="badge badge-warning badge-sm ml-2">{{ counts.listings }}</span>
+      </button>
+      <button class="tab" :class="{ 'tab-active': activeTab === 'finds' }" @click="activeTab = 'finds'">
+        Finds
+        <span v-if="counts.finds > 0" class="badge badge-warning badge-sm ml-2">{{ counts.finds }}</span>
+      </button>
+      <button class="tab" :class="{ 'tab-active': activeTab === 'wanted' }" @click="activeTab = 'wanted'">
+        Wanted
+        <span v-if="counts.wanted > 0" class="badge badge-warning badge-sm ml-2">{{ counts.wanted }}</span>
+      </button>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="space-y-4">
+      <div v-for="i in 3" :key="i" class="skeleton h-40 w-full"></div>
+    </div>
+
+    <!-- ===== LISTINGS TAB ===== -->
+    <div v-else-if="activeTab === 'listings'">
+      <div v-if="tabErrors.listings" class="alert alert-error mb-4">
+        <i class="fas fa-triangle-exclamation"></i>
+        <span>{{ tabErrors.listings }}</span>
+        <button class="btn btn-ghost btn-sm" @click="loadPendingListings">Retry</button>
+      </div>
+      <div v-else-if="pendingListings.length > 0" class="space-y-4">
+        <div v-for="listing in pendingListings" :key="listing.id" class="card bg-base-100 shadow-sm">
+          <div class="card-body p-4">
+            <div class="flex flex-col md:flex-row gap-4">
+              <!-- Thumbnail -->
+              <div class="shrink-0">
+                <div class="w-full md:w-32 aspect-video bg-base-300 rounded-lg overflow-hidden">
+                  <img
+                    v-if="getPrimaryPhoto(listing)"
+                    :src="getPhotoUrl(getPrimaryPhoto(listing))"
+                    :alt="listing.title"
+                    class="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                  <div v-else class="w-full h-full flex items-center justify-center">
+                    <i class="fas fa-image text-2xl text-base-content/30"></i>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Content -->
+              <div class="flex-1 min-w-0">
+                <h3 class="font-bold text-lg mb-1">{{ listing.title }}</h3>
+                <div class="flex flex-wrap gap-3 text-sm text-base-content/70 mb-2">
+                  <span v-if="listing.year || listing.model"> {{ listing.year }} {{ listing.model }} </span>
+                  <span v-if="listing.price != null" class="font-semibold text-primary">
+                    ${{ formatPrice(listing.price) }}
+                  </span>
+                </div>
+                <div class="text-sm text-base-content/50 mb-3">
+                  <span class="flex items-center gap-1">
+                    <i class="fas fa-user"></i>
+                    {{ listing.profiles?.display_name || 'Unknown' }}
+                    <span v-if="listing.profiles?.email" class="text-base-content/40">
+                      ({{ listing.profiles.email }})
+                    </span>
+                  </span>
+                  <span class="flex items-center gap-1 mt-1">
+                    <i class="fas fa-calendar"></i>
+                    {{ formatDate(listing.created_at) }}
+                  </span>
+                </div>
+
+                <!-- Actions -->
+                <div class="flex flex-wrap gap-2">
+                  <button class="btn btn-success btn-sm gap-1" @click="approveListing(listing.id)">
+                    <i class="fas fa-circle-check"></i>
+                    Approve
+                  </button>
+                  <NuxtLink :to="`/exchange/listings/${listing.slug}`" target="_blank" class="btn btn-ghost btn-sm gap-1">
+                    <i class="fas fa-eye"></i>
+                    View
+                  </NuxtLink>
+                  <button
+                    class="btn btn-error btn-sm btn-outline gap-1"
+                    @click="openDeleteModal('listing', listing.id, listing.title)"
+                  >
+                    <i class="fas fa-trash"></i>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Truncation notice -->
+      <div v-if="listingsTotalCount > pendingListings.length" class="alert alert-info mt-4">
+        <i class="fas fa-circle-info"></i>
+        <span
+          >Showing {{ pendingListings.length }} of {{ listingsTotalCount }} pending listings. Visit the
+          <NuxtLink to="/admin/exchange/listings" class="link">full listings page</NuxtLink> to see all.
+        </span>
+      </div>
+
+      <!-- Empty state -->
+      <div
+        v-else-if="!tabErrors.listings && pendingListings.length === 0"
+        class="text-center py-16 card bg-base-100 shadow-sm"
+      >
+        <i class="fas fa-circle-check text-6xl mx-auto mb-4 text-success/50"></i>
+        <h3 class="text-xl font-semibold mb-2">No Pending Listings</h3>
+        <p class="text-base-content/70">All listings have been reviewed.</p>
+      </div>
+    </div>
+
+    <!-- ===== FINDS TAB ===== -->
+    <div v-else-if="activeTab === 'finds'">
+      <div v-if="tabErrors.finds" class="alert alert-error mb-4">
+        <i class="fas fa-triangle-exclamation"></i>
+        <span>{{ tabErrors.finds }}</span>
+        <button class="btn btn-ghost btn-sm" @click="loadPendingFinds">Retry</button>
+      </div>
+      <div v-else-if="pendingFinds.length > 0" class="space-y-4">
+        <div v-for="find in pendingFinds" :key="find.id" class="card bg-base-100 shadow-sm">
+          <div class="card-body p-4">
+            <div class="flex flex-col md:flex-row gap-4">
+              <!-- Thumbnail -->
+              <div class="shrink-0">
+                <div class="w-full md:w-48 aspect-video bg-base-300 rounded-lg overflow-hidden">
+                  <img
+                    v-if="find.og_image_url"
+                    :src="find.og_image_url"
+                    :alt="find.title"
+                    class="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                  <div v-else class="w-full h-full flex items-center justify-center">
+                    <i class="fas fa-link text-3xl text-base-content/30"></i>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Content -->
+              <div class="flex-1 min-w-0">
+                <!-- Title & Source -->
+                <div class="flex flex-wrap items-start gap-2 mb-2">
+                  <h3 class="font-bold text-lg">{{ find.title }}</h3>
+                  <span class="badge badge-sm" :class="getSourceBadgeClass(find.source_site)">
+                    {{ getSourceDisplayName(find.source_site) }}
+                  </span>
+                </div>
+
+                <!-- Metadata -->
+                <div class="flex flex-wrap gap-3 text-sm text-base-content/70 mb-2">
+                  <span v-if="find.year">
+                    <i class="fas fa-calendar inline"></i>
+                    {{ find.year }}
+                  </span>
+                  <span v-if="find.model">
+                    <i class="fas fa-truck inline"></i>
+                    {{ find.model }}
+                  </span>
+                  <span v-if="find.price != null || find.price_label" class="font-semibold text-primary">
+                    {{ find.price_label || formatCurrency(find.price!) }}
+                  </span>
+                  <span v-if="find.category" class="badge badge-xs badge-outline">{{ find.category }}</span>
+                </div>
+
+                <!-- Submitter & Date -->
+                <div class="text-sm text-base-content/50 mb-2">
+                  Submitted by <strong>{{ find.profiles?.display_name || 'Unknown' }}</strong> on
+                  {{ formatDate(find.created_at) }}
+                </div>
+
+                <!-- Source URL -->
+                <a
+                  :href="find.source_url"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="link link-primary text-sm inline-flex items-center gap-1 mb-3"
+                >
+                  <i class="fas fa-arrow-up-right-from-square"></i>
+                  {{ truncateUrl(find.source_url) }}
+                </a>
+
+                <!-- Actions -->
+                <div class="flex flex-wrap gap-2">
+                  <button class="btn btn-success btn-sm gap-1" @click="openApproveFindsModal(find)">
+                    <i class="fas fa-circle-check"></i>
+                    Approve
+                  </button>
+                  <button class="btn btn-error btn-sm btn-outline gap-1" @click="openRejectFindModal(find.id)">
+                    <i class="fas fa-circle-xmark"></i>
+                    Reject
+                  </button>
+                  <button
+                    class="btn btn-ghost btn-sm gap-1"
+                    :disabled="refetchingFindId === find.id"
+                    @click="handleRefetchMetadata(find.id)"
+                  >
+                    <span v-if="refetchingFindId === find.id" class="loading loading-spinner loading-xs"></span>
+                    <i v-else class="fas fa-arrows-rotate"></i>
+                    {{ refetchingFindId === find.id ? 'Fetching...' : 'Re-fetch' }}
+                  </button>
+                  <button
+                    class="btn btn-ghost btn-sm btn-error gap-1"
+                    @click="openDeleteModal('find', find.id, find.title)"
+                  >
+                    <i class="fas fa-trash"></i>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div v-else class="text-center py-16 card bg-base-100 shadow-sm">
+        <i class="fas fa-circle-check text-6xl mx-auto mb-4 text-success/50"></i>
+        <h3 class="text-xl font-semibold mb-2">No Pending Finds</h3>
+        <p class="text-base-content/70">All finds have been reviewed.</p>
+      </div>
+    </div>
+
+    <!-- ===== WANTED TAB ===== -->
+    <div v-else-if="activeTab === 'wanted'">
+      <div v-if="tabErrors.wanted" class="alert alert-error mb-4">
+        <i class="fas fa-triangle-exclamation"></i>
+        <span>{{ tabErrors.wanted }}</span>
+        <button class="btn btn-ghost btn-sm" @click="loadWantedPosts">Retry</button>
+      </div>
+      <div v-else-if="wantedPosts.length > 0" class="space-y-4">
+        <div v-for="post in wantedPosts" :key="post.id" class="card bg-base-100 shadow-sm">
+          <div class="card-body p-4">
+            <div class="flex flex-col md:flex-row gap-4">
+              <!-- Content -->
+              <div class="flex-1 min-w-0">
+                <div class="flex flex-wrap items-start gap-2 mb-2">
+                  <h3 class="font-bold text-lg">{{ post.title }}</h3>
+                  <span class="badge badge-sm badge-outline">{{ post.category }}</span>
+                  <span v-if="post.moderation_status === 'flagged'" class="badge badge-sm badge-error"> Flagged </span>
+                </div>
+
+                <!-- Description preview -->
+                <p class="text-sm text-base-content/60 line-clamp-2 mb-2">
+                  {{ post.description }}
+                </p>
+
+                <!-- Moderation issues -->
+                <div v-if="post.moderation_issues?.length" class="flex flex-wrap gap-1 mb-2">
+                  <span v-for="issue in post.moderation_issues" :key="issue" class="badge badge-warning badge-sm">
+                    {{ issue }}
+                  </span>
+                </div>
+
+                <!-- User info -->
+                <div class="text-sm text-base-content/50 mb-3">
+                  <span class="flex items-center gap-1">
+                    <i class="fas fa-user"></i>
+                    {{ post.profiles?.display_name || post.profiles?.email || 'Unknown' }}
+                  </span>
+                  <span class="flex items-center gap-1 mt-1">
+                    <i class="fas fa-calendar"></i>
+                    {{ formatDate(post.created_at) }}
+                  </span>
+                </div>
+
+                <!-- Actions -->
+                <div class="flex flex-wrap gap-2">
+                  <button class="btn btn-success btn-sm gap-1" @click="approveWantedPost(post.id)">
+                    <i class="fas fa-circle-check"></i>
+                    Approve
+                  </button>
+                  <button class="btn btn-error btn-sm btn-outline gap-1" @click="rejectWantedPost(post.id)">
+                    <i class="fas fa-circle-xmark"></i>
+                    Reject
+                  </button>
+                  <button
+                    class="btn btn-ghost btn-sm btn-error gap-1"
+                    @click="openDeleteModal('wanted', post.id, post.title)"
+                  >
+                    <i class="fas fa-trash"></i>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div v-else class="text-center py-16 card bg-base-100 shadow-sm">
+        <i class="fas fa-circle-check text-6xl mx-auto mb-4 text-success/50"></i>
+        <h3 class="text-xl font-semibold mb-2">No Pending Wanted Posts</h3>
+        <p class="text-base-content/70">All wanted posts have been reviewed.</p>
+      </div>
+    </div>
+
+    <!-- ===== DELETE CONFIRMATION MODAL ===== -->
+    <dialog ref="deleteModalRef" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">Delete {{ deleteTarget?.type }}</h3>
+        <p class="py-4">
+          Are you sure you want to delete
+          <strong>{{ deleteTarget?.title }}</strong
+          >? This action cannot be undone.
+        </p>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeDeleteModal">Cancel</button>
+          <button class="btn btn-error" @click="confirmDelete">Delete</button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+
+    <!-- ===== FINDS APPROVE MODAL ===== -->
+    <dialog ref="approveFindsModalRef" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Approve Find</h3>
+
+        <div v-if="approvingFind" class="space-y-4">
+          <p class="text-base-content/70">
+            Approving: <strong>{{ approvingFind.title }}</strong>
+          </p>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Editor's Commentary (optional)</legend>
+            <textarea
+              v-model="approveCommentary"
+              class="textarea textarea-bordered w-full"
+              placeholder="Add a note about why this find is interesting..."
+              rows="3"
+            ></textarea>
+          </fieldset>
+
+          <label class="flex items-center gap-3 cursor-pointer">
+            <input v-model="approveEditorsPick" type="checkbox" class="checkbox checkbox-accent" />
+            <span class="label-text">
+              <i class="fas fa-star inline text-accent"></i>
+              Mark as Editor's Pick
+            </span>
+          </label>
+        </div>
+
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeApproveFindsModal">Cancel</button>
+          <button class="btn btn-success" @click="confirmApproveFind">
+            <i class="fas fa-circle-check"></i>
+            Approve
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+
+    <!-- ===== FINDS REJECTION MODAL ===== -->
+    <dialog ref="rejectFindModalRef" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Reject Find</h3>
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend">Rejection Reason (optional)</legend>
+          <textarea
+            v-model="findRejectionReason"
+            rows="3"
+            placeholder="e.g., Duplicate listing, not a Classic Mini, broken link..."
+            class="textarea w-full"
+          ></textarea>
+        </fieldset>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="closeRejectFindModal">Cancel</button>
+          <button class="btn btn-error" @click="confirmRejectFind">
+            <i class="fas fa-circle-xmark"></i>
+            Reject
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { ListingWithPhotos } from '~/composables/useListings';
+  import type { ExternalListing } from '~/composables/useExternalListings';
+  import type { WantedPost } from '~/composables/useWantedPosts';
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useHead({
+    title: 'Moderation Queue - Admin - The Mini Exchange',
+    meta: [
+      {
+        name: 'robots',
+        content: 'noindex, nofollow',
+      },
+    ],
+  });
+
+  // ---- Composables ----
+  const route = useRoute();
+  const router = useRouter();
+  const supabase = useSupabase();
+  const toast = useToast();
+  const { getAllListings, updateListingStatus, deleteListing } = useAdmin();
+  const { pendingFinds, fetchPending, approve, reject, refetchMetadata, deleteFind } = useExternalListingAdmin();
+  const {
+    formatPrice,
+    formatDate,
+    formatCurrency,
+    formatFieldName,
+    formatValue,
+    getSourceDisplayName,
+    getSourceBadgeClass,
+    truncateUrl,
+  } = useFormatters();
+
+  // ---- State ----
+  const loading = ref(true);
+  const activeTab = ref<'listings' | 'finds' | 'wanted'>('listings');
+  const tabErrors = ref<Record<string, string | null>>({
+    listings: null,
+    finds: null,
+    wanted: null,
+  });
+
+  // Listings tab
+  const pendingListings = ref<ListingWithPhotos[]>([]);
+  const listingsTotalCount = ref(0);
+
+  // Wanted tab
+  const wantedPosts = ref<WantedPost[]>([]);
+
+  // Finds tab
+  const refetchingFindId = ref<string | null>(null);
+
+  // Delete modal
+  const deleteModalRef = ref<HTMLDialogElement | null>(null);
+  const deleteTarget = ref<{ type: string; id: string; title: string } | null>(null);
+
+  // Finds approve modal
+  const approveFindsModalRef = ref<HTMLDialogElement | null>(null);
+  const approvingFind = ref<ExternalListing | null>(null);
+  const approveCommentary = ref('');
+  const approveEditorsPick = ref(false);
+
+  // Finds rejection modal
+  const rejectFindModalRef = ref<HTMLDialogElement | null>(null);
+  const rejectingFindId = ref<string | null>(null);
+  const findRejectionReason = ref('');
+
+  // ---- Computed counts ----
+  const counts = computed(() => ({
+    listings: pendingListings.value.length,
+    finds: pendingFinds.value.length,
+    wanted: wantedPosts.value.length,
+  }));
+
+  const totalCount = computed(() => counts.value.listings + counts.value.finds + counts.value.wanted);
+
+  // ---- Tab URL sync ----
+  watch(activeTab, (tab) => {
+    router.replace({ query: { ...route.query, tab } });
+  });
+
+  // ---- Data loading ----
+  const loadPendingListings = async () => {
+    tabErrors.value.listings = null;
+    try {
+      const result = await getAllListings(1, 100, 'pending');
+      pendingListings.value = result.listings;
+      listingsTotalCount.value = result.total;
+    } catch (error: any) {
+      console.error('Error loading pending listings:', error);
+      tabErrors.value.listings = 'Failed to load pending listings';
+    }
+  };
+
+  const loadWantedPosts = async () => {
+    tabErrors.value.wanted = null;
+    try {
+      const { data, error } = await supabase
+        .from('wanted_posts')
+        .select('*, profiles!wanted_posts_user_id_fkey(id, display_name, email, avatar_url)')
+        .in('moderation_status', ['pending', 'flagged'])
+        .order('created_at', { ascending: false });
+
+      if (error) throw error;
+      wantedPosts.value = (data as unknown as WantedPost[]) || [];
+    } catch (error: any) {
+      console.error('Error loading wanted posts:', error);
+      tabErrors.value.wanted = 'Failed to load wanted posts';
+    }
+  };
+
+  const loadPendingFinds = async () => {
+    tabErrors.value.finds = null;
+    try {
+      await fetchPending();
+    } catch (error: any) {
+      console.error('Error loading pending finds:', error);
+      tabErrors.value.finds = 'Failed to load pending finds';
+    }
+  };
+
+  const refreshAll = async () => {
+    loading.value = true;
+    await Promise.all([loadPendingListings(), loadPendingFinds(), loadWantedPosts()]);
+    loading.value = false;
+  };
+
+  // ---- Photo helpers ----
+  const getPrimaryPhoto = (listing: ListingWithPhotos) => {
+    if (!listing.listing_photos?.length) return null;
+    return listing.listing_photos.find((p: any) => p.is_primary) || listing.listing_photos[0];
+  };
+
+  const getPhotoUrl = (photo: any) => {
+    if (!photo) return '';
+    const { data } = supabase.storage.from('listing-photos').getPublicUrl(photo.storage_path);
+    return data.publicUrl;
+  };
+
+  // ---- Listings actions ----
+  const approveListing = async (listingId: string) => {
+    try {
+      await updateListingStatus(listingId, 'active');
+      toast.add({
+        title: 'Listing Approved',
+        description: 'The listing is now active.',
+        color: 'success',
+      });
+      pendingListings.value = pendingListings.value.filter((l) => l.id !== listingId);
+    } catch (error: any) {
+      toast.add({
+        title: 'Error',
+        description: error.message || 'Failed to approve listing',
+        color: 'error',
+      });
+    }
+  };
+
+  // ---- Finds actions ----
+  const openApproveFindsModal = (find: ExternalListing) => {
+    approvingFind.value = find;
+    approveCommentary.value = '';
+    approveEditorsPick.value = false;
+    approveFindsModalRef.value?.showModal();
+  };
+
+  const closeApproveFindsModal = () => {
+    approveFindsModalRef.value?.close();
+    approvingFind.value = null;
+  };
+
+  const confirmApproveFind = async () => {
+    if (!approvingFind.value) return;
+    await approve(
+      approvingFind.value.id,
+      approveCommentary.value.trim() || undefined,
+      approveEditorsPick.value || undefined
+    );
+    closeApproveFindsModal();
+  };
+
+  const openRejectFindModal = (id: string) => {
+    rejectingFindId.value = id;
+    findRejectionReason.value = '';
+    rejectFindModalRef.value?.showModal();
+  };
+
+  const closeRejectFindModal = () => {
+    rejectFindModalRef.value?.close();
+    rejectingFindId.value = null;
+  };
+
+  const confirmRejectFind = async () => {
+    if (!rejectingFindId.value) return;
+    await reject(rejectingFindId.value, findRejectionReason.value.trim() || undefined);
+    closeRejectFindModal();
+  };
+
+  const handleRefetchMetadata = async (id: string) => {
+    if (refetchingFindId.value) return;
+    refetchingFindId.value = id;
+    try {
+      await refetchMetadata(id);
+      await fetchPending();
+    } finally {
+      refetchingFindId.value = null;
+    }
+  };
+
+  // ---- Wanted actions ----
+  const approveWantedPost = async (id: string) => {
+    try {
+      const { error } = await supabase
+        .from('wanted_posts')
+        .update({ status: 'active', moderation_status: 'approved' })
+        .eq('id', id);
+
+      if (error) throw error;
+
+      wantedPosts.value = wantedPosts.value.filter((p) => p.id !== id);
+      toast.add({
+        title: 'Wanted Post Approved',
+        description: 'The wanted post is now active.',
+        color: 'success',
+      });
+    } catch (error: any) {
+      toast.add({
+        title: 'Error',
+        description: error.message || 'Failed to approve wanted post',
+        color: 'error',
+      });
+    }
+  };
+
+  const rejectWantedPost = async (id: string) => {
+    try {
+      const { error } = await supabase
+        .from('wanted_posts')
+        .update({ status: 'removed', moderation_status: 'rejected' })
+        .eq('id', id);
+
+      if (error) throw error;
+
+      wantedPosts.value = wantedPosts.value.filter((p) => p.id !== id);
+      toast.add({
+        title: 'Wanted Post Rejected',
+        description: 'The wanted post has been rejected.',
+        color: 'warning',
+      });
+    } catch (error: any) {
+      toast.add({
+        title: 'Error',
+        description: error.message || 'Failed to reject wanted post',
+        color: 'error',
+      });
+    }
+  };
+
+  // ---- Generic delete modal ----
+  const openDeleteModal = (type: string, id: string, title: string) => {
+    deleteTarget.value = { type, id, title };
+    deleteModalRef.value?.showModal();
+  };
+
+  const closeDeleteModal = () => {
+    deleteModalRef.value?.close();
+    deleteTarget.value = null;
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget.value) return;
+
+    const { type, id } = deleteTarget.value;
+
+    try {
+      if (type === 'listing') {
+        await deleteListing(id);
+        pendingListings.value = pendingListings.value.filter((l) => l.id !== id);
+      } else if (type === 'find') {
+        await deleteFind(id);
+      } else if (type === 'wanted') {
+        const { error } = await supabase.from('wanted_posts').delete().eq('id', id);
+        if (error) throw error;
+        wantedPosts.value = wantedPosts.value.filter((p) => p.id !== id);
+      }
+
+      toast.add({
+        title: 'Deleted',
+        description: `The ${type} has been deleted.`,
+        color: 'success',
+      });
+    } catch (error: any) {
+      toast.add({
+        title: 'Error',
+        description: error.message || `Failed to delete ${type}`,
+        color: 'error',
+      });
+    } finally {
+      closeDeleteModal();
+    }
+  };
+
+  // ---- Lifecycle ----
+  onMounted(async () => {
+    loading.value = true;
+    await Promise.all([loadPendingListings(), loadPendingFinds(), loadWantedPosts()]);
+    loading.value = false;
+
+    // Auto-select tab from URL or busiest tab
+    const queryTab = route.query.tab as string;
+    if (['listings', 'finds', 'wanted'].includes(queryTab)) {
+      activeTab.value = queryTab as typeof activeTab.value;
+    } else {
+      const entries = Object.entries(counts.value) as Array<[typeof activeTab.value, number]>;
+      const busiest = entries.reduce((max, entry) => (entry[1] > max[1] ? entry : max));
+      if (busiest[1] > 0) {
+        activeTab.value = busiest[0];
+      }
+    }
+  });
+</script>

--- a/app/pages/admin/exchange/moderation.vue
+++ b/app/pages/admin/exchange/moderation.vue
@@ -19,7 +19,7 @@
     </div>
 
     <!-- Tab Navigation -->
-    <div class="tabs tabs-bordered mb-6">
+    <div class="tabs tabs-border mb-6">
       <button class="tab" :class="{ 'tab-active': activeTab === 'listings' }" @click="activeTab = 'listings'">
         Listings
         <span v-if="counts.listings > 0" class="badge badge-warning badge-sm ml-2">{{ counts.listings }}</span>

--- a/app/pages/admin/exchange/newsletter.vue
+++ b/app/pages/admin/exchange/newsletter.vue
@@ -1,0 +1,403 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold mb-2">Weekly Newsletter</h1>
+      <p class="text-base-content/70">Manage the weekly digest sent to all subscribers</p>
+    </div>
+
+    <!-- Stats Cards -->
+    <div class="grid md:grid-cols-4 gap-4 mb-8">
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <div class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center">
+              <i class="fas fa-users text-xl text-primary"></i>
+            </div>
+            <div>
+              <div class="text-2xl font-bold">{{ preview?.subscriberCount || 0 }}</div>
+              <div class="text-sm text-base-content/70">Total Subscribers</div>
+              <div v-if="preview?.shopifySubscriberCount" class="text-xs text-base-content/50 mt-0.5">
+                {{ preview.profileSubscriberCount }} TME + {{ preview.shopifySubscriberCount }} Shopify
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <div class="w-12 h-12 bg-success/10 rounded-lg flex items-center justify-center">
+              <i class="far fa-star text-xl text-success"></i>
+            </div>
+            <div>
+              <div class="text-2xl font-bold">{{ preview?.totalPremiumThisWeek || 0 }}</div>
+              <div class="text-sm text-base-content/70">Premium Listings</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <div class="w-12 h-12 bg-info/10 rounded-lg flex items-center justify-center">
+              <i class="fas fa-list text-xl text-info"></i>
+            </div>
+            <div>
+              <div class="text-2xl font-bold">{{ preview?.totalFreeThisWeek || 0 }}</div>
+              <div class="text-sm text-base-content/70">Free Listings</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <div class="w-12 h-12 bg-warning/10 rounded-lg flex items-center justify-center">
+              <i class="fas fa-clock text-xl text-warning"></i>
+            </div>
+            <div>
+              <div class="text-2xl font-bold">{{ lastSentDisplay }}</div>
+              <div class="text-sm text-base-content/70">Last Sent</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Newsletter Preview -->
+    <div class="card bg-base-100 shadow mb-8">
+      <div class="card-body">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+          <div>
+            <h2 class="card-title">
+              <i class="fas fa-eye text-xl"></i>
+              Newsletter Preview
+            </h2>
+            <p class="text-sm text-base-content/70 mt-1">
+              These {{ preview?.totalCount || 0 }} listings will be included in the next newsletter
+            </p>
+          </div>
+          <div class="flex gap-2">
+            <button @click="refreshPreview" class="btn btn-ghost btn-sm" :class="{ loading: loading }">
+              <i v-if="!loading" class="fas fa-arrows-rotate"></i>
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <div v-if="loading" class="flex justify-center py-12">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+
+        <div v-else-if="!preview?.listings?.length" class="text-center py-12 text-base-content/50">
+          <i class="fas fa-inbox text-4xl mx-auto mb-2 opacity-50"></i>
+          <p>No listings available for this week's newsletter</p>
+        </div>
+
+        <div v-else>
+          <iframe
+            ref="emailPreviewFrame"
+            :srcdoc="preview.emailHtml"
+            class="w-full border border-base-300 rounded-lg"
+            style="min-height: 600px"
+            sandbox="allow-same-origin"
+            @load="resizeIframe"
+          ></iframe>
+        </div>
+
+        <!-- Actions -->
+        <div class="divider"></div>
+        <div class="flex flex-col sm:flex-row gap-4 justify-between items-center">
+          <div class="text-sm text-base-content/70">
+            <template v-if="!canSendNewsletter">
+              <i class="fas fa-clock inline mr-1"></i>
+              Next send available in {{ daysUntilNextSend }} day{{ daysUntilNextSend === 1 ? '' : 's' }}
+            </template>
+            <template v-else>
+              <i class="fas fa-circle-check inline mr-1 text-success"></i>
+              Ready to send
+            </template>
+          </div>
+          <div class="flex gap-2">
+            <button @click="openTestModal" class="btn btn-outline btn-sm" :disabled="!preview?.listings?.length">
+              <i class="fas fa-paper-plane"></i>
+              Send Test Email
+            </button>
+            <button
+              @click="openSendModal"
+              class="btn btn-primary btn-sm"
+              :disabled="!preview?.listings?.length || sending"
+            >
+              <i class="fas fa-envelope"></i>
+              Send to All ({{ preview?.subscriberCount || 0 }})
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Send History -->
+    <div class="card bg-base-100 shadow">
+      <div class="card-body">
+        <h2 class="card-title mb-4">
+          <i class="fas fa-clock text-xl"></i>
+          Send History
+        </h2>
+
+        <div v-if="historyLoading" class="flex justify-center py-8">
+          <span class="loading loading-spinner loading-md"></span>
+        </div>
+
+        <div v-else-if="sendHistory.length === 0" class="text-center py-8 text-base-content/50">
+          <i class="fas fa-boxes-stacked text-4xl mx-auto mb-2 opacity-50"></i>
+          <p>No newsletters have been sent yet</p>
+        </div>
+
+        <div v-else class="overflow-x-auto">
+          <table class="table">
+            <thead>
+              <tr>
+                <th class="cursor-pointer select-none" @click="toggleSort('sent_at')">
+                  <span class="flex items-center gap-1">
+                    Date
+                    <i
+                      class="text-xs"
+                      :class="[getSortIcon('sent_at'), { 'opacity-30': !isSortedBy('sent_at') }]"
+                    ></i>
+                  </span>
+                </th>
+                <th class="cursor-pointer select-none" @click="toggleSort('recipient_count')">
+                  <span class="flex items-center gap-1">
+                    Recipients
+                    <i
+                      class="text-xs"
+                      :class="[getSortIcon('recipient_count'), { 'opacity-30': !isSortedBy('recipient_count') }]"
+                    ></i>
+                  </span>
+                </th>
+                <th>Listings</th>
+                <th class="cursor-pointer select-none" @click="toggleSort('status')">
+                  <span class="flex items-center gap-1">
+                    Status
+                    <i
+                      class="text-xs"
+                      :class="[getSortIcon('status'), { 'opacity-30': !isSortedBy('status') }]"
+                    ></i>
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="record in sortedHistory" :key="record.id">
+                <td>{{ formatDateTime(record.sent_at) }}</td>
+                <td>{{ record.recipient_count }}</td>
+                <td>
+                  <span class="badge badge-success badge-sm mr-1">{{ record.premium_count }} premium</span>
+                  <span v-if="record.free_count > 0" class="badge badge-info badge-sm"
+                    >{{ record.free_count }} free</span
+                  >
+                </td>
+                <td>
+                  <span :class="getStatusBadgeClass(record.status)">
+                    {{ record.status }}
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- Test Email Modal -->
+    <dialog ref="testModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Send Test Email</h3>
+        <p class="text-base-content/70 mb-4">
+          Send a test newsletter to preview how it will look. The email will be marked as a test.
+        </p>
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend">Email Address</legend>
+          <input v-model="testEmail" type="email" placeholder="your@email.com" class="input input-bordered w-full" />
+          <p class="text-xs text-base-content/50 mt-1">Leave blank to send to your account email</p>
+        </fieldset>
+        <div class="modal-action">
+          <button @click="closeTestModal" class="btn btn-ghost">Cancel</button>
+          <button @click="handleSendTest" class="btn btn-primary" :class="{ loading: testSending }">
+            <i v-if="!testSending" class="fas fa-paper-plane"></i>
+            Send Test
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+
+    <!-- Send Confirmation Modal -->
+    <dialog ref="sendModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Send Newsletter to All Subscribers</h3>
+        <div class="bg-warning/10 border border-warning/30 rounded-lg p-4 mb-4">
+          <p class="text-sm">
+            <i class="fas fa-triangle-exclamation inline mr-1 text-warning"></i>
+            This will send the newsletter to <strong>{{ preview?.subscriberCount || 0 }}</strong> subscribers.
+          </p>
+          <p v-if="preview?.shopifySubscriberCount" class="text-xs text-base-content/50 mt-1 ml-6">
+            {{ preview.profileSubscriberCount }} TME users + {{ preview.shopifySubscriberCount }} Shopify marketing subscribers
+          </p>
+        </div>
+        <p class="text-base-content/70 mb-4">
+          The newsletter will include {{ preview?.totalCount || 0 }} listings ({{ preview?.premiumCount || 0 }} premium,
+          {{ preview?.freeCount || 0 }} free).
+        </p>
+        <template v-if="!canSendNewsletter">
+          <div class="bg-info/10 border border-info/30 rounded-lg p-4 mb-4">
+            <p class="text-sm">
+              <i class="fas fa-circle-info inline mr-1 text-info"></i>
+              Newsletter was sent within the last 6 days. You can still send with override if needed.
+            </p>
+          </div>
+          <label class="flex items-center gap-2 mb-4 cursor-pointer">
+            <input v-model="forceOverride" type="checkbox" class="checkbox checkbox-sm" />
+            <span class="text-sm">Override and send anyway</span>
+          </label>
+        </template>
+        <div class="modal-action">
+          <button @click="closeSendModal" class="btn btn-ghost">Cancel</button>
+          <button
+            @click="handleSendToAll"
+            class="btn btn-primary"
+            :class="{ loading: sending }"
+            :disabled="!canSendNewsletter && !forceOverride"
+          >
+            <i v-if="!sending" class="fas fa-envelope"></i>
+            Send Newsletter
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useHead({
+    title: 'Weekly Newsletter - Admin - The Mini Exchange',
+  });
+
+  useSeoMeta({
+    robots: 'noindex, nofollow',
+  });
+
+  const {
+    loading,
+    sending,
+    testSending,
+    preview,
+    sendHistory,
+    historyLoading,
+    canSendNewsletter,
+    daysUntilNextSend,
+    fetchPreview,
+    sendTestEmail,
+    sendToAllSubscribers,
+    fetchSendHistory,
+  } = useNewsletter();
+
+  const { toggleSort, getSortIcon, isSortedBy, sortFn } = useTableSort('sent_at', 'desc');
+
+  const testModal = ref<HTMLDialogElement | null>(null);
+  const sendModal = ref<HTMLDialogElement | null>(null);
+  const emailPreviewFrame = ref<HTMLIFrameElement | null>(null);
+  const testEmail = ref('');
+  const forceOverride = ref(false);
+
+  const resizeIframe = () => {
+    const iframe = emailPreviewFrame.value;
+    if (iframe?.contentDocument?.body) {
+      iframe.style.height = iframe.contentDocument.body.scrollHeight + 32 + 'px';
+    }
+  };
+
+  const sortedHistory = computed(() => [...sendHistory.value].sort(sortFn));
+
+  // Computed
+
+  const lastSentDisplay = computed(() => {
+    if (!preview.value?.lastSentAt) return 'Never';
+    const date = new Date(preview.value.lastSentAt);
+    const now = new Date();
+    const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return formatDateTime(preview.value.lastSentAt);
+  });
+
+  // Methods
+  const refreshPreview = async () => {
+    await fetchPreview();
+  };
+
+  const getStatusBadgeClass = (status: string): string => {
+    switch (status) {
+      case 'sending':
+        return 'badge badge-info';
+      case 'sent':
+        return 'badge badge-success';
+      case 'partial':
+        return 'badge badge-warning';
+      case 'failed':
+        return 'badge badge-error';
+      default:
+        return 'badge';
+    }
+  };
+
+  const openTestModal = () => {
+    testEmail.value = '';
+    testModal.value?.showModal();
+  };
+
+  const closeTestModal = () => {
+    testModal.value?.close();
+  };
+
+  const handleSendTest = async () => {
+    const success = await sendTestEmail(testEmail.value || undefined);
+    if (success) {
+      closeTestModal();
+    }
+  };
+
+  const openSendModal = () => {
+    forceOverride.value = false;
+    sendModal.value?.showModal();
+  };
+
+  const closeSendModal = () => {
+    sendModal.value?.close();
+  };
+
+  const handleSendToAll = async () => {
+    const success = await sendToAllSubscribers(forceOverride.value);
+    if (success) {
+      closeSendModal();
+    }
+  };
+
+  // Load data on mount
+  onMounted(async () => {
+    await Promise.all([fetchPreview(), fetchSendHistory()]);
+  });
+</script>

--- a/app/pages/admin/exchange/promotions.vue
+++ b/app/pages/admin/exchange/promotions.vue
@@ -426,6 +426,7 @@
                     v-if="item.hasFacebook && item.features.facebook_post_id"
                     :href="`https://facebook.com/${item.features.facebook_post_id}`"
                     target="_blank"
+                    rel="noopener noreferrer"
                     class="btn btn-ghost btn-sm"
                     title="View Facebook post"
                   >
@@ -443,6 +444,7 @@
                     v-if="item.hasInstagram && item.features.instagram_post_id"
                     :href="`https://instagram.com/p/${item.features.instagram_post_id}`"
                     target="_blank"
+                    rel="noopener noreferrer"
                     class="btn btn-ghost btn-sm"
                     title="View Instagram post"
                   >
@@ -460,6 +462,7 @@
                     v-if="item.hasBluesky && item.features.bluesky_post_id"
                     :href="`https://bsky.app/profile/${blueskyHandle}/post/${item.features.bluesky_post_id}`"
                     target="_blank"
+                    rel="noopener noreferrer"
                     class="btn btn-ghost btn-sm"
                     title="View Bluesky post"
                   >

--- a/app/pages/admin/exchange/promotions.vue
+++ b/app/pages/admin/exchange/promotions.vue
@@ -1,0 +1,884 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold mb-2">Social Posting</h1>
+      <p class="text-base-content/70">Manage social media posts for listings</p>
+    </div>
+
+    <!-- Stats Cards -->
+    <div class="grid md:grid-cols-3 gap-4 mb-8">
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <div class="w-12 h-12 bg-warning/10 rounded-lg flex items-center justify-center">
+              <i class="fas fa-clock text-xl text-warning"></i>
+            </div>
+            <div>
+              <div class="text-2xl font-bold">{{ pendingSocialPromotions.length }}</div>
+              <div class="text-sm text-base-content/70">Pending Posts</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <div class="w-12 h-12 bg-error/10 rounded-lg flex items-center justify-center">
+              <i class="fas fa-triangle-exclamation text-xl text-error"></i>
+            </div>
+            <div>
+              <div class="text-2xl font-bold">{{ failedSocialPosts.length }}</div>
+              <div class="text-sm text-base-content/70">Failed Posts</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <div class="w-12 h-12 bg-success/10 rounded-lg flex items-center justify-center">
+              <i class="fas fa-circle-check text-xl text-success"></i>
+            </div>
+            <div>
+              <div class="text-2xl font-bold">{{ successfulSocialPosts.length }}</div>
+              <div class="text-sm text-base-content/70">Successfully Posted</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Failed Social Posts Section -->
+    <div v-if="failedSocialPosts.length > 0" class="card bg-base-100 shadow mb-8 border-2 border-error/30">
+      <div class="card-body">
+        <h2 class="card-title mb-4 text-error">
+          <i class="fas fa-triangle-exclamation"></i>
+          Failed Social Media Posts
+        </h2>
+        <p class="text-sm text-base-content/70 mb-4">
+          These listings had partial failures during social media posting. Click retry to attempt posting again.
+        </p>
+
+        <div class="space-y-4">
+          <div v-for="item in failedSocialPosts" :key="item.listing.id" class="card bg-base-200">
+            <div class="card-body p-4">
+              <div class="flex flex-col md:flex-row md:items-center gap-4">
+                <div class="flex items-center gap-3 flex-1">
+                  <div class="avatar shrink-0">
+                    <div class="w-16 h-16 rounded">
+                      <img
+                        v-if="item.listing.listing_photos?.[0]"
+                        :src="getPhotoUrl(item.listing.listing_photos[0].storage_path)"
+                        :alt="item.listing.title"
+                        loading="lazy"
+                      />
+                    </div>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <h3 class="font-semibold">{{ item.listing.title }}</h3>
+                    <p class="text-sm text-base-content/70">{{ item.listing.year }} {{ item.listing.model }}</p>
+                  </div>
+                </div>
+
+                <div class="flex flex-col gap-2">
+                  <!-- Platform Status -->
+                  <div class="flex flex-wrap items-center gap-2 text-sm">
+                    <span class="flex items-center gap-1" :class="item.hasFacebook ? 'text-success' : 'text-error'">
+                      <i :class="item.hasFacebook ? 'fas fa-circle-check' : 'fas fa-circle-xmark'"></i>
+                      Facebook
+                    </span>
+                    <span class="flex items-center gap-1" :class="item.hasInstagram ? 'text-success' : 'text-error'">
+                      <i :class="item.hasInstagram ? 'fas fa-circle-check' : 'fas fa-circle-xmark'"></i>
+                      Instagram
+                    </span>
+                    <span class="flex items-center gap-1" :class="item.hasBluesky ? 'text-success' : 'text-error'">
+                      <i :class="item.hasBluesky ? 'fas fa-circle-check' : 'fas fa-circle-xmark'"></i>
+                      Bluesky
+                    </span>
+                  </div>
+
+                  <!-- Retry Buttons -->
+                  <div class="flex flex-wrap gap-2">
+                    <NuxtLink :to="`/exchange/listings/${item.listing.slug}`" target="_blank" class="btn btn-sm btn-ghost">
+                      <i class="fas fa-eye"></i>
+                      View
+                    </NuxtLink>
+                    <button
+                      v-if="!item.hasFacebook"
+                      @click="retrySocialPost(item.listing.id, ['facebook'])"
+                      class="btn btn-sm btn-primary"
+                      :class="{ loading: retryingId === item.listing.id }"
+                      :disabled="retryingId === item.listing.id"
+                    >
+                      <i v-if="retryingId !== item.listing.id" class="fas fa-arrows-rotate"></i>
+                      Retry FB
+                    </button>
+                    <button
+                      v-if="!item.hasInstagram"
+                      @click="retrySocialPost(item.listing.id, ['instagram'])"
+                      class="btn btn-sm btn-primary"
+                      :class="{ loading: retryingId === item.listing.id }"
+                      :disabled="retryingId === item.listing.id"
+                    >
+                      <i v-if="retryingId !== item.listing.id" class="fas fa-arrows-rotate"></i>
+                      Retry IG
+                    </button>
+                    <button
+                      v-if="!item.hasBluesky"
+                      @click="retrySocialPost(item.listing.id, ['bluesky'])"
+                      class="btn btn-sm btn-primary"
+                      :class="{ loading: retryingId === item.listing.id }"
+                      :disabled="retryingId === item.listing.id"
+                    >
+                      <i v-if="retryingId !== item.listing.id" class="fas fa-arrows-rotate"></i>
+                      Retry Bsky
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Last retry diagnostics — shown after a retry attempt returns failures -->
+              <div v-if="retryErrors[item.listing.id]" class="mt-3 space-y-2">
+                <div
+                  v-for="(detail, platform) in retryErrors[item.listing.id]"
+                  :key="platform"
+                  class="alert alert-error alert-soft text-sm"
+                >
+                  <i class="fas fa-triangle-exclamation shrink-0"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="font-semibold capitalize">{{ platform }} failed</div>
+                    <div class="break-words">{{ detail.error }}</div>
+                    <details v-if="hasDiagnostics(detail)" class="mt-2">
+                      <summary class="cursor-pointer text-xs opacity-80 hover:opacity-100">
+                        Diagnostic details
+                      </summary>
+                      <dl class="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                        <template v-if="detail.errorCode !== undefined">
+                          <dt class="opacity-70">Code</dt>
+                          <dd><code>{{ detail.errorCode }}</code></dd>
+                        </template>
+                        <template v-if="detail.errorSubcode !== undefined">
+                          <dt class="opacity-70">Subcode</dt>
+                          <dd><code>{{ detail.errorSubcode }}</code></dd>
+                        </template>
+                        <template v-if="detail.errorType">
+                          <dt class="opacity-70">Type</dt>
+                          <dd><code>{{ detail.errorType }}</code></dd>
+                        </template>
+                        <template v-if="detail.userMessage">
+                          <dt class="opacity-70">User msg</dt>
+                          <dd class="break-words">{{ detail.userMessage }}</dd>
+                        </template>
+                        <template v-if="detail.fbtraceId">
+                          <dt class="opacity-70">fbtrace_id</dt>
+                          <dd class="flex items-center gap-2 min-w-0">
+                            <code class="truncate flex-1 min-w-0">{{ detail.fbtraceId }}</code>
+                            <button
+                              type="button"
+                              class="btn btn-xs btn-ghost shrink-0"
+                              :title="`Copy ${detail.fbtraceId}`"
+                              @click="copyToClipboard(detail.fbtraceId!)"
+                            >
+                              <i class="fas fa-clipboard text-xs"></i>
+                              Copy
+                            </button>
+                          </dd>
+                        </template>
+                      </dl>
+                    </details>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Pending Social Media Posts -->
+    <div class="card bg-base-100 shadow mb-8">
+      <div class="card-body">
+        <h2 class="card-title mb-4">
+          <i class="fas fa-clock"></i>
+          Pending Social Media Posts
+        </h2>
+
+        <div v-if="loading" class="flex justify-center py-8">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+
+        <div v-else-if="pendingSocialPromotions.length === 0" class="text-center py-8 text-base-content/50">
+          <i class="fas fa-circle-check text-4xl mx-auto mb-2 opacity-50"></i>
+          <p>No pending social media posts</p>
+        </div>
+
+        <div v-else>
+          <!-- Mobile Card View -->
+          <div class="md:hidden space-y-4">
+            <div v-for="listing in paginatedPending" :key="listing.id" class="card bg-base-200">
+              <div class="card-body p-4">
+                <div class="flex items-start gap-3 mb-3">
+                  <div class="avatar shrink-0">
+                    <div class="w-16 h-16 rounded">
+                      <img
+                        v-if="listing.listing_photos?.[0]"
+                        :src="getPhotoUrl(listing.listing_photos[0].storage_path)"
+                        :alt="listing.title"
+                        loading="lazy"
+                      />
+                    </div>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <h3 class="font-semibold">{{ listing.title }}</h3>
+                    <p class="text-sm text-base-content/70">{{ listing.year }} {{ listing.model }}</p>
+                    <div class="mt-2">
+                      <ExchangeListingsFeaturedBadge :tier="listing.tier" :featured-until="listing.featured_until" />
+                    </div>
+                  </div>
+                </div>
+                <div class="text-sm text-base-content/70 mb-3">
+                  <i class="fas fa-calendar inline mr-1"></i>
+                  {{ formatDate(listing.created_at) }}
+                </div>
+                <div class="flex gap-2">
+                  <NuxtLink :to="`/exchange/listings/${listing.slug}`" target="_blank" class="btn btn-sm btn-ghost flex-1">
+                    <i class="fas fa-eye"></i>
+                    View
+                  </NuxtLink>
+                  <button
+                    @click="autoPostToSocials(listing.id)"
+                    class="btn btn-primary btn-sm flex-1"
+                    :class="{ loading: postingId === listing.id }"
+                    :disabled="postingId === listing.id"
+                  >
+                    <i v-if="postingId !== listing.id" class="fas fa-paper-plane"></i>
+                    Post to Socials
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Desktop Table View -->
+          <div class="hidden md:block overflow-x-auto">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Listing</th>
+                  <th class="cursor-pointer select-none" @click="togglePendingSort('tier')">
+                    <span class="flex items-center gap-1">
+                      Tier
+                      <i
+                        class="text-xs"
+                        :class="[getPendingSortIcon('tier'), { 'opacity-30': !isPendingSortedBy('tier') }]"
+                      ></i>
+                    </span>
+                  </th>
+                  <th class="cursor-pointer select-none" @click="togglePendingSort('created_at')">
+                    <span class="flex items-center gap-1">
+                      Created
+                      <i
+                        class="text-xs"
+                        :class="[getPendingSortIcon('created_at'), { 'opacity-30': !isPendingSortedBy('created_at') }]"
+                      ></i>
+                    </span>
+                  </th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="listing in paginatedPending" :key="listing.id">
+                  <td>
+                    <div class="flex items-center gap-3">
+                      <div class="avatar">
+                        <div class="w-12 h-12 rounded">
+                          <img
+                            v-if="listing.listing_photos?.[0]"
+                            :src="getPhotoUrl(listing.listing_photos[0].storage_path)"
+                            :alt="listing.title"
+                            loading="lazy"
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <div class="font-semibold">{{ listing.title }}</div>
+                        <div class="text-sm text-base-content/70">{{ listing.year }} {{ listing.model }}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <ExchangeListingsFeaturedBadge :tier="listing.tier" :featured-until="listing.featured_until" />
+                  </td>
+                  <td>{{ formatDate(listing.created_at) }}</td>
+                  <td>
+                    <div class="flex gap-2">
+                      <NuxtLink
+                        :to="`/exchange/listings/${listing.slug}`"
+                        target="_blank"
+                        class="btn btn-ghost btn-sm"
+                        title="View listing"
+                      >
+                        <i class="fas fa-eye"></i>
+                      </NuxtLink>
+                      <button
+                        @click="autoPostToSocials(listing.id)"
+                        class="btn btn-primary btn-sm"
+                        :class="{ loading: postingId === listing.id }"
+                        :disabled="postingId === listing.id"
+                        title="Auto-post to all social platforms"
+                      >
+                        <i v-if="postingId !== listing.id" class="fas fa-paper-plane"></i>
+                        Post
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pending Pagination -->
+          <div v-if="pendingTotalPages > 1" class="flex justify-center mt-4">
+            <div class="join">
+              <button class="join-item btn btn-sm" :disabled="pendingPage <= 1" @click="pendingPage--">
+                <i class="fas fa-chevron-left"></i>
+              </button>
+              <button
+                v-for="page in pendingTotalPages"
+                :key="page"
+                class="join-item btn btn-sm"
+                :class="{ 'btn-active': page === pendingPage }"
+                @click="pendingPage = page"
+              >
+                {{ page }}
+              </button>
+              <button class="join-item btn btn-sm" :disabled="pendingPage >= pendingTotalPages" @click="pendingPage++">
+                <i class="fas fa-chevron-right"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Successfully Posted -->
+    <div class="card bg-base-100 shadow">
+      <div class="card-body">
+        <h2 class="card-title mb-4">
+          <i class="fas fa-circle-check text-success"></i>
+          Successfully Posted
+        </h2>
+
+        <div v-if="loading" class="flex justify-center py-8">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+
+        <div v-else-if="successfulSocialPosts.length === 0" class="text-center py-8 text-base-content/50">
+          <i class="fas fa-inbox text-4xl mx-auto mb-2 opacity-50"></i>
+          <p>No successfully posted listings yet</p>
+        </div>
+
+        <div v-else class="overflow-x-auto">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Listing</th>
+                <th class="cursor-pointer select-none" @click="toggleSuccessSort('listing.created_at')">
+                  <span class="flex items-center gap-1">
+                    Posted
+                    <i
+                      class="text-xs"
+                      :class="[getSuccessSortIcon('listing.created_at'), { 'opacity-30': !isSuccessSortedBy('listing.created_at') }]"
+                    ></i>
+                  </span>
+                </th>
+                <th>Facebook</th>
+                <th>Instagram</th>
+                <th>Bluesky</th>
+                <th>Listing</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in paginatedSuccess" :key="item.listing.id">
+                <td>
+                  <div class="flex items-center gap-3">
+                    <div class="avatar">
+                      <div class="w-12 h-12 rounded">
+                        <img
+                          v-if="item.listing.listing_photos?.[0]"
+                          :src="getPhotoUrl(item.listing.listing_photos[0].storage_path)"
+                          :alt="item.listing.title"
+                          loading="lazy"
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <div class="font-semibold">{{ item.listing.title }}</div>
+                      <div class="text-sm text-base-content/70">{{ item.listing.year }} {{ item.listing.model }}</div>
+                    </div>
+                  </div>
+                </td>
+                <td>{{ formatDate(item.listing.created_at) }}</td>
+                <td>
+                  <a
+                    v-if="item.hasFacebook && item.features.facebook_post_id"
+                    :href="`https://facebook.com/${item.features.facebook_post_id}`"
+                    target="_blank"
+                    class="btn btn-ghost btn-sm"
+                    title="View Facebook post"
+                  >
+                    <i class="fab fa-facebook"></i>
+                    View
+                  </a>
+                  <span v-else-if="item.hasFacebook" class="text-success flex items-center gap-1">
+                    <i class="fas fa-circle-check"></i>
+                    Posted
+                  </span>
+                  <span v-else class="text-base-content/50">-</span>
+                </td>
+                <td>
+                  <a
+                    v-if="item.hasInstagram && item.features.instagram_post_id"
+                    :href="`https://instagram.com/p/${item.features.instagram_post_id}`"
+                    target="_blank"
+                    class="btn btn-ghost btn-sm"
+                    title="View Instagram post"
+                  >
+                    <i class="fab fa-instagram"></i>
+                    View
+                  </a>
+                  <span v-else-if="item.hasInstagram" class="text-success flex items-center gap-1">
+                    <i class="fas fa-circle-check"></i>
+                    Posted
+                  </span>
+                  <span v-else class="text-base-content/50">-</span>
+                </td>
+                <td>
+                  <a
+                    v-if="item.hasBluesky && item.features.bluesky_post_id"
+                    :href="`https://bsky.app/profile/${blueskyHandle}/post/${item.features.bluesky_post_id}`"
+                    target="_blank"
+                    class="btn btn-ghost btn-sm"
+                    title="View Bluesky post"
+                  >
+                    <i class="fab fa-bluesky text-[#0085FF]"></i>
+                    View
+                  </a>
+                  <span v-else-if="item.hasBluesky" class="text-success flex items-center gap-1">
+                    <i class="fas fa-circle-check"></i>
+                    Posted
+                  </span>
+                  <span v-else class="text-base-content/50">-</span>
+                </td>
+                <td>
+                  <NuxtLink
+                    :to="`/exchange/listings/${item.listing.slug}`"
+                    target="_blank"
+                    class="btn btn-ghost btn-sm"
+                    title="View listing"
+                  >
+                    <i class="fas fa-eye"></i>
+                    View
+                  </NuxtLink>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <!-- Success Pagination -->
+          <div v-if="successTotalPages > 1" class="flex justify-center mt-4">
+            <div class="join">
+              <button class="join-item btn btn-sm" :disabled="successPage <= 1" @click="successPage--">
+                <i class="fas fa-chevron-left"></i>
+              </button>
+              <button
+                v-for="page in successTotalPages"
+                :key="page"
+                class="join-item btn btn-sm"
+                :class="{ 'btn-active': page === successPage }"
+                @click="successPage = page"
+              >
+                {{ page }}
+              </button>
+              <button class="join-item btn btn-sm" :disabled="successPage >= successTotalPages" @click="successPage++">
+                <i class="fas fa-chevron-right"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { ListingWithPhotos } from '~/composables/useListings';
+
+  interface SocialPostInfo {
+    listing: ListingWithPhotos;
+    hasFacebook: boolean;
+    hasInstagram: boolean;
+    hasBluesky: boolean;
+    features: Record<string, unknown>;
+  }
+
+  // Bluesky handle for constructing post URLs
+  const blueskyHandle = useRuntimeConfig().public.blueskyHandle || 'theminiexchange.bsky.social';
+
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useHead({
+    title: 'Social Posting - Admin - The Mini Exchange',
+    meta: [
+      {
+        name: 'robots',
+        content: 'noindex, nofollow',
+      },
+    ],
+  });
+
+  const supabase = useSupabase();
+  const toast = useToast();
+  const { getPhotoUrl } = useListings();
+  const {
+    toggleSort: togglePendingSort,
+    getSortIcon: getPendingSortIcon,
+    isSortedBy: isPendingSortedBy,
+    sortFn: pendingSortFn,
+  } = useTableSort('created_at', 'desc');
+  const {
+    toggleSort: toggleSuccessSort,
+    getSortIcon: getSuccessSortIcon,
+    isSortedBy: isSuccessSortedBy,
+    sortFn: successSortFn,
+  } = useTableSort('listing.created_at', 'desc');
+
+  const PAGE_SIZE = 25;
+
+  // Mirrors the server-side SocialPostResult shape (kept inline to avoid a
+  // client-side import of server-only code).
+  interface PlatformErrorDetail {
+    error?: string;
+    errorCode?: number;
+    errorSubcode?: number;
+    errorType?: string;
+    fbtraceId?: string;
+    userMessage?: string;
+  }
+  type PlatformKey = 'facebook' | 'instagram' | 'bluesky';
+  type ListingErrorMap = Partial<Record<PlatformKey, PlatformErrorDetail>>;
+
+  const loading = ref(true);
+  const retryingId = ref<string | null>(null);
+  const postingId = ref<string | null>(null);
+  const pendingSocialPromotions = ref<ListingWithPhotos[]>([]);
+  const failedSocialPosts = ref<SocialPostInfo[]>([]);
+  const successfulSocialPosts = ref<SocialPostInfo[]>([]);
+  // Per-listing diagnostic detail from the most recent retry attempt.
+  const retryErrors = ref<Record<string, ListingErrorMap>>({});
+
+  const hasDiagnostics = (detail: PlatformErrorDetail): boolean =>
+    detail.errorCode !== undefined ||
+    detail.errorSubcode !== undefined ||
+    !!detail.fbtraceId ||
+    !!detail.errorType ||
+    !!detail.userMessage;
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.add({ title: 'Copied', description: text, color: 'success' });
+    } catch {
+      toast.add({ title: 'Copy failed', description: 'Clipboard unavailable', color: 'error' });
+    }
+  };
+
+  /** Pluck only the diagnostic fields off a result, skipping `success`/`postId`. */
+  const pickErrorDetail = (result: any): PlatformErrorDetail => ({
+    error: result?.error,
+    errorCode: result?.errorCode,
+    errorSubcode: result?.errorSubcode,
+    errorType: result?.errorType,
+    fbtraceId: result?.fbtraceId,
+    userMessage: result?.userMessage,
+  });
+
+  /** Format a one-line summary safe for a toast (no fbtrace dumps). */
+  const formatPlatformError = (platform: string, detail: PlatformErrorDetail): string => {
+    const name = platform.charAt(0).toUpperCase() + platform.slice(1);
+    return `${name}: ${detail.error || 'Unknown error'}`;
+  };
+
+  // Pagination
+  const pendingPage = ref(1);
+  const successPage = ref(1);
+
+  const pendingTotalPages = computed(() => Math.ceil(pendingSocialPromotions.value.length / PAGE_SIZE));
+  const successTotalPages = computed(() => Math.ceil(successfulSocialPosts.value.length / PAGE_SIZE));
+
+  const sortedPending = computed(() => [...pendingSocialPromotions.value].sort(pendingSortFn));
+  const sortedSuccess = computed(() => [...successfulSocialPosts.value].sort(successSortFn));
+
+  const paginatedPending = computed(() => {
+    const start = (pendingPage.value - 1) * PAGE_SIZE;
+    return sortedPending.value.slice(start, start + PAGE_SIZE);
+  });
+
+  const paginatedSuccess = computed(() => {
+    const start = (successPage.value - 1) * PAGE_SIZE;
+    return sortedSuccess.value.slice(start, start + PAGE_SIZE);
+  });
+
+  // Load social posting data
+  const loadSocialPosts = async () => {
+    loading.value = true;
+    pendingPage.value = 1;
+    successPage.value = 1;
+
+    try {
+      // Fetch all active listings that need social media promotion
+      const { data: socialData, error: socialError } = await applyPhotoOrdering(
+        supabase
+          .from('listings')
+          .select(
+            `
+          *,
+          listing_photos (
+            id,
+            storage_path,
+            display_order,
+            category
+          )
+        `
+          )
+          .eq('promoted_on_social', false)
+          .eq('status', 'active')
+          .not('status', 'in', '("example_free","example_paid")')
+          .order('created_at', { ascending: false })
+      );
+
+      if (socialError) throw socialError;
+      pendingSocialPromotions.value = socialData as ListingWithPhotos[];
+
+      // Fetch listings with promotions data to determine success/failure status
+      try {
+        const { data: promotionData } = await supabase.from('listing_promotions').select('id, listing_id, features');
+
+        if (promotionData && promotionData.length > 0) {
+          const listingIds = promotionData.map((p) => p.listing_id);
+
+          // Fetch listing details
+          const { data: listingsData } = await applyPhotoOrdering(
+            supabase
+              .from('listings')
+              .select(
+                `
+                id,
+                title,
+                slug,
+                year,
+                model,
+                tier,
+                payment_status,
+                created_at,
+                listing_photos (
+                  id,
+                  storage_path,
+                  display_order,
+                  category
+                )
+              `
+              )
+              .in('id', listingIds)
+              .not('status', 'in', '("example_free","example_paid")')
+              .order('created_at', { ascending: false })
+          );
+
+          if (listingsData) {
+            const failed: SocialPostInfo[] = [];
+            const successful: SocialPostInfo[] = [];
+
+            for (const listing of listingsData) {
+              const promo = promotionData.find((p) => p.listing_id === listing.id);
+              if (!promo) continue;
+
+              const features = (promo.features || {}) as Record<string, unknown>;
+              const hasFacebook = !!features.facebook_post_id;
+              const hasInstagram = !!features.instagram_post_id;
+              const hasBluesky = !!features.bluesky_post_id;
+
+              const postInfo: SocialPostInfo = {
+                listing: listing as ListingWithPhotos,
+                hasFacebook,
+                hasInstagram,
+                hasBluesky,
+                features,
+              };
+
+              // Partial failure: at least one platform but not all three
+              if ((hasFacebook || hasInstagram || hasBluesky) && !(hasFacebook && hasInstagram && hasBluesky)) {
+                failed.push(postInfo);
+              }
+              // Success: all three platforms
+              else if (hasFacebook && hasInstagram && hasBluesky) {
+                successful.push(postInfo);
+              }
+            }
+
+            failedSocialPosts.value = failed;
+            successfulSocialPosts.value = successful;
+          }
+        }
+      } catch (promoErr) {
+        console.warn('Failed to fetch social post status:', promoErr);
+      }
+    } catch (error: any) {
+      console.error('Failed to load social posts:', error);
+      toast.add({
+        title: 'Error',
+        description: 'Failed to load social posting data',
+        color: 'error',
+      });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  // Auto-post a listing to all social media platforms
+  const autoPostToSocials = async (listingId: string) => {
+    postingId.value = listingId;
+
+    try {
+      const session = await supabase.auth.getSession();
+      const token = session.data.session?.access_token;
+
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await $fetch('/api/admin/exchange/social-retry', {
+        method: 'POST',
+        body: { listingId, platforms: ['facebook', 'instagram', 'bluesky'] },
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (response.allSucceeded) {
+        delete retryErrors.value[listingId];
+        toast.add({
+          title: 'Success',
+          description: 'Successfully posted to all platforms',
+          color: 'success',
+        });
+      } else {
+        const errorMap: ListingErrorMap = {};
+        const failures: string[] = [];
+        for (const [platform, result] of Object.entries(response.results)) {
+          if (!result || result.success) continue;
+          const detail = pickErrorDetail(result);
+          errorMap[platform as PlatformKey] = detail;
+          failures.push(formatPlatformError(platform, detail));
+        }
+        retryErrors.value = { ...retryErrors.value, [listingId]: errorMap };
+
+        toast.add({
+          title: 'Partial Success',
+          description: failures.length > 0 ? failures.join('. ') : 'Some platforms may have failed',
+          color: 'warning',
+        });
+      }
+
+      await loadSocialPosts();
+    } catch (error: any) {
+      console.error('Failed to post to social media:', error);
+      toast.add({
+        title: 'Error',
+        description: error?.data?.message || 'Failed to post to social media',
+        color: 'error',
+      });
+    } finally {
+      postingId.value = null;
+    }
+  };
+
+  // Retry social media post for failed platforms
+  const retrySocialPost = async (listingId: string, platforms: ('facebook' | 'instagram' | 'bluesky')[]) => {
+    retryingId.value = listingId;
+
+    try {
+      const session = await supabase.auth.getSession();
+      const token = session.data.session?.access_token;
+
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await $fetch('/api/admin/exchange/social-retry', {
+        method: 'POST',
+        body: { listingId, platforms },
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (response.allSucceeded) {
+        // Clear stale diagnostics for the platforms we just successfully retried.
+        const remaining = { ...(retryErrors.value[listingId] || {}) };
+        for (const platform of platforms) delete remaining[platform];
+        if (Object.keys(remaining).length === 0) {
+          const next = { ...retryErrors.value };
+          delete next[listingId];
+          retryErrors.value = next;
+        } else {
+          retryErrors.value = { ...retryErrors.value, [listingId]: remaining };
+        }
+
+        toast.add({
+          title: 'Success',
+          description: `Successfully posted to ${platforms.join(' and ')}`,
+          color: 'success',
+        });
+      } else {
+        const errorMap: ListingErrorMap = { ...(retryErrors.value[listingId] || {}) };
+        const failures: string[] = [];
+        for (const [platform, result] of Object.entries(response.results)) {
+          if (!result) continue;
+          if (result.success) {
+            delete errorMap[platform as PlatformKey];
+            continue;
+          }
+          const detail = pickErrorDetail(result);
+          errorMap[platform as PlatformKey] = detail;
+          failures.push(formatPlatformError(platform, detail));
+        }
+        retryErrors.value = { ...retryErrors.value, [listingId]: errorMap };
+
+        toast.add({
+          title: 'Partial Failure',
+          description: failures.length > 0 ? failures.join('. ') : 'Some platforms failed',
+          color: 'warning',
+        });
+      }
+
+      await loadSocialPosts();
+    } catch (error: any) {
+      console.error('Failed to retry social post:', error);
+      toast.add({
+        title: 'Error',
+        description: error?.data?.message || 'Failed to retry social media post',
+        color: 'error',
+      });
+    } finally {
+      retryingId.value = null;
+    }
+  };
+
+  onMounted(() => {
+    loadSocialPosts();
+  });
+</script>

--- a/app/pages/admin/exchange/wanted.vue
+++ b/app/pages/admin/exchange/wanted.vue
@@ -118,7 +118,7 @@
                 </button>
                 <ul
                   tabindex="0"
-                  class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-52 border border-base-300 z-9999"
+                  class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-52 border border-base-300 z-[9999]"
                 >
                   <li v-if="post.status !== 'active' || post.moderation_status !== 'approved'">
                     <a @click="confirmAction(post.id, 'approve')">
@@ -251,7 +251,7 @@
                       </button>
                       <ul
                         tabindex="0"
-                        class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-52 border border-base-300 z-9999"
+                        class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-52 border border-base-300 z-[9999]"
                       >
                         <li v-if="post.status !== 'active' || post.moderation_status !== 'approved'">
                           <a @click="confirmAction(post.id, 'approve')">

--- a/app/pages/admin/exchange/wanted.vue
+++ b/app/pages/admin/exchange/wanted.vue
@@ -1,0 +1,609 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h1 class="text-3xl font-bold mb-2">Wanted Post Moderation</h1>
+        <p class="text-base-content/70">Review and moderate wanted posts from the community</p>
+      </div>
+      <button class="btn btn-ghost btn-sm" :disabled="loading" @click="loadPosts">
+        <i class="fas fa-arrows-rotate" :class="{ 'animate-spin': loading }"></i>
+        Refresh
+      </button>
+    </div>
+
+    <!-- Filters -->
+    <div class="card bg-base-100 shadow-sm mb-6">
+      <div class="card-body">
+        <div class="flex flex-wrap gap-4 items-center">
+          <div class="form-control">
+            <label for="status-filter" class="label">
+              <span class="label-text">Filter by Status</span>
+            </label>
+            <select
+              id="status-filter"
+              v-model="selectedStatus"
+              class="select select-bordered w-full max-w-xs"
+            >
+              <option value="all">All Statuses</option>
+              <option value="flagged">Flagged</option>
+              <option value="active">Active</option>
+              <option value="removed">Removed</option>
+              <option value="fulfilled">Fulfilled</option>
+              <option value="expired">Expired</option>
+            </select>
+          </div>
+          <div class="form-control flex-1">
+            <label class="label">
+              <span class="label-text">Search</span>
+            </label>
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="Search by title or description..."
+              class="input input-bordered w-full"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="space-y-4">
+      <div v-for="i in 5" :key="i" class="skeleton h-32 w-full"></div>
+    </div>
+
+    <!-- Posts (Mobile + Desktop) -->
+    <div v-else-if="filteredPosts.length > 0">
+      <!-- Mobile Card View -->
+      <div class="md:hidden space-y-4">
+        <div v-for="post in filteredPosts" :key="post.id" class="card bg-base-100 shadow-sm">
+          <div class="card-body p-4">
+            <!-- Header -->
+            <div class="flex items-start gap-3 mb-3">
+              <div class="flex-1 min-w-0">
+                <h3 class="font-bold truncate">{{ post.title }}</h3>
+                <p class="text-sm text-base-content/70 line-clamp-2 mt-1">{{ post.description }}</p>
+              </div>
+              <div class="flex flex-col gap-1 shrink-0">
+                <span class="badge badge-sm" :class="getStatusBadgeClass(post.status)">
+                  {{ formatStatus(post.status) }}
+                </span>
+                <span class="badge badge-sm" :class="getModerationBadgeClass(post.moderation_status)">
+                  {{ formatModerationStatus(post.moderation_status) }}
+                </span>
+              </div>
+            </div>
+
+            <!-- Moderation Issues -->
+            <div v-if="post.moderation_issues && post.moderation_issues.length > 0" class="mb-3">
+              <div class="flex flex-wrap gap-1">
+                <span
+                  v-for="(issue, idx) in post.moderation_issues"
+                  :key="idx"
+                  class="badge badge-warning badge-sm gap-1"
+                >
+                  <i class="fas fa-triangle-exclamation"></i>
+                  {{ issue }}
+                </span>
+              </div>
+            </div>
+
+            <!-- User and Date Info -->
+            <div class="text-sm space-y-1 mb-3">
+              <div class="flex items-center gap-2">
+                <i class="fas fa-user text-base-content/50"></i>
+                <span class="font-medium">{{ post.profiles?.display_name || 'Unknown' }}</span>
+                <span class="text-base-content/50">{{ post.profiles?.email }}</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <i class="fas fa-tag text-base-content/50"></i>
+                <span class="capitalize">{{ post.category }}</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <i class="fas fa-calendar text-base-content/50"></i>
+                <span class="text-base-content/70">{{ formatDate(post.created_at) }}</span>
+              </div>
+            </div>
+
+            <!-- Actions -->
+            <div class="flex gap-2">
+              <NuxtLink :to="`/exchange/wanted/${post.id}`" class="btn btn-sm btn-ghost flex-1" target="_blank">
+                <i class="fas fa-eye"></i>
+                View
+              </NuxtLink>
+              <div class="dropdown dropdown-end">
+                <button tabindex="0" class="btn btn-sm btn-ghost">
+                  <i class="fas fa-ellipsis-vertical"></i>
+                </button>
+                <ul
+                  tabindex="0"
+                  class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-52 border border-base-300 z-9999"
+                >
+                  <li v-if="post.status !== 'active' || post.moderation_status !== 'approved'">
+                    <a @click="confirmAction(post.id, 'approve')">
+                      <i class="fas fa-circle-check text-success"></i>
+                      Approve
+                    </a>
+                  </li>
+                  <li v-if="post.status !== 'removed'">
+                    <a @click="confirmAction(post.id, 'reject')">
+                      <i class="fas fa-circle-xmark text-warning"></i>
+                      Reject
+                    </a>
+                  </li>
+                  <li class="border-t border-base-300 mt-1 pt-1">
+                    <a @click="confirmAction(post.id, 'delete')" class="text-error">
+                      <i class="fas fa-trash"></i>
+                      Delete
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop Table View -->
+      <div class="hidden md:block card bg-base-100 shadow-sm">
+        <div class="overflow-x-auto">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Post</th>
+                <th>User</th>
+                <th class="cursor-pointer select-none" @click="toggleSort('category')">
+                  <span class="flex items-center gap-1">
+                    Category
+                    <i
+                      class="text-xs"
+                      :class="[getSortIcon('category'), { 'opacity-30': !isSortedBy('category') }]"
+                    ></i>
+                  </span>
+                </th>
+                <th class="cursor-pointer select-none" @click="toggleSort('status')">
+                  <span class="flex items-center gap-1">
+                    Status
+                    <i
+                      class="text-xs"
+                      :class="[getSortIcon('status'), { 'opacity-30': !isSortedBy('status') }]"
+                    ></i>
+                  </span>
+                </th>
+                <th class="cursor-pointer select-none" @click="toggleSort('moderation_status')">
+                  <span class="flex items-center gap-1">
+                    Moderation
+                    <i
+                      class="text-xs"
+                      :class="[getSortIcon('moderation_status'), { 'opacity-30': !isSortedBy('moderation_status') }]"
+                    ></i>
+                  </span>
+                </th>
+                <th class="cursor-pointer select-none" @click="toggleSort('created_at')">
+                  <span class="flex items-center gap-1">
+                    Created
+                    <i
+                      class="text-xs"
+                      :class="[getSortIcon('created_at'), { 'opacity-30': !isSortedBy('created_at') }]"
+                    ></i>
+                  </span>
+                </th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="post in filteredPosts" :key="post.id">
+                <td>
+                  <div class="max-w-xs">
+                    <div class="font-bold truncate">{{ post.title }}</div>
+                    <div class="text-sm text-base-content/70 line-clamp-1">{{ post.description }}</div>
+                    <div
+                      v-if="post.moderation_issues && post.moderation_issues.length > 0"
+                      class="flex flex-wrap gap-1 mt-1"
+                    >
+                      <span
+                        v-for="(issue, idx) in post.moderation_issues"
+                        :key="idx"
+                        class="badge badge-warning badge-xs gap-1"
+                      >
+                        <i class="fas fa-triangle-exclamation"></i>
+                        {{ issue }}
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="text-sm">
+                    <div class="font-medium">{{ post.profiles?.display_name || 'Unknown' }}</div>
+                    <div class="text-base-content/70">{{ post.profiles?.email }}</div>
+                  </div>
+                </td>
+                <td>
+                  <span class="capitalize">{{ post.category }}</span>
+                </td>
+                <td>
+                  <span class="badge badge-sm" :class="getStatusBadgeClass(post.status)">
+                    {{ formatStatus(post.status) }}
+                  </span>
+                </td>
+                <td>
+                  <span class="badge badge-sm" :class="getModerationBadgeClass(post.moderation_status)">
+                    {{ formatModerationStatus(post.moderation_status) }}
+                  </span>
+                </td>
+                <td>
+                  <span class="text-sm">{{ formatDate(post.created_at) }}</span>
+                </td>
+                <td>
+                  <div class="flex gap-2">
+                    <NuxtLink
+                      :to="`/exchange/wanted/${post.id}`"
+                      class="btn btn-ghost btn-xs"
+                      target="_blank"
+                      aria-label="View wanted post"
+                    >
+                      <i class="fas fa-eye"></i>
+                    </NuxtLink>
+                    <div class="dropdown dropdown-end">
+                      <button tabindex="0" class="btn btn-ghost btn-xs">
+                        <i class="fas fa-ellipsis-vertical"></i>
+                      </button>
+                      <ul
+                        tabindex="0"
+                        class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-52 border border-base-300 z-9999"
+                      >
+                        <li v-if="post.status !== 'active' || post.moderation_status !== 'approved'">
+                          <a @click="confirmAction(post.id, 'approve')">
+                            <i class="fas fa-circle-check text-success"></i>
+                            Approve
+                          </a>
+                        </li>
+                        <li v-if="post.status !== 'removed'">
+                          <a @click="confirmAction(post.id, 'reject')">
+                            <i class="fas fa-circle-xmark text-warning"></i>
+                            Reject
+                          </a>
+                        </li>
+                        <li class="border-t border-base-300 mt-1 pt-1">
+                          <a @click="confirmAction(post.id, 'delete')" class="text-error">
+                            <i class="fas fa-trash"></i>
+                            Delete
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <!-- Bottom padding for dropdown space -->
+          <div class="h-48"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty State -->
+    <div v-else class="text-center py-16 card bg-base-100 shadow-sm">
+      <i class="fas fa-inbox text-6xl mx-auto mb-4 text-base-content/30"></i>
+      <h3 class="text-xl font-semibold mb-2">No Wanted Posts Found</h3>
+      <p class="text-base-content/70">Try adjusting your filters</p>
+    </div>
+
+    <!-- Action Confirmation Modal -->
+    <dialog ref="actionModalRef" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg">{{ actionModalTitle }}</h3>
+        <p class="py-4">{{ actionModalMessage }}</p>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="cancelAction">Cancel</button>
+          <button class="btn" :class="actionModalButtonClass" :disabled="actionLoading" @click="executeAction">
+            <span v-if="actionLoading" class="loading loading-spinner loading-xs"></span>
+            {{ actionModalConfirmText }}
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button @click="cancelAction">close</button>
+      </form>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { WantedPost } from '~/composables/useWantedPosts';
+
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useSeoMeta({
+    title: 'Wanted Post Moderation - Admin - The Mini Exchange',
+    robots: 'noindex, nofollow',
+  });
+
+  const supabase = useSupabase();
+  const toast = useToast();
+  const { handleError } = useErrorHandler();
+  const { toggleSort, getSortIcon, isSortedBy, sortFn } = useTableSort('created_at', 'desc');
+
+  // State
+  const posts = ref<WantedPost[]>([]);
+  const loading = ref(true);
+  const selectedStatus = ref('all');
+  const searchQuery = ref('');
+
+  // Action modal state
+  const actionModalRef = ref<HTMLDialogElement | null>(null);
+  const pendingAction = ref<{ id: string; type: 'approve' | 'reject' | 'delete' } | null>(null);
+  const actionLoading = ref(false);
+
+  /**
+   * Computed: modal title based on pending action.
+   */
+  const actionModalTitle = computed(() => {
+    switch (pendingAction.value?.type) {
+      case 'approve':
+        return 'Approve Wanted Post';
+      case 'reject':
+        return 'Reject Wanted Post';
+      case 'delete':
+        return 'Delete Wanted Post';
+      default:
+        return 'Confirm Action';
+    }
+  });
+
+  const actionModalMessage = computed(() => {
+    switch (pendingAction.value?.type) {
+      case 'approve':
+        return 'This will set the post to active with an approved moderation status. It will be visible to all users.';
+      case 'reject':
+        return 'This will remove the post and mark it as rejected. The user will no longer see it as active.';
+      case 'delete':
+        return 'Are you sure you want to permanently delete this wanted post? This action cannot be undone.';
+      default:
+        return 'Are you sure?';
+    }
+  });
+
+  const actionModalConfirmText = computed(() => {
+    switch (pendingAction.value?.type) {
+      case 'approve':
+        return 'Approve';
+      case 'reject':
+        return 'Reject';
+      case 'delete':
+        return 'Delete';
+      default:
+        return 'Confirm';
+    }
+  });
+
+  const actionModalButtonClass = computed(() => {
+    switch (pendingAction.value?.type) {
+      case 'approve':
+        return 'btn-success';
+      case 'reject':
+        return 'btn-warning';
+      case 'delete':
+        return 'btn-error';
+      default:
+        return 'btn-primary';
+    }
+  });
+
+  /**
+   * Filter posts by local search query.
+   */
+  const filteredPosts = computed(() => {
+    let filtered = posts.value;
+
+    if (searchQuery.value) {
+      const query = searchQuery.value.toLowerCase();
+      filtered = filtered.filter(
+        (p) =>
+          p.title.toLowerCase().includes(query) ||
+          p.description.toLowerCase().includes(query) ||
+          p.profiles?.display_name?.toLowerCase().includes(query) ||
+          p.profiles?.email?.toLowerCase().includes(query)
+      );
+    }
+
+    return [...filtered].sort(sortFn);
+  });
+
+  /**
+   * Fetch all wanted posts for admin moderation.
+   */
+  const loadPosts = async () => {
+    loading.value = true;
+
+    try {
+      let query = supabase
+        .from('wanted_posts')
+        .select('*, profiles!wanted_posts_user_id_fkey(id, display_name, email, avatar_url)')
+        .order('created_at', { ascending: false });
+
+      if (selectedStatus.value && selectedStatus.value !== 'all') {
+        // For "flagged" filter, match moderation_status instead of status
+        if (selectedStatus.value === 'flagged') {
+          query = query.eq('moderation_status', 'flagged');
+        } else {
+          query = query.eq('status', selectedStatus.value);
+        }
+      }
+
+      const { data, error } = await query;
+
+      if (error) throw error;
+
+      posts.value = (data as unknown as WantedPost[]) || [];
+    } catch (error) {
+      handleError(error, { toastTitle: 'Failed to load wanted posts' });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /**
+   * Update a post's status and moderation status.
+   */
+  const adminUpdateStatus = async (id: string, status: string, moderationStatus: string) => {
+    const { error } = await supabase
+      .from('wanted_posts')
+      .update({ status, moderation_status: moderationStatus })
+      .eq('id', id);
+
+    if (error) throw error;
+  };
+
+  /**
+   * Delete a wanted post permanently.
+   */
+  const adminDeletePost = async (id: string) => {
+    const { error } = await supabase.from('wanted_posts').delete().eq('id', id);
+
+    if (error) throw error;
+  };
+
+  /**
+   * Open the confirmation modal for a given action.
+   */
+  const confirmAction = (id: string, type: 'approve' | 'reject' | 'delete') => {
+    pendingAction.value = { id, type };
+    actionModalRef.value?.showModal();
+  };
+
+  /**
+   * Cancel and close the action modal.
+   */
+  const cancelAction = () => {
+    actionModalRef.value?.close();
+    pendingAction.value = null;
+  };
+
+  /**
+   * Execute the pending admin action.
+   */
+  const executeAction = async () => {
+    if (!pendingAction.value) return;
+
+    const { id, type } = pendingAction.value;
+    actionLoading.value = true;
+
+    try {
+      switch (type) {
+        case 'approve':
+          await adminUpdateStatus(id, 'active', 'approved');
+          toast.add({
+            title: 'Post Approved',
+            description: 'The wanted post is now active and visible.',
+            color: 'success',
+          });
+          break;
+
+        case 'reject':
+          await adminUpdateStatus(id, 'removed', 'rejected');
+          toast.add({
+            title: 'Post Rejected',
+            description: 'The wanted post has been removed.',
+            color: 'warning',
+          });
+          break;
+
+        case 'delete':
+          await adminDeletePost(id);
+          toast.add({
+            title: 'Post Deleted',
+            description: 'The wanted post has been permanently deleted.',
+            color: 'success',
+          });
+          break;
+      }
+
+      actionModalRef.value?.close();
+      pendingAction.value = null;
+      await loadPosts();
+    } catch (error) {
+      handleError(error, { toastTitle: `Failed to ${type} wanted post` });
+    } finally {
+      actionLoading.value = false;
+    }
+  };
+
+  /**
+   * Format status for display.
+   */
+  const formatStatus = (status: string): string => {
+    const labels: Record<string, string> = {
+      active: 'Active',
+      fulfilled: 'Fulfilled',
+      expired: 'Expired',
+      removed: 'Removed',
+      cancelled: 'Cancelled',
+    };
+    return labels[status] || status;
+  };
+
+  /**
+   * Format moderation status for display.
+   */
+  const formatModerationStatus = (status: string): string => {
+    const labels: Record<string, string> = {
+      approved: 'Approved',
+      pending: 'Pending',
+      flagged: 'Flagged',
+      rejected: 'Rejected',
+    };
+    return labels[status] || status;
+  };
+
+  /**
+   * Get badge class for post status.
+   */
+  const getStatusBadgeClass = (status: string): string => {
+    const classes: Record<string, string> = {
+      active: 'badge-success',
+      fulfilled: 'badge-info',
+      expired: 'badge-error',
+      removed: 'badge-ghost',
+      cancelled: 'badge-ghost',
+    };
+    return classes[status] || 'badge-ghost';
+  };
+
+  /**
+   * Get badge class for moderation status.
+   */
+  const getModerationBadgeClass = (status: string): string => {
+    const classes: Record<string, string> = {
+      approved: 'badge-success',
+      pending: 'badge-warning',
+      flagged: 'badge-error',
+      rejected: 'badge-ghost',
+    };
+    return classes[status] || 'badge-ghost';
+  };
+
+  /**
+   * Format a date string to locale date.
+   */
+  const formatDate = (dateString: string): string => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  // Watch filter changes
+  watch(selectedStatus, () => {
+    loadPosts();
+  });
+
+  onMounted(() => {
+    loadPosts();
+  });
+</script>

--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -19,6 +19,9 @@
   // Get user info from Supabase auth
   const { userProfile, signOut } = useAuth();
 
+  // Marketplace admin is only surfaced when the Exchange section is enabled
+  const exchangeEnabled = useRuntimeConfig().public.exchangeEnabled;
+
   // Fetch pending count — uses useAdminFetch to inject auth header and skip SSR
   const { data: totalPendingCount } = await useAdminFetch<{ count: number }>('/api/admin/queue/count');
 
@@ -160,6 +163,33 @@
               <NuxtLink to="/admin/users" class="btn btn-warning">
                 <i class="fad fa-arrow-right mr-2"></i>
                 Manage Users
+              </NuxtLink>
+            </div>
+          </div>
+        </div>
+
+        <!-- The Mini Exchange Card -->
+        <div
+          v-if="exchangeEnabled"
+          class="card bg-base-100 shadow-md border border-base-300 hover:shadow-2xl transition-shadow"
+        >
+          <div class="card-body">
+            <div class="flex items-center gap-3 mb-4">
+              <div class="w-12 h-12 bg-accent/10 rounded-lg flex items-center justify-center">
+                <i class="fad fa-store text-2xl text-accent"></i>
+              </div>
+              <h2 class="text-xl font-bold">The Mini Exchange</h2>
+            </div>
+
+            <p class="opacity-70 mb-6">
+              Marketplace admin — listings, wanted posts, finds, message moderation, promotions, newsletter, and the
+              site announcement banner.
+            </p>
+
+            <div class="card-actions justify-end">
+              <NuxtLink to="/admin/exchange" class="btn btn-accent">
+                <i class="fad fa-arrow-right mr-2"></i>
+                Open Exchange
               </NuxtLink>
             </div>
           </div>


### PR DESCRIPTION
## Section 8 of 10 — TheMiniExchange consolidation

Completes the `/admin/exchange/*` moderation surface (flag-gated behind \`NUXT_PUBLIC_EXCHANGE_ENABLED\`, invisible in prod until cutover).

### Pages added
- \`admin/exchange/finds.vue\` — external-find submission moderation (approve/reject/edit)
- \`admin/exchange/promotions.vue\` — paid listing-promotion management
- \`admin/exchange/messages.vue\` — message-report queue + warn/ban moderation
- \`admin/exchange/moderation.vue\` — unified listing + wanted-post moderation
- \`admin/exchange/newsletter.vue\` — newsletter preview/test/send admin (proxies land later)
- \`admin/exchange/announcements.vue\` — site-announcement management
- \`admin/exchange/wanted.vue\` — wanted-post admin
- \`admin/index.vue\` — flag-gated Exchange card on the admin dashboard

8 files, ~4.3k lines. English-only per the CMDIY admin convention (no i18n blocks on `/admin/exchange/*`).

### Notes for review
- Admin pages display `profiles.email` **by design** — moderators need it to identify/contact users; reads are RLS-gated to admins.
- All data loads client-side in `onMounted` (admin JWT from localStorage), so `toLocaleDateString` renders only post-mount — no SSR hydration mismatch.
- External `<a target="_blank">` links carry `rel="noopener noreferrer"`; the newsletter preview iframe is `sandbox="allow-same-origin"` (no `allow-scripts`).
- Pre-empted the PR #645 `z-9999`→`z-[9999]` finding on the wanted dropdown.

Some admin actions call `/api/admin/exchange/{social-retry,newsletter/*}` which 404 until the deferred social/newsletter backend lands (tracked in the handoff doc).