### PR TITLE
feat(exchange): onboarding gate + remaining pages + seller signals (9/10)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -81,6 +81,7 @@
     <div class="app-content">
       <MainNav></MainNav>
       <Toaster />
+      <OnboardingNudge />
       <NuxtLoadingIndicator />
       <main id="main-content" class="bg-base-100">
         <NuxtPage />

--- a/app/components/OnboardingNudge.vue
+++ b/app/components/OnboardingNudge.vue
@@ -1,0 +1,53 @@
+<template>
+  <!-- Soft onboarding nudge. Site-wide, takes the chat-overlay slot for logged-in
+       users who haven't completed onboarding. Non-blocking; persists until done.
+       Hidden on the onboarding page itself. The hard /exchange gate lives in
+       middleware/exchange-onboarding.global.ts. -->
+  <div v-if="show" class="fixed bottom-6 right-6 z-50 max-w-sm w-full px-4">
+    <div class="bg-base-100 rounded-2xl shadow-xl border border-base-300 p-5">
+      <div class="flex items-start gap-3">
+        <div class="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+          <i class="fas fa-user-check text-primary"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="font-bold text-base">{{ t('title') }}</h3>
+          <p class="text-sm text-base-content/70 mt-1">{{ t('body') }}</p>
+          <button type="button" class="btn btn-primary btn-sm mt-3 w-full" @click="goToOnboarding">
+            <i class="fas fa-arrow-right"></i>
+            {{ t('cta') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+  const { needsOnboarding } = useOnboardingGate();
+  const route = useRoute();
+  const { capture } = usePostHog();
+
+  // Never nudge on the onboarding page (they're already there) or the auth callback.
+  const show = computed(() => needsOnboarding.value && route.path !== '/onboarding' && route.path !== '/auth/callback');
+
+  const goToOnboarding = () => {
+    capture('onboarding_nudge_clicked', { from: route.path });
+    navigateTo(`/onboarding?redirect=${encodeURIComponent(route.fullPath)}`);
+  };
+</script>
+
+<i18n lang="json">
+{
+  "en": { "title": "Finish setting up your account", "body": "Complete your profile to unlock The Mini Exchange — buy, sell, and message other Classic Mini owners.", "cta": "Complete your profile" },
+  "es": { "title": "Termina de configurar tu cuenta", "body": "Completa tu perfil para desbloquear The Mini Exchange: compra, vende y contacta con otros propietarios de Classic Mini.", "cta": "Completar mi perfil" },
+  "fr": { "title": "Terminez la configuration de votre compte", "body": "Complétez votre profil pour débloquer The Mini Exchange : achetez, vendez et échangez avec d'autres propriétaires de Classic Mini.", "cta": "Compléter mon profil" },
+  "de": { "title": "Schließe die Einrichtung deines Kontos ab", "body": "Vervollständige dein Profil, um The Mini Exchange freizuschalten — kaufen, verkaufen und mit anderen Classic-Mini-Besitzern schreiben.", "cta": "Profil vervollständigen" },
+  "it": { "title": "Completa la configurazione del tuo account", "body": "Completa il tuo profilo per sbloccare The Mini Exchange: compra, vendi e scrivi ad altri proprietari di Classic Mini.", "cta": "Completa il profilo" },
+  "pt": { "title": "Conclua a configuração da sua conta", "body": "Complete o seu perfil para desbloquear o The Mini Exchange: compre, venda e converse com outros donos de Classic Mini.", "cta": "Completar meu perfil" },
+  "ru": { "title": "Завершите настройку аккаунта", "body": "Заполните профиль, чтобы открыть The Mini Exchange — покупайте, продавайте и общайтесь с другими владельцами Classic Mini.", "cta": "Заполнить профиль" },
+  "ja": { "title": "アカウント設定を完了しましょう", "body": "プロフィールを完成させて The Mini Exchange を利用しましょう — 他の Classic Mini オーナーと売買・メッセージができます。", "cta": "プロフィールを完成させる" },
+  "zh": { "title": "完成账户设置", "body": "完善个人资料即可解锁 The Mini Exchange — 与其他 Classic Mini 车主买卖和私信。", "cta": "完善个人资料" },
+  "ko": { "title": "계정 설정을 완료하세요", "body": "프로필을 완성하면 The Mini Exchange를 이용할 수 있습니다 — 다른 Classic Mini 오너와 사고팔고 메시지를 주고받으세요.", "cta": "프로필 완성하기" }
+}
+</i18n>

--- a/app/components/OnboardingNudge.vue
+++ b/app/components/OnboardingNudge.vue
@@ -3,23 +3,29 @@
        users who haven't completed onboarding. Non-blocking; persists until done.
        Hidden on the onboarding page itself. The hard /exchange gate lives in
        middleware/exchange-onboarding.global.ts. -->
-  <div v-if="show" class="fixed bottom-6 right-6 z-50 max-w-sm w-full px-4">
+  <aside
+    v-if="show"
+    role="complementary"
+    aria-live="polite"
+    :aria-label="t('title')"
+    class="fixed bottom-6 right-6 z-50 max-w-sm w-full px-4"
+  >
     <div class="bg-base-100 rounded-2xl shadow-xl border border-base-300 p-5">
       <div class="flex items-start gap-3">
         <div class="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-          <i class="fas fa-user-check text-primary"></i>
+          <i class="fas fa-user-check text-primary" aria-hidden="true"></i>
         </div>
         <div class="flex-1 min-w-0">
           <h3 class="font-bold text-base">{{ t('title') }}</h3>
           <p class="text-sm text-base-content/70 mt-1">{{ t('body') }}</p>
           <button type="button" class="btn btn-primary btn-sm mt-3 w-full" @click="goToOnboarding">
-            <i class="fas fa-arrow-right"></i>
+            <i class="fas fa-arrow-right" aria-hidden="true"></i>
             {{ t('cta') }}
           </button>
         </div>
       </div>
     </div>
-  </div>
+  </aside>
 </template>
 
 <script setup lang="ts">

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -9,6 +9,10 @@ interface UserProfile {
   total_submissions: number;
   approved_submissions: number;
   rejected_submissions: number;
+  // Profile-onboarding flag (a real `profiles` column). Drives the exchange
+  // onboarding gate + the toolbox nudge (see useOnboardingGate). Distinct from
+  // `onboarding_completed_app`, which is the mobile app's flag.
+  onboarding_completed: boolean;
   // Sustaining Member status. NOT a `profiles` column — it is computed by
   // user_has_subscription() and folded in here so the badge + benefits area
   // can gate on shared auth state (keystone §9). See fetchMembership below.
@@ -65,7 +69,7 @@ export const useAuth = () => {
       const { data, error } = await supabase
         .from('profiles')
         .select(
-          'is_admin, display_name, email, avatar_url, trust_level, total_submissions, approved_submissions, rejected_submissions'
+          'is_admin, display_name, email, avatar_url, trust_level, total_submissions, approved_submissions, rejected_submissions, onboarding_completed'
         )
         .eq('id', userId)
         .single();

--- a/app/composables/useOnboardingGate.ts
+++ b/app/composables/useOnboardingGate.ts
@@ -1,0 +1,31 @@
+/**
+ * Single source of truth for "does this user still need to complete onboarding?"
+ *
+ * Drives three consumers:
+ *  - OnboardingNudge.vue (renders the soft toolbox nudge when true)
+ *  - pages/index.vue     (hides the homepage chat overlay when true)
+ *  - middleware/exchange-onboarding.global.ts (the hard /exchange gate — though
+ *    the middleware does its own async profile fetch to avoid the load race)
+ *
+ * The whole onboarding concept is flag-gated: when `exchangeEnabled` is off
+ * (pre-cutover) this is always false, so nothing about onboarding is visible.
+ *
+ * `needsOnboarding` is intentionally conservative: it is true ONLY once we have
+ * a loaded profile whose `onboarding_completed` is explicitly false. While the
+ * profile is still loading (null) it stays false, so there's no premature nudge
+ * flash before auth settles.
+ */
+export function useOnboardingGate() {
+  const { exchangeEnabled } = useRuntimeConfig().public;
+  const { isAuthenticated, userProfile } = useAuth();
+
+  const needsOnboarding = computed(
+    () =>
+      !!exchangeEnabled &&
+      isAuthenticated.value &&
+      !!userProfile.value &&
+      userProfile.value.onboarding_completed === false
+  );
+
+  return { needsOnboarding };
+}

--- a/app/composables/useProfile.ts
+++ b/app/composables/useProfile.ts
@@ -129,6 +129,48 @@ export const useProfile = () => {
   };
 
   /**
+   * Complete profile onboarding. Upserts the profile (handles both the
+   * trigger-created row and the edge case where no row exists yet) and flips
+   * `onboarding_completed` true. Display name + location are required; the rest
+   * are optional. Drives the exchange onboarding gate (see useOnboardingGate).
+   */
+  const completeOnboarding = async (profileData: {
+    display_name: string;
+    location: string;
+    bio?: string;
+    avatar_url?: string;
+    preferred_currency?: string;
+  }) => {
+    if (!user.value) throw new Error('Not authenticated');
+    if (!profileData.display_name?.trim()) throw new Error('Display name is required');
+    if (!profileData.location?.trim()) throw new Error('Location is required');
+
+    const { data, error } = await supabase
+      .from('profiles')
+      .upsert(
+        {
+          id: user.value.id,
+          email: user.value.email!,
+          ...profileData,
+          onboarding_completed: true,
+        },
+        { onConflict: 'id' }
+      )
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    capture('onboarding_completed', {
+      has_avatar: !!profileData.avatar_url,
+      has_bio: !!profileData.bio,
+      preferred_currency: profileData.preferred_currency,
+    });
+
+    return data;
+  };
+
+  /**
    * Get a public profile by UUID.
    * Returns { profile } on success, { private: true } if user exists but is private,
    * or null if user doesn't exist.
@@ -169,6 +211,7 @@ export const useProfile = () => {
     fetchProfile,
     updateProfile,
     uploadAvatar,
+    completeOnboarding,
     getPublicProfile,
     getPublicProfileVehicles,
   };

--- a/app/middleware/exchange-flag.global.ts
+++ b/app/middleware/exchange-flag.global.ts
@@ -8,6 +8,7 @@
 // the /exchange section, the dashboard/admin exchange tabs, and the feeds.
 const GUARDED_PREFIXES = [
   '/exchange',
+  '/onboarding',
   '/dashboard/listings',
   '/dashboard/wanted',
   '/dashboard/notifications',

--- a/app/middleware/exchange-flag.global.ts
+++ b/app/middleware/exchange-flag.global.ts
@@ -4,21 +4,12 @@
 // already merged to main. Flipping the flag (env-only, no rebuild) lights them up.
 //
 // Runs on server AND client (unlike admin.global.ts) so SSR returns a real 404,
-// not a flash of content. Keep this list in sync as marketplace surfaces land:
-// the /exchange section, the dashboard/admin exchange tabs, and the feeds.
-const GUARDED_PREFIXES = [
-  '/exchange',
-  '/onboarding',
-  '/dashboard/listings',
-  '/dashboard/wanted',
-  '/dashboard/notifications',
-  '/dashboard/saved-searches',
-  '/admin/exchange',
-];
+// not a flash of content. The guarded set lives in ~/utils/exchangeRoutes so the
+// flag-gate and the onboarding-gate share one definition of "the Exchange".
+import { EXCHANGE_FLAG_PREFIXES, pathInPrefixes } from '~/utils/exchangeRoutes';
 
 export default defineNuxtRouteMiddleware((to) => {
-  const isGuarded = GUARDED_PREFIXES.some((prefix) => to.path === prefix || to.path.startsWith(`${prefix}/`));
-  if (!isGuarded) {
+  if (!pathInPrefixes(to.path, EXCHANGE_FLAG_PREFIXES)) {
     return;
   }
 

--- a/app/middleware/exchange-onboarding.global.ts
+++ b/app/middleware/exchange-onboarding.global.ts
@@ -11,6 +11,8 @@
 // state. We actively wait for auth + fetch the profile before deciding, so a
 // not-onboarded user can't slip in during the auth-load window. Verified state
 // is cached per user id to avoid refetching on every in-section navigation.
+import { EXCHANGE_PREFIXES, pathInPrefixes } from '~/utils/exchangeRoutes';
+
 let verifiedUserId: string | null = null;
 
 export default defineNuxtRouteMiddleware(async (to) => {
@@ -20,9 +22,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const { exchangeEnabled } = useRuntimeConfig().public;
   if (!exchangeEnabled) return;
 
-  // Only guard the exchange section.
-  const inExchange = to.path === '/exchange' || to.path.startsWith('/exchange/');
-  if (!inExchange) return;
+  // Guard the whole Exchange — the /exchange section AND the user's marketplace
+  // management tabs under /dashboard (shared prefix list with the flag-gate).
+  if (!pathInPrefixes(to.path, EXCHANGE_PREFIXES)) return;
 
   // Never trap the onboarding page or the auth callback.
   if (to.path === '/onboarding' || to.path === '/auth/callback') return;

--- a/app/middleware/exchange-onboarding.global.ts
+++ b/app/middleware/exchange-onboarding.global.ts
@@ -1,0 +1,52 @@
+// Hard onboarding gate for the Mini Exchange section.
+//
+// When the exchange is live (NUXT_PUBLIC_EXCHANGE_ENABLED on), a logged-in user
+// whose profile isn't complete cannot enter any /exchange route — they're
+// redirected to the full /onboarding page (non-skippable), with their intended
+// destination preserved as ?redirect=. Anonymous visitors pass through so public
+// listing pages stay browsable + indexable. The soft, skippable toolbox nudge
+// lives in OnboardingNudge.vue (see useOnboardingGate).
+//
+// Client-only: the Supabase session is in localStorage, so SSR can't know auth
+// state. We actively wait for auth + fetch the profile before deciding, so a
+// not-onboarded user can't slip in during the auth-load window. Verified state
+// is cached per user id to avoid refetching on every in-section navigation.
+let verifiedUserId: string | null = null;
+
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (import.meta.server) return;
+
+  // The whole onboarding concept is flag-gated.
+  const { exchangeEnabled } = useRuntimeConfig().public;
+  if (!exchangeEnabled) return;
+
+  // Only guard the exchange section.
+  const inExchange = to.path === '/exchange' || to.path.startsWith('/exchange/');
+  if (!inExchange) return;
+
+  // Never trap the onboarding page or the auth callback.
+  if (to.path === '/onboarding' || to.path === '/auth/callback') return;
+
+  const { user, userProfile, waitForAuth, fetchUserProfile } = useAuth();
+  await waitForAuth(1500);
+
+  // Anonymous browsing of the exchange stays public.
+  if (!user.value) return;
+
+  // Already verified this user this session — skip.
+  if (verifiedUserId === user.value.id) return;
+
+  // Race with the deferred onAuthStateChange fetch: pull the profile now.
+  if (!userProfile.value) {
+    await fetchUserProfile(user.value.id);
+  }
+
+  if (userProfile.value?.onboarding_completed) {
+    verifiedUserId = user.value.id;
+    return;
+  }
+
+  // Incomplete (or profile still unknown) → send to the full onboarding flow,
+  // preserving where they were headed.
+  return navigateTo(`/onboarding?redirect=${encodeURIComponent(to.fullPath)}`);
+});

--- a/app/middleware/exchange-onboarding.global.ts
+++ b/app/middleware/exchange-onboarding.global.ts
@@ -30,7 +30,13 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (to.path === '/onboarding' || to.path === '/auth/callback') return;
 
   const { user, userProfile, waitForAuth, fetchUserProfile } = useAuth();
-  await waitForAuth(1500);
+  // Wait for auth to actually settle before deciding. If the bounded wait times
+  // out (e.g. a slow session/token refresh), extend it once — otherwise a
+  // slow-loading logged-in user would be read as null here, mistaken for an
+  // anonymous visitor, and allowed to bypass onboarding.
+  if (!(await waitForAuth(1500))) {
+    await waitForAuth();
+  }
 
   // Anonymous browsing of the exchange stays public.
   if (!user.value) return;

--- a/app/pages/exchange/feeds/index.vue
+++ b/app/pages/exchange/feeds/index.vue
@@ -1,0 +1,345 @@
+<template>
+  <div class="container py-12">
+    <!-- Header -->
+    <div class="max-w-4xl mx-auto mb-16 text-center">
+      <h1 class="text-5xl font-bold mb-6">{{ t('hero.title') }}</h1>
+      <p class="text-xl text-base-content/70 leading-relaxed">{{ t('hero.subtitle') }}</p>
+    </div>
+
+    <!-- Main Content -->
+    <div class="max-w-4xl mx-auto space-y-16">
+      <!-- What is RSS? -->
+      <section>
+        <div class="flex items-center gap-3 mb-6">
+          <i class="fas fa-rss text-2xl text-primary"></i>
+          <h2 class="text-3xl font-bold">{{ t('whatIsRss.title') }}</h2>
+        </div>
+        <div class="prose prose-lg max-w-none">
+          <p>{{ t('whatIsRss.body') }}</p>
+        </div>
+      </section>
+
+      <!-- Available Feeds -->
+      <section>
+        <div class="flex items-center gap-3 mb-8">
+          <i class="fas fa-list text-2xl text-primary"></i>
+          <h2 class="text-3xl font-bold">{{ t('available.title') }}</h2>
+        </div>
+
+        <div class="space-y-4">
+          <!-- Everything Feed -->
+          <div class="card bg-base-100 shadow-sm">
+            <div class="card-body">
+              <div class="flex items-start gap-4">
+                <div class="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-1">
+                  <i class="fas fa-globe text-primary"></i>
+                </div>
+                <div class="flex-1 min-w-0">
+                  <h3 class="card-title text-lg">{{ t('everything.title') }}</h3>
+                  <p class="text-base-content/70 text-sm mt-1">{{ t('everything.description') }}</p>
+                  <div class="flex flex-wrap gap-2 mt-3">
+                    <a href="/exchange/feed.xml" class="btn btn-sm btn-primary gap-1.5">
+                      <i class="fas fa-rss"></i>
+                      RSS
+                    </a>
+                    <a href="/exchange/atom.xml" class="btn btn-sm btn-outline gap-1.5">
+                      <i class="fas fa-rss"></i>
+                      Atom
+                    </a>
+                    <a href="/exchange/feed.json" class="btn btn-sm btn-outline gap-1.5">
+                      <i class="fas fa-code"></i>
+                      JSON
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Divider: Marketplace Listings -->
+          <div class="divider text-sm text-base-content/50">{{ t('dividers.marketplace') }}</div>
+
+          <!-- Feed cards -->
+          <template v-for="(feed, index) in feedCards" :key="feed.basePath">
+            <!-- Community divider before first community feed -->
+            <div
+              v-if="feed.section === 'community' && index === firstCommunityIndex"
+              class="divider text-sm text-base-content/50"
+            >
+              {{ t('dividers.community') }}
+            </div>
+
+            <div class="card bg-base-100 shadow-sm">
+              <div class="card-body">
+                <div class="flex items-start gap-4">
+                  <div class="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-1">
+                    <i :class="[feed.icon, 'text-primary']"></i>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <h3 class="card-title text-lg">{{ feed.title }}</h3>
+                    <p class="text-base-content/70 text-sm mt-1">{{ feed.description }}</p>
+                    <div class="flex flex-wrap gap-2 mt-3">
+                      <a :href="`${feed.basePath}.xml`" class="btn btn-sm btn-primary gap-1.5">
+                        <i class="fas fa-rss"></i>
+                        RSS
+                      </a>
+                      <a :href="`${feed.basePath}.atom`" class="btn btn-sm btn-outline gap-1.5">
+                        <i class="fas fa-rss"></i>
+                        Atom
+                      </a>
+                      <a :href="`${feed.basePath}.json`" class="btn btn-sm btn-outline gap-1.5">
+                        <i class="fas fa-code"></i>
+                        JSON
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+      </section>
+
+      <!-- CTA -->
+      <section class="bg-primary/5 rounded-box p-12 text-center">
+        <i class="fas fa-rss text-4xl mb-4 text-primary"></i>
+        <h2 class="text-2xl font-bold mb-3">{{ t('cta.title') }}</h2>
+        <p class="text-base-content/70 max-w-lg mx-auto mb-6">{{ t('cta.body') }}</p>
+        <NuxtLink to="/exchange/listings" class="btn btn-primary btn-lg">{{ t('cta.button') }}</NuxtLink>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+  const config = useRuntimeConfig();
+
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.title'),
+    ogDescription: () => t('seo.ogDescription'),
+    ogType: 'website',
+    ogUrl: `${config.public.siteUrl}/exchange/feeds`,
+    ogImage: `${config.public.siteUrl}/og-image.jpg`,
+  });
+
+  const feedCards = computed(() => [
+    {
+      icon: 'fas fa-tag',
+      title: t('cards.listings.title'),
+      description: t('cards.listings.description'),
+      basePath: '/exchange/feed/listings',
+    },
+    {
+      icon: 'fas fa-car',
+      title: t('cards.vehicles.title'),
+      description: t('cards.vehicles.description'),
+      basePath: '/exchange/feed/vehicles',
+    },
+    {
+      icon: 'fas fa-gear',
+      title: t('cards.engines.title'),
+      description: t('cards.engines.description'),
+      basePath: '/exchange/feed/engines',
+    },
+    {
+      icon: 'fas fa-screwdriver-wrench',
+      title: t('cards.parts.title'),
+      description: t('cards.parts.description'),
+      basePath: '/exchange/feed/parts',
+    },
+    {
+      icon: 'fas fa-globe',
+      title: t('cards.finds.title'),
+      description: t('cards.finds.description'),
+      basePath: '/exchange/feed/finds',
+      section: 'community',
+    },
+    {
+      icon: 'fas fa-bullhorn',
+      title: t('cards.wanted.title'),
+      description: t('cards.wanted.description'),
+      basePath: '/exchange/feed/wanted',
+      section: 'community',
+    },
+  ]);
+
+  const firstCommunityIndex = computed(() => feedCards.value.findIndex((f) => f.section === 'community'));
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "hero": { "title": "RSS Feeds", "subtitle": "Subscribe to Classic Mini marketplace listings, Mini Finds, and Wanted posts in your favorite feed reader" },
+    "whatIsRss": { "title": "What is RSS?", "body": "RSS (Really Simple Syndication) lets you follow updates from The Mini Exchange without having to check the site manually. Add any of the feeds below to an RSS reader like Feedly, NetNewsWire, Inoreader, or your reader of choice, and new listings will appear automatically." },
+    "available": { "title": "Available Feeds" },
+    "everything": { "title": "Everything", "description": "All marketplace listings, Mini Finds, and Wanted posts combined in one feed." },
+    "dividers": { "marketplace": "Marketplace Listings", "community": "Community" },
+    "cards": {
+      "listings": { "title": "All Marketplace Listings", "description": "Every active listing from the marketplace — vehicles, engines, and parts." },
+      "vehicles": { "title": "Vehicles", "description": "Classic Mini vehicles for sale — complete cars from projects to concours." },
+      "engines": { "title": "Engines", "description": "Complete A-Series engines and engine assemblies for sale." },
+      "parts": { "title": "Parts", "description": "Classic Mini parts and accessories — body, interior, suspension, electrical, and more." },
+      "finds": { "title": "Mini Finds", "description": "Curated Classic Mini listings spotted across the web — Bring a Trailer, Cars & Bids, eBay, and more." },
+      "wanted": { "title": "Wanted Posts", "description": "Classic Mini vehicles, engines, and parts that community members are looking for." }
+    },
+    "cta": { "title": "Never Miss a Listing", "body": "Copy any feed URL above and paste it into your preferred RSS reader. New listings will appear automatically as they're published.", "button": "Browse Listings" },
+    "seo": { "title": "RSS Feeds | The Mini Exchange", "description": "Subscribe to Classic Mini marketplace listings, Mini Finds, and Wanted posts via RSS feeds. Follow vehicles, engines, parts, and community finds.", "ogDescription": "Subscribe to Classic Mini listings via RSS — vehicles, engines, parts, finds, and wanted posts." }
+  },
+  "es": {
+    "hero": { "title": "Canales RSS", "subtitle": "Suscríbete a los anuncios del mercado Classic Mini, los Mini Finds y los anuncios de búsqueda en tu lector de feeds favorito" },
+    "whatIsRss": { "title": "¿Qué es RSS?", "body": "RSS (Really Simple Syndication) te permite seguir las novedades de The Mini Exchange sin tener que consultar el sitio manualmente. Añade cualquiera de los canales de abajo a un lector RSS como Feedly, NetNewsWire, Inoreader o el lector que prefieras, y los nuevos anuncios aparecerán automáticamente." },
+    "available": { "title": "Canales disponibles" },
+    "everything": { "title": "Todo", "description": "Todos los anuncios del mercado, los Mini Finds y los anuncios de búsqueda combinados en un solo canal." },
+    "dividers": { "marketplace": "Anuncios del mercado", "community": "Comunidad" },
+    "cards": {
+      "listings": { "title": "Todos los anuncios del mercado", "description": "Todos los anuncios activos del mercado: vehículos, motores y piezas." },
+      "vehicles": { "title": "Vehículos", "description": "Vehículos Classic Mini en venta: coches completos, desde proyectos hasta concurso." },
+      "engines": { "title": "Motores", "description": "Motores A-Series completos y conjuntos de motor en venta." },
+      "parts": { "title": "Piezas", "description": "Piezas y accesorios para Classic Mini: carrocería, interior, suspensión, sistema eléctrico y más." },
+      "finds": { "title": "Mini Finds", "description": "Anuncios de Classic Mini seleccionados de toda la web: Bring a Trailer, Cars & Bids, eBay y más." },
+      "wanted": { "title": "Anuncios de búsqueda", "description": "Vehículos, motores y piezas Classic Mini que buscan los miembros de la comunidad." }
+    },
+    "cta": { "title": "No te pierdas ningún anuncio", "body": "Copia cualquier URL de canal de arriba y pégala en tu lector RSS preferido. Los nuevos anuncios aparecerán automáticamente a medida que se publiquen.", "button": "Explorar anuncios" },
+    "seo": { "title": "Canales RSS | The Mini Exchange", "description": "Suscríbete a los anuncios del mercado Classic Mini, los Mini Finds y los anuncios de búsqueda mediante canales RSS. Sigue vehículos, motores, piezas y hallazgos de la comunidad.", "ogDescription": "Suscríbete a los anuncios Classic Mini por RSS: vehículos, motores, piezas, hallazgos y anuncios de búsqueda." }
+  },
+  "fr": {
+    "hero": { "title": "Flux RSS", "subtitle": "Abonnez-vous aux annonces de la place de marché Classic Mini, aux Mini Finds et aux annonces de recherche dans votre lecteur de flux préféré" },
+    "whatIsRss": { "title": "Qu'est-ce que le RSS ?", "body": "Le RSS (Really Simple Syndication) vous permet de suivre les nouveautés de The Mini Exchange sans avoir à consulter le site manuellement. Ajoutez n'importe lequel des flux ci-dessous à un lecteur RSS comme Feedly, NetNewsWire, Inoreader ou le lecteur de votre choix, et les nouvelles annonces apparaîtront automatiquement." },
+    "available": { "title": "Flux disponibles" },
+    "everything": { "title": "Tout", "description": "Toutes les annonces de la place de marché, les Mini Finds et les annonces de recherche réunis dans un seul flux." },
+    "dividers": { "marketplace": "Annonces de la place de marché", "community": "Communauté" },
+    "cards": {
+      "listings": { "title": "Toutes les annonces", "description": "Toutes les annonces actives de la place de marché : véhicules, moteurs et pièces." },
+      "vehicles": { "title": "Véhicules", "description": "Véhicules Classic Mini à vendre : voitures complètes, du projet au concours." },
+      "engines": { "title": "Moteurs", "description": "Moteurs A-Series complets et ensembles moteur à vendre." },
+      "parts": { "title": "Pièces", "description": "Pièces et accessoires Classic Mini : carrosserie, intérieur, suspension, électricité et plus encore." },
+      "finds": { "title": "Mini Finds", "description": "Annonces Classic Mini sélectionnées sur le web : Bring a Trailer, Cars & Bids, eBay et plus encore." },
+      "wanted": { "title": "Annonces de recherche", "description": "Véhicules, moteurs et pièces Classic Mini recherchés par les membres de la communauté." }
+    },
+    "cta": { "title": "Ne manquez aucune annonce", "body": "Copiez l'URL d'un flux ci-dessus et collez-la dans votre lecteur RSS préféré. Les nouvelles annonces apparaîtront automatiquement dès leur publication.", "button": "Parcourir les annonces" },
+    "seo": { "title": "Flux RSS | The Mini Exchange", "description": "Abonnez-vous aux annonces de la place de marché Classic Mini, aux Mini Finds et aux annonces de recherche via les flux RSS. Suivez véhicules, moteurs, pièces et trouvailles de la communauté.", "ogDescription": "Abonnez-vous aux annonces Classic Mini par RSS : véhicules, moteurs, pièces, trouvailles et annonces de recherche." }
+  },
+  "de": {
+    "hero": { "title": "RSS-Feeds", "subtitle": "Abonniere Classic-Mini-Marktinserate, Mini Finds und Gesuche in deinem bevorzugten Feed-Reader" },
+    "whatIsRss": { "title": "Was ist RSS?", "body": "Mit RSS (Really Simple Syndication) kannst du Neuigkeiten von The Mini Exchange verfolgen, ohne die Seite manuell aufzurufen. Füge einen der unten stehenden Feeds zu einem RSS-Reader wie Feedly, NetNewsWire, Inoreader oder deinem Reader deiner Wahl hinzu, und neue Inserate erscheinen automatisch." },
+    "available": { "title": "Verfügbare Feeds" },
+    "everything": { "title": "Alles", "description": "Alle Marktinserate, Mini Finds und Gesuche in einem einzigen Feed." },
+    "dividers": { "marketplace": "Marktinserate", "community": "Community" },
+    "cards": {
+      "listings": { "title": "Alle Marktinserate", "description": "Jedes aktive Inserat des Marktplatzes — Fahrzeuge, Motoren und Teile." },
+      "vehicles": { "title": "Fahrzeuge", "description": "Classic-Mini-Fahrzeuge zum Verkauf — komplette Autos vom Projekt bis zum Concours." },
+      "engines": { "title": "Motoren", "description": "Komplette A-Series-Motoren und Motorbaugruppen zum Verkauf." },
+      "parts": { "title": "Teile", "description": "Classic-Mini-Teile und Zubehör — Karosserie, Innenraum, Fahrwerk, Elektrik und mehr." },
+      "finds": { "title": "Mini Finds", "description": "Ausgewählte Classic-Mini-Inserate aus dem Web — Bring a Trailer, Cars & Bids, eBay und mehr." },
+      "wanted": { "title": "Gesuche", "description": "Classic-Mini-Fahrzeuge, -Motoren und -Teile, die Community-Mitglieder suchen." }
+    },
+    "cta": { "title": "Kein Inserat mehr verpassen", "body": "Kopiere eine beliebige Feed-URL von oben und füge sie in deinen bevorzugten RSS-Reader ein. Neue Inserate erscheinen automatisch, sobald sie veröffentlicht werden.", "button": "Inserate durchsuchen" },
+    "seo": { "title": "RSS-Feeds | The Mini Exchange", "description": "Abonniere Classic-Mini-Marktinserate, Mini Finds und Gesuche per RSS-Feed. Folge Fahrzeugen, Motoren, Teilen und Community-Funden.", "ogDescription": "Abonniere Classic-Mini-Inserate per RSS — Fahrzeuge, Motoren, Teile, Funde und Gesuche." }
+  },
+  "it": {
+    "hero": { "title": "Feed RSS", "subtitle": "Iscriviti agli annunci del mercato Classic Mini, ai Mini Finds e agli annunci di ricerca nel tuo lettore di feed preferito" },
+    "whatIsRss": { "title": "Cos'è l'RSS?", "body": "L'RSS (Really Simple Syndication) ti permette di seguire gli aggiornamenti di The Mini Exchange senza dover controllare il sito manualmente. Aggiungi uno qualsiasi dei feed qui sotto a un lettore RSS come Feedly, NetNewsWire, Inoreader o il lettore che preferisci, e i nuovi annunci appariranno automaticamente." },
+    "available": { "title": "Feed disponibili" },
+    "everything": { "title": "Tutto", "description": "Tutti gli annunci del mercato, i Mini Finds e gli annunci di ricerca riuniti in un unico feed." },
+    "dividers": { "marketplace": "Annunci del mercato", "community": "Comunità" },
+    "cards": {
+      "listings": { "title": "Tutti gli annunci", "description": "Ogni annuncio attivo del mercato: veicoli, motori e ricambi." },
+      "vehicles": { "title": "Veicoli", "description": "Veicoli Classic Mini in vendita: auto complete, dai progetti al concorso." },
+      "engines": { "title": "Motori", "description": "Motori A-Series completi e gruppi motore in vendita." },
+      "parts": { "title": "Ricambi", "description": "Ricambi e accessori Classic Mini: carrozzeria, interni, sospensioni, impianto elettrico e altro." },
+      "finds": { "title": "Mini Finds", "description": "Annunci Classic Mini selezionati dal web: Bring a Trailer, Cars & Bids, eBay e altro." },
+      "wanted": { "title": "Annunci di ricerca", "description": "Veicoli, motori e ricambi Classic Mini che i membri della comunità stanno cercando." }
+    },
+    "cta": { "title": "Non perderti nessun annuncio", "body": "Copia un qualsiasi URL di feed qui sopra e incollalo nel tuo lettore RSS preferito. I nuovi annunci appariranno automaticamente man mano che vengono pubblicati.", "button": "Esplora gli annunci" },
+    "seo": { "title": "Feed RSS | The Mini Exchange", "description": "Iscriviti agli annunci del mercato Classic Mini, ai Mini Finds e agli annunci di ricerca tramite feed RSS. Segui veicoli, motori, ricambi e ritrovamenti della comunità.", "ogDescription": "Iscriviti agli annunci Classic Mini via RSS: veicoli, motori, ricambi, ritrovamenti e annunci di ricerca." }
+  },
+  "pt": {
+    "hero": { "title": "Feeds RSS", "subtitle": "Inscreva-se nos anúncios do mercado Classic Mini, nos Mini Finds e nos anúncios de procura no seu leitor de feeds favorito" },
+    "whatIsRss": { "title": "O que é RSS?", "body": "O RSS (Really Simple Syndication) permite acompanhar as novidades do The Mini Exchange sem precisar verificar o site manualmente. Adicione qualquer um dos feeds abaixo a um leitor RSS como Feedly, NetNewsWire, Inoreader ou o leitor da sua preferência, e os novos anúncios aparecerão automaticamente." },
+    "available": { "title": "Feeds disponíveis" },
+    "everything": { "title": "Tudo", "description": "Todos os anúncios do mercado, os Mini Finds e os anúncios de procura combinados em um único feed." },
+    "dividers": { "marketplace": "Anúncios do mercado", "community": "Comunidade" },
+    "cards": {
+      "listings": { "title": "Todos os anúncios", "description": "Todos os anúncios ativos do mercado: veículos, motores e peças." },
+      "vehicles": { "title": "Veículos", "description": "Veículos Classic Mini à venda: carros completos, de projetos a concurso." },
+      "engines": { "title": "Motores", "description": "Motores A-Series completos e conjuntos de motor à venda." },
+      "parts": { "title": "Peças", "description": "Peças e acessórios Classic Mini: carroceria, interior, suspensão, elétrica e mais." },
+      "finds": { "title": "Mini Finds", "description": "Anúncios Classic Mini selecionados pela web: Bring a Trailer, Cars & Bids, eBay e mais." },
+      "wanted": { "title": "Anúncios de procura", "description": "Veículos, motores e peças Classic Mini que os membros da comunidade estão procurando." }
+    },
+    "cta": { "title": "Nunca perca um anúncio", "body": "Copie qualquer URL de feed acima e cole no seu leitor RSS preferido. Os novos anúncios aparecerão automaticamente assim que forem publicados.", "button": "Explorar anúncios" },
+    "seo": { "title": "Feeds RSS | The Mini Exchange", "description": "Inscreva-se nos anúncios do mercado Classic Mini, nos Mini Finds e nos anúncios de procura via feeds RSS. Acompanhe veículos, motores, peças e achados da comunidade.", "ogDescription": "Inscreva-se nos anúncios Classic Mini por RSS: veículos, motores, peças, achados e anúncios de procura." }
+  },
+  "ru": {
+    "hero": { "title": "RSS-ленты", "subtitle": "Подпишитесь на объявления маркетплейса Classic Mini, находки Mini Finds и запросы «Куплю» в любимом RSS-ридере" },
+    "whatIsRss": { "title": "Что такое RSS?", "body": "RSS (Really Simple Syndication) позволяет следить за обновлениями The Mini Exchange, не заходя на сайт вручную. Добавьте любую из лент ниже в RSS-ридер, например Feedly, NetNewsWire, Inoreader или любой другой на ваш выбор, и новые объявления будут появляться автоматически." },
+    "available": { "title": "Доступные ленты" },
+    "everything": { "title": "Всё", "description": "Все объявления маркетплейса, находки Mini Finds и запросы «Куплю» в одной ленте." },
+    "dividers": { "marketplace": "Объявления маркетплейса", "community": "Сообщество" },
+    "cards": {
+      "listings": { "title": "Все объявления", "description": "Все активные объявления маркетплейса — автомобили, двигатели и запчасти." },
+      "vehicles": { "title": "Автомобили", "description": "Автомобили Classic Mini на продажу — от проектов до состояния конкурса." },
+      "engines": { "title": "Двигатели", "description": "Полные двигатели A-Series и моторные сборки на продажу." },
+      "parts": { "title": "Запчасти", "description": "Запчасти и аксессуары Classic Mini — кузов, салон, подвеска, электрика и многое другое." },
+      "finds": { "title": "Mini Finds", "description": "Отобранные объявления Classic Mini со всего интернета — Bring a Trailer, Cars & Bids, eBay и другие." },
+      "wanted": { "title": "Запросы «Куплю»", "description": "Автомобили, двигатели и запчасти Classic Mini, которые ищут участники сообщества." }
+    },
+    "cta": { "title": "Не пропустите ни одного объявления", "body": "Скопируйте любой адрес ленты выше и вставьте его в свой RSS-ридер. Новые объявления будут появляться автоматически по мере публикации.", "button": "Смотреть объявления" },
+    "seo": { "title": "RSS-ленты | The Mini Exchange", "description": "Подпишитесь на объявления маркетплейса Classic Mini, находки Mini Finds и запросы «Куплю» через RSS-ленты. Следите за автомобилями, двигателями, запчастями и находками сообщества.", "ogDescription": "Подпишитесь на объявления Classic Mini через RSS — автомобили, двигатели, запчасти, находки и запросы." }
+  },
+  "ja": {
+    "hero": { "title": "RSS フィード", "subtitle": "Classic Mini マーケットプレイスの出品、Mini Finds、Wanted 投稿をお好みのフィードリーダーで購読できます" },
+    "whatIsRss": { "title": "RSS とは？", "body": "RSS（Really Simple Syndication）を使うと、サイトを手動で確認しなくても The Mini Exchange の更新を追えます。下のいずれかのフィードを Feedly、NetNewsWire、Inoreader などお好みの RSS リーダーに追加すれば、新しい出品が自動的に表示されます。" },
+    "available": { "title": "利用できるフィード" },
+    "everything": { "title": "すべて", "description": "マーケットプレイスの全出品、Mini Finds、Wanted 投稿を 1 つのフィードにまとめています。" },
+    "dividers": { "marketplace": "マーケットプレイスの出品", "community": "コミュニティ" },
+    "cards": {
+      "listings": { "title": "すべての出品", "description": "マーケットプレイスのすべての有効な出品 — 車両、エンジン、パーツ。" },
+      "vehicles": { "title": "車両", "description": "販売中の Classic Mini 車両 — プロジェクト車からコンクール仕様まで。" },
+      "engines": { "title": "エンジン", "description": "販売中の A シリーズ・コンプリートエンジンおよびエンジンアッセンブリ。" },
+      "parts": { "title": "パーツ", "description": "Classic Mini のパーツとアクセサリー — ボディ、内装、サスペンション、電装など。" },
+      "finds": { "title": "Mini Finds", "description": "Bring a Trailer、Cars & Bids、eBay などウェブ各所で見つけた Classic Mini の厳選出品。" },
+      "wanted": { "title": "Wanted 投稿", "description": "コミュニティのメンバーが探している Classic Mini の車両、エンジン、パーツ。" }
+    },
+    "cta": { "title": "出品を見逃さない", "body": "上のフィード URL をコピーして、お好みの RSS リーダーに貼り付けてください。新しい出品は公開され次第、自動的に表示されます。", "button": "出品を見る" },
+    "seo": { "title": "RSS フィード | The Mini Exchange", "description": "Classic Mini マーケットプレイスの出品、Mini Finds、Wanted 投稿を RSS フィードで購読。車両、エンジン、パーツ、コミュニティの発見をフォローできます。", "ogDescription": "Classic Mini の出品を RSS で購読 — 車両、エンジン、パーツ、発見、Wanted 投稿。" }
+  },
+  "zh": {
+    "hero": { "title": "RSS 订阅", "subtitle": "在你喜爱的订阅阅读器中订阅 Classic Mini 市场商品、Mini Finds 和求购帖子" },
+    "whatIsRss": { "title": "什么是 RSS？", "body": "RSS（Really Simple Syndication）让你无需手动查看网站即可关注 The Mini Exchange 的更新。将下面任意订阅源添加到 Feedly、NetNewsWire、Inoreader 或你喜欢的 RSS 阅读器，新商品就会自动显示。" },
+    "available": { "title": "可用订阅源" },
+    "everything": { "title": "全部", "description": "将所有市场商品、Mini Finds 和求购帖子合并到一个订阅源中。" },
+    "dividers": { "marketplace": "市场商品", "community": "社区" },
+    "cards": {
+      "listings": { "title": "全部市场商品", "description": "市场上所有在售商品 — 车辆、发动机和零件。" },
+      "vehicles": { "title": "车辆", "description": "在售的 Classic Mini 车辆 — 从项目车到顶级车况。" },
+      "engines": { "title": "发动机", "description": "在售的 A 系列整机及发动机总成。" },
+      "parts": { "title": "零件", "description": "Classic Mini 零件与配件 — 车身、内饰、悬挂、电气等。" },
+      "finds": { "title": "Mini Finds", "description": "从网络各处精选的 Classic Mini 商品 — Bring a Trailer、Cars & Bids、eBay 等。" },
+      "wanted": { "title": "求购帖子", "description": "社区成员正在寻找的 Classic Mini 车辆、发动机和零件。" }
+    },
+    "cta": { "title": "不错过任何商品", "body": "复制上面任意订阅源网址，粘贴到你常用的 RSS 阅读器中。新商品发布后会自动显示。", "button": "浏览商品" },
+    "seo": { "title": "RSS 订阅 | The Mini Exchange", "description": "通过 RSS 订阅 Classic Mini 市场商品、Mini Finds 和求购帖子。关注车辆、发动机、零件和社区发现。", "ogDescription": "通过 RSS 订阅 Classic Mini 商品 — 车辆、发动机、零件、发现和求购帖子。" }
+  },
+  "ko": {
+    "hero": { "title": "RSS 피드", "subtitle": "즐겨 쓰는 피드 리더에서 Classic Mini 마켓플레이스 매물, Mini Finds, 구함 게시물을 구독하세요" },
+    "whatIsRss": { "title": "RSS란?", "body": "RSS(Really Simple Syndication)를 사용하면 사이트를 직접 확인하지 않아도 The Mini Exchange의 업데이트를 따라갈 수 있습니다. 아래 피드 중 하나를 Feedly, NetNewsWire, Inoreader 또는 원하는 RSS 리더에 추가하면 새 매물이 자동으로 표시됩니다." },
+    "available": { "title": "사용 가능한 피드" },
+    "everything": { "title": "전체", "description": "모든 마켓플레이스 매물, Mini Finds, 구함 게시물을 하나의 피드로 모았습니다." },
+    "dividers": { "marketplace": "마켓플레이스 매물", "community": "커뮤니티" },
+    "cards": {
+      "listings": { "title": "모든 마켓플레이스 매물", "description": "마켓플레이스의 모든 활성 매물 — 차량, 엔진, 부품." },
+      "vehicles": { "title": "차량", "description": "판매 중인 Classic Mini 차량 — 프로젝트 차부터 콩쿠르 수준까지." },
+      "engines": { "title": "엔진", "description": "판매 중인 A 시리즈 완성 엔진 및 엔진 어셈블리." },
+      "parts": { "title": "부품", "description": "Classic Mini 부품 및 액세서리 — 차체, 실내, 서스펜션, 전기 등." },
+      "finds": { "title": "Mini Finds", "description": "웹 곳곳에서 발견한 엄선된 Classic Mini 매물 — Bring a Trailer, Cars & Bids, eBay 등." },
+      "wanted": { "title": "구함 게시물", "description": "커뮤니티 회원들이 찾고 있는 Classic Mini 차량, 엔진, 부품." }
+    },
+    "cta": { "title": "매물을 놓치지 마세요", "body": "위의 피드 URL을 복사해 원하는 RSS 리더에 붙여넣으세요. 새 매물이 게시되는 대로 자동으로 표시됩니다.", "button": "매물 둘러보기" },
+    "seo": { "title": "RSS 피드 | The Mini Exchange", "description": "RSS 피드로 Classic Mini 마켓플레이스 매물, Mini Finds, 구함 게시물을 구독하세요. 차량, 엔진, 부품, 커뮤니티 발견을 팔로우하세요.", "ogDescription": "RSS로 Classic Mini 매물을 구독하세요 — 차량, 엔진, 부품, 발견, 구함 게시물." }
+  }
+}
+</i18n>

--- a/app/pages/exchange/how-it-works.vue
+++ b/app/pages/exchange/how-it-works.vue
@@ -1,0 +1,1354 @@
+<template>
+  <div class="container py-12">
+    <!-- Header -->
+    <div class="max-w-4xl mx-auto mb-16 text-center">
+      <h1 class="text-5xl font-bold mb-6">{{ t('hero.title') }}</h1>
+      <p class="text-xl text-base-content/70 leading-relaxed">
+        {{ t('hero.subtitle') }}
+      </p>
+    </div>
+
+    <!-- Buyer / Seller Toggle -->
+    <div class="max-w-4xl mx-auto mb-12">
+      <div class="flex justify-center gap-2 p-1 bg-base-200 rounded-box inline-flex mx-auto">
+        <button @click="activeTab = 'buyers'" :class="['btn', activeTab === 'buyers' ? 'btn-primary' : 'btn-ghost']">
+          <i class="fas fa-magnifying-glass"></i>
+          {{ t('tabs.buyers') }}
+        </button>
+        <button @click="activeTab = 'sellers'" :class="['btn', activeTab === 'sellers' ? 'btn-primary' : 'btn-ghost']">
+          <i class="fas fa-bullhorn"></i>
+          {{ t('tabs.sellers') }}
+        </button>
+      </div>
+    </div>
+
+    <!-- For Buyers -->
+    <div v-if="activeTab === 'buyers'" class="max-w-4xl mx-auto space-y-8">
+      <h2 class="sr-only">{{ t('buyers.srTitle') }}</h2>
+      <template v-for="(step, i) in tm('buyers.steps')" :key="i">
+        <div v-if="i > 0" class="divider"></div>
+        <div class="flex gap-6 items-start">
+          <div class="flex-shrink-0">
+            <div
+              class="w-16 h-16 rounded-full bg-primary text-primary-content flex items-center justify-center text-2xl font-bold"
+            >
+              {{ i + 1 }}
+            </div>
+          </div>
+          <div class="flex-1">
+            <h3 class="text-2xl font-bold mb-3">{{ rt(step.title) }}</h3>
+            <p class="text-base-content/70 text-lg mb-4">
+              {{ rt(step.body) }}
+            </p>
+            <div class="card bg-base-100 shadow-sm">
+              <div class="card-body">
+                <p class="text-sm text-base-content/70">
+                  <strong>{{ rt(step.tipLabel) }}</strong> {{ rt(step.tip) }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <div class="mt-12 text-center">
+        <NuxtLink to="/exchange/listings" class="btn btn-primary btn-lg">
+          <i class="fas fa-magnifying-glass"></i>
+          {{ t('buyers.cta') }}
+        </NuxtLink>
+      </div>
+    </div>
+
+    <!-- For Sellers -->
+    <div v-else class="max-w-4xl mx-auto space-y-8">
+      <h2 class="sr-only">{{ t('sellers.srTitle') }}</h2>
+      <template v-for="(step, i) in tm('sellers.steps')" :key="i">
+        <div v-if="i > 0" class="divider"></div>
+        <div class="flex gap-6 items-start">
+          <div class="flex-shrink-0">
+            <div
+              class="w-16 h-16 rounded-full bg-secondary text-secondary-content flex items-center justify-center text-2xl font-bold"
+            >
+              {{ i + 1 }}
+            </div>
+          </div>
+          <div class="flex-1">
+            <h3 class="text-2xl font-bold mb-3">{{ rt(step.title) }}</h3>
+            <p class="text-base-content/70 text-lg mb-4">
+              {{ rt(step.body) }}
+            </p>
+            <div class="card bg-base-100 shadow-sm">
+              <div class="card-body">
+                <p class="text-sm text-base-content/70">
+                  <strong>{{ rt(step.tipLabel) }}</strong> {{ rt(step.tip) }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <div class="mt-12 text-center">
+        <NuxtLink to="/exchange/listings/new" class="btn btn-secondary btn-lg">
+          <i class="fas fa-plus"></i>
+          {{ t('sellers.cta') }}
+        </NuxtLink>
+      </div>
+    </div>
+
+    <!-- FAQ Section -->
+    <div class="max-w-4xl mx-auto mt-20">
+      <h2 class="text-3xl font-bold mb-8 text-center">{{ t('faq.title') }}</h2>
+      <div class="space-y-4">
+        <div v-for="(item, i) in tm('faq.items')" :key="i" class="collapse collapse-plus bg-base-100 shadow-sm">
+          <input type="radio" name="faq-accordion" :aria-label="rt(item.question)" />
+          <div class="collapse-title text-xl font-medium">{{ rt(item.question) }}</div>
+          <div class="collapse-content">
+            <p class="text-base-content/70">{{ rt(item.answer) }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Still Have Questions -->
+    <div class="max-w-2xl mx-auto mt-16 text-center bg-primary/5 rounded-box p-12">
+      <h3 class="text-2xl font-bold mb-4">{{ t('questions.title') }}</h3>
+      <p class="text-base-content/70 mb-6">
+        {{ t('questions.body') }}
+      </p>
+      <NuxtLink to="/contact" class="btn btn-primary">
+        <i class="fas fa-envelope"></i>
+        {{ t('questions.button') }}
+      </NuxtLink>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t, tm, rt } = useI18n();
+  const config = useRuntimeConfig();
+  const activeTab = ref<'buyers' | 'sellers'>('buyers');
+
+  // SEO metadata
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.title'),
+    ogDescription: () => t('seo.ogDescription'),
+    ogType: 'website',
+    ogUrl: `${config.public.siteUrl}/exchange/how-it-works`,
+    ogImage: '/og-image.jpg',
+    twitterCard: 'summary_large_image',
+    twitterTitle: () => t('seo.title'),
+    twitterDescription: () => t('seo.ogDescription'),
+  });
+
+  // FAQPage schema for the FAQ section
+  useSchemaOrg([
+    {
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: () => t('faq.items.0.question'),
+          acceptedAnswer: { '@type': 'Answer', text: () => t('faq.items.0.answer') },
+        },
+        {
+          '@type': 'Question',
+          name: () => t('faq.items.1.question'),
+          acceptedAnswer: { '@type': 'Answer', text: () => t('faq.items.1.answer') },
+        },
+        {
+          '@type': 'Question',
+          name: () => t('faq.items.2.question'),
+          acceptedAnswer: { '@type': 'Answer', text: () => t('faq.items.2.answer') },
+        },
+        {
+          '@type': 'Question',
+          name: () => t('faq.items.3.question'),
+          acceptedAnswer: { '@type': 'Answer', text: () => t('faq.items.3.answer') },
+        },
+        {
+          '@type': 'Question',
+          name: () => t('faq.items.4.question'),
+          acceptedAnswer: { '@type': 'Answer', text: () => t('faq.items.4.answer') },
+        },
+        {
+          '@type': 'Question',
+          name: () => t('faq.items.5.question'),
+          acceptedAnswer: { '@type': 'Answer', text: () => t('faq.items.5.answer') },
+        },
+        {
+          '@type': 'Question',
+          name: () => t('faq.items.6.question'),
+          acceptedAnswer: { '@type': 'Answer', text: () => t('faq.items.6.answer') },
+        },
+      ],
+    },
+  ]);
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "hero": {
+      "title": "How It Works",
+      "subtitle": "A simple, straightforward platform for buying and selling Classic Minis"
+    },
+    "tabs": { "buyers": "For Buyers", "sellers": "For Sellers" },
+    "buyers": {
+      "srTitle": "Steps for Buyers",
+      "cta": "Start Browsing Listings",
+      "steps": [
+        {
+          "title": "Browse Listings",
+          "body": "Explore our collection of Classic Minis from around the world. Use filters to narrow down by model, year, location, price range, and condition.",
+          "tipLabel": "Pro tip:",
+          "tip": "Add listings to your watchlist to track price changes and get notified when sellers respond to your messages."
+        },
+        {
+          "title": "View Detailed Listings",
+          "body": "Each listing includes comprehensive details: full specifications, modification history, multiple photo galleries (body, engine, interior, details), and seller notes about condition and history.",
+          "tipLabel": "What to look for:",
+          "tip": "Check the photos carefully, read the seller's condition notes, and note any modifications or non-original parts. Ask questions if anything is unclear."
+        },
+        {
+          "title": "Contact the Seller",
+          "body": "Use our built-in messaging system to ask questions, request additional photos, or arrange a viewing. All communication stays on the platform until you're ready to connect directly.",
+          "tipLabel": "Safety first:",
+          "tip": "Always inspect the car in person if possible, and consider bringing a knowledgeable friend or mechanic. Never send payment before seeing the vehicle."
+        },
+        {
+          "title": "Complete the Deal",
+          "body": "Once you've inspected the Mini and agreed on terms, finalize the purchase. The seller can mark the listing as sold, and you can leave feedback about your experience.",
+          "tipLabel": "After the purchase:",
+          "tip": "Join the community! Share your new Mini story, ask for advice, and connect with other enthusiasts."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "Steps for Sellers",
+      "cta": "Create Your Listing",
+      "steps": [
+        {
+          "title": "Create Your Account",
+          "body": "Sign up with your email address to get started. Set up your profile with your location and a display name. Your profile helps buyers understand who they're dealing with.",
+          "tipLabel": "Profile tip:",
+          "tip": "A complete profile with a profile picture builds trust with potential buyers."
+        },
+        {
+          "title": "Prepare Your Listing",
+          "body": "Take high-quality photos from all angles: body exterior, engine bay, interior, undercarriage, and any special details or issues. Write a detailed description including history, modifications, condition notes, and what makes your Mini special.",
+          "tipLabel": "Photo tips:",
+          "tip": "Clean your Mini before photographing. Good lighting and multiple angles help buyers understand the condition. Don't hide issues — transparency builds trust."
+        },
+        {
+          "title": "Post Your Listing",
+          "body": "Fill out the listing form with all the details: year, model, mileage, price, location, and condition. Upload your photos organized by category (body, engine, interior, details). Review and publish your listing.",
+          "tipLabel": "Pricing tip:",
+          "tip": "Research similar Minis to set a fair price. Consider your Mini's condition, modifications, and any included extras."
+        },
+        {
+          "title": "Respond to Inquiries",
+          "body": "When buyers message you with questions, respond promptly and honestly. Be prepared to provide additional photos, answer detailed questions, and arrange viewings for serious buyers.",
+          "tipLabel": "Communication tip:",
+          "tip": "Quick, honest responses help close deals faster. Be upfront about any issues and set clear expectations."
+        },
+        {
+          "title": "Close the Sale",
+          "body": "Once you've found the right buyer and agreed on terms, arrange a safe meeting place for the exchange. After the sale, mark your listing as sold to let other interested buyers know.",
+          "tipLabel": "Safety first:",
+          "tip": "Meet in public places for viewings. Accept secure payment methods, and transfer title properly according to your local regulations."
+        }
+      ]
+    },
+    "faq": {
+      "title": "Frequently Asked Questions",
+      "items": [
+        {
+          "question": "Is The Mini Exchange free to use?",
+          "answer": "Yes! Creating an account, browsing listings, and posting your own listings is completely free. We're building this platform for the Mini community."
+        },
+        {
+          "question": "How do payments work?",
+          "answer": "The Mini Exchange is a marketplace platform — we don't process payments. Buyers and sellers arrange payment and transfer directly. We recommend secure payment methods like bank transfers or escrow services for high-value transactions."
+        },
+        {
+          "question": "What if there's a dispute with a buyer or seller?",
+          "answer": "While we provide the platform for connections, transactions happen directly between buyers and sellers. We encourage transparency, thorough communication, and in-person inspections. If you encounter fraudulent activity, please report it to us immediately."
+        },
+        {
+          "question": "Can I edit my listing after posting?",
+          "answer": "Absolutely! You can edit your listing details, add or remove photos, update the price, or mark it as sold at any time from your dashboard."
+        },
+        {
+          "question": "Do you ship Classic Minis, or help with transport?",
+          "answer": "We don't provide shipping services, but many buyers and sellers arrange transport through specialized classic car shipping companies. Buyers and sellers coordinate transport and costs directly."
+        },
+        {
+          "question": "What types of Classic Minis can I list?",
+          "answer": "All Classic Minis from 1959-2000 are welcome! This includes original Minis, Cooper S models, Clubman estates, Travellers, Pickups, Vans, limited editions, and project cars. If it's a Classic Mini, it belongs here."
+        },
+        {
+          "question": "What parts and accessories can I list?",
+          "answer": "We welcome all parts and accessories that are useful to Classic Mini owners — not just original or first-party Mini parts. Aftermarket upgrades, tuning tools, gauges, performance parts, and accessories commonly used on Classic Minis are all appropriate. For example, an Innovate wideband controller you used for carb tuning absolutely belongs here. The key is relevance: if a Mini owner would find it useful, list it! We just ask that listings stay relevant to the Classic Mini community and avoid completely unrelated general automotive items."
+        }
+      ]
+    },
+    "questions": {
+      "title": "Still Have Questions?",
+      "body": "We're here to help. Reach out if you need assistance or have suggestions for improving the platform.",
+      "button": "Contact Us"
+    },
+    "seo": {
+      "title": "How It Works - The Mini Exchange",
+      "description": "Learn how to buy and sell on The Mini Exchange. A simple guide for listing your Classic Mini, parts, or engine.",
+      "ogDescription": "A simple guide to buying and selling Classic Minis, parts, and engines on The Mini Exchange."
+    }
+  },
+  "es": {
+    "hero": {
+      "title": "Cómo funciona",
+      "subtitle": "Una plataforma sencilla y directa para comprar y vender Classic Minis"
+    },
+    "tabs": { "buyers": "Para compradores", "sellers": "Para vendedores" },
+    "buyers": {
+      "srTitle": "Pasos para compradores",
+      "cta": "Empezar a explorar anuncios",
+      "steps": [
+        {
+          "title": "Explora los anuncios",
+          "body": "Descubre nuestra colección de Classic Minis de todo el mundo. Usa los filtros para acotar por modelo, año, ubicación, rango de precio y estado.",
+          "tipLabel": "Consejo:",
+          "tip": "Añade anuncios a tu lista de seguimiento para controlar los cambios de precio y recibir avisos cuando los vendedores respondan a tus mensajes."
+        },
+        {
+          "title": "Consulta los anuncios detallados",
+          "body": "Cada anuncio incluye información completa: especificaciones, historial de modificaciones, varias galerías de fotos (carrocería, motor, interior, detalles) y notas del vendedor sobre el estado y la historia.",
+          "tipLabel": "Qué buscar:",
+          "tip": "Revisa bien las fotos, lee las notas de estado del vendedor y fíjate en cualquier modificación o pieza no original. Pregunta si algo no queda claro."
+        },
+        {
+          "title": "Contacta con el vendedor",
+          "body": "Usa nuestro sistema de mensajería integrado para hacer preguntas, pedir más fotos o concertar una visita. Toda la comunicación se mantiene en la plataforma hasta que estés listo para conectar directamente.",
+          "tipLabel": "La seguridad primero:",
+          "tip": "Siempre que puedas, inspecciona el coche en persona y plantéate llevar a un amigo o mecánico con conocimientos. Nunca envíes el pago antes de ver el vehículo."
+        },
+        {
+          "title": "Cierra el trato",
+          "body": "Una vez que hayas inspeccionado el Mini y acordado las condiciones, finaliza la compra. El vendedor puede marcar el anuncio como vendido y tú puedes dejar tu valoración de la experiencia.",
+          "tipLabel": "Después de la compra:",
+          "tip": "¡Únete a la comunidad! Comparte la historia de tu nuevo Mini, pide consejo y conecta con otros aficionados."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "Pasos para vendedores",
+      "cta": "Crea tu anuncio",
+      "steps": [
+        {
+          "title": "Crea tu cuenta",
+          "body": "Regístrate con tu correo electrónico para empezar. Configura tu perfil con tu ubicación y un nombre visible. Tu perfil ayuda a los compradores a saber con quién tratan.",
+          "tipLabel": "Consejo de perfil:",
+          "tip": "Un perfil completo con foto genera confianza en los posibles compradores."
+        },
+        {
+          "title": "Prepara tu anuncio",
+          "body": "Haz fotos de calidad desde todos los ángulos: exterior de la carrocería, vano motor, interior, bajos y cualquier detalle o problema especial. Escribe una descripción detallada con la historia, las modificaciones, las notas de estado y lo que hace especial a tu Mini.",
+          "tipLabel": "Consejos de fotos:",
+          "tip": "Limpia tu Mini antes de fotografiarlo. Una buena iluminación y varios ángulos ayudan a los compradores a entender el estado. No ocultes los problemas: la transparencia genera confianza."
+        },
+        {
+          "title": "Publica tu anuncio",
+          "body": "Rellena el formulario del anuncio con todos los datos: año, modelo, kilometraje, precio, ubicación y estado. Sube tus fotos organizadas por categoría (carrocería, motor, interior, detalles). Revisa y publica tu anuncio.",
+          "tipLabel": "Consejo de precio:",
+          "tip": "Investiga Minis similares para fijar un precio justo. Ten en cuenta el estado de tu Mini, sus modificaciones y cualquier extra incluido."
+        },
+        {
+          "title": "Responde a las consultas",
+          "body": "Cuando los compradores te escriban con preguntas, responde con rapidez y honestidad. Prepárate para aportar más fotos, responder preguntas detalladas y concertar visitas con los compradores serios.",
+          "tipLabel": "Consejo de comunicación:",
+          "tip": "Las respuestas rápidas y honestas ayudan a cerrar tratos más rápido. Sé claro sobre cualquier problema y establece expectativas claras."
+        },
+        {
+          "title": "Cierra la venta",
+          "body": "Cuando hayas encontrado al comprador adecuado y acordado las condiciones, concierta un lugar de encuentro seguro para el intercambio. Tras la venta, marca tu anuncio como vendido para avisar a otros interesados.",
+          "tipLabel": "La seguridad primero:",
+          "tip": "Queda en lugares públicos para las visitas. Acepta métodos de pago seguros y transfiere la titularidad correctamente según la normativa local."
+        }
+      ]
+    },
+    "faq": {
+      "title": "Preguntas frecuentes",
+      "items": [
+        {
+          "question": "¿Es gratis usar The Mini Exchange?",
+          "answer": "¡Sí! Crear una cuenta, explorar anuncios y publicar los tuyos es totalmente gratis. Estamos construyendo esta plataforma para la comunidad Mini."
+        },
+        {
+          "question": "¿Cómo funcionan los pagos?",
+          "answer": "The Mini Exchange es una plataforma de mercado: no procesamos pagos. Compradores y vendedores acuerdan el pago y la transferencia directamente. Recomendamos métodos de pago seguros como transferencias bancarias o servicios de depósito en garantía para transacciones de alto valor."
+        },
+        {
+          "question": "¿Qué pasa si hay una disputa con un comprador o vendedor?",
+          "answer": "Aunque proporcionamos la plataforma para conectar, las transacciones ocurren directamente entre compradores y vendedores. Fomentamos la transparencia, una comunicación exhaustiva y las inspecciones en persona. Si detectas actividad fraudulenta, denúnciala de inmediato."
+        },
+        {
+          "question": "¿Puedo editar mi anuncio después de publicarlo?",
+          "answer": "¡Por supuesto! Puedes editar los datos de tu anuncio, añadir o quitar fotos, actualizar el precio o marcarlo como vendido en cualquier momento desde tu panel."
+        },
+        {
+          "question": "¿Enviáis Classic Minis o ayudáis con el transporte?",
+          "answer": "No ofrecemos servicios de envío, pero muchos compradores y vendedores organizan el transporte a través de empresas especializadas en clásicos. Compradores y vendedores coordinan el transporte y los costes directamente."
+        },
+        {
+          "question": "¿Qué tipos de Classic Minis puedo anunciar?",
+          "answer": "¡Todos los Classic Minis de 1959 a 2000 son bienvenidos! Esto incluye Minis originales, modelos Cooper S, familiares Clubman, Travellers, Pickups, furgonetas, ediciones limitadas y coches de proyecto. Si es un Classic Mini, tiene su sitio aquí."
+        },
+        {
+          "question": "¿Qué piezas y accesorios puedo anunciar?",
+          "answer": "Aceptamos todas las piezas y accesorios útiles para los propietarios de Classic Mini, no solo las piezas originales o de primera marca. Mejoras de posventa, herramientas de puesta a punto, relojes, piezas de rendimiento y accesorios habituales en los Classic Mini son todos apropiados. Por ejemplo, un controlador wideband de Innovate que usaste para reglar el carburador encaja perfectamente. La clave es la relevancia: si a un propietario de Mini le resulta útil, ¡anúncialo! Solo pedimos que los anuncios sigan siendo relevantes para la comunidad Classic Mini y se eviten artículos de automoción general sin ninguna relación."
+        }
+      ]
+    },
+    "questions": {
+      "title": "¿Todavía tienes dudas?",
+      "body": "Estamos aquí para ayudar. Escríbenos si necesitas ayuda o tienes sugerencias para mejorar la plataforma.",
+      "button": "Contáctanos"
+    },
+    "seo": {
+      "title": "Cómo funciona - The Mini Exchange",
+      "description": "Aprende a comprar y vender en The Mini Exchange. Una guía sencilla para anunciar tu Classic Mini, piezas o motor.",
+      "ogDescription": "Una guía sencilla para comprar y vender Classic Minis, piezas y motores en The Mini Exchange."
+    }
+  },
+  "fr": {
+    "hero": {
+      "title": "Comment ça marche",
+      "subtitle": "Une plateforme simple et directe pour acheter et vendre des Classic Minis"
+    },
+    "tabs": { "buyers": "Pour les acheteurs", "sellers": "Pour les vendeurs" },
+    "buyers": {
+      "srTitle": "Étapes pour les acheteurs",
+      "cta": "Commencer à parcourir les annonces",
+      "steps": [
+        {
+          "title": "Parcourez les annonces",
+          "body": "Explorez notre collection de Classic Minis du monde entier. Utilisez les filtres pour affiner par modèle, année, lieu, fourchette de prix et état.",
+          "tipLabel": "Astuce :",
+          "tip": "Ajoutez des annonces à votre liste de suivi pour suivre les variations de prix et être averti quand les vendeurs répondent à vos messages."
+        },
+        {
+          "title": "Consultez les annonces détaillées",
+          "body": "Chaque annonce comprend des détails complets : caractéristiques, historique des modifications, plusieurs galeries de photos (carrosserie, moteur, intérieur, détails) et les notes du vendeur sur l'état et l'historique.",
+          "tipLabel": "À quoi faire attention :",
+          "tip": "Examinez attentivement les photos, lisez les notes d'état du vendeur et repérez les modifications ou pièces non d'origine. Posez des questions si quelque chose n'est pas clair."
+        },
+        {
+          "title": "Contactez le vendeur",
+          "body": "Utilisez notre messagerie intégrée pour poser des questions, demander des photos supplémentaires ou organiser une visite. Toute la communication reste sur la plateforme jusqu'à ce que vous soyez prêt à vous contacter directement.",
+          "tipLabel": "La sécurité avant tout :",
+          "tip": "Inspectez toujours la voiture en personne si possible et envisagez d'emmener un ami ou un mécanicien averti. N'envoyez jamais de paiement avant d'avoir vu le véhicule."
+        },
+        {
+          "title": "Finalisez la transaction",
+          "body": "Une fois la Mini inspectée et les conditions convenues, finalisez l'achat. Le vendeur peut marquer l'annonce comme vendue et vous pouvez laisser un avis sur votre expérience.",
+          "tipLabel": "Après l'achat :",
+          "tip": "Rejoignez la communauté ! Partagez l'histoire de votre nouvelle Mini, demandez des conseils et échangez avec d'autres passionnés."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "Étapes pour les vendeurs",
+      "cta": "Créez votre annonce",
+      "steps": [
+        {
+          "title": "Créez votre compte",
+          "body": "Inscrivez-vous avec votre adresse e-mail pour commencer. Configurez votre profil avec votre localisation et un nom d'affichage. Votre profil aide les acheteurs à savoir à qui ils ont affaire.",
+          "tipLabel": "Astuce profil :",
+          "tip": "Un profil complet avec une photo inspire confiance aux acheteurs potentiels."
+        },
+        {
+          "title": "Préparez votre annonce",
+          "body": "Prenez des photos de qualité sous tous les angles : extérieur de la carrosserie, compartiment moteur, intérieur, dessous de caisse et tout détail ou défaut particulier. Rédigez une description détaillée incluant l'historique, les modifications, les notes d'état et ce qui rend votre Mini spéciale.",
+          "tipLabel": "Astuces photos :",
+          "tip": "Nettoyez votre Mini avant de la photographier. Un bon éclairage et plusieurs angles aident les acheteurs à comprendre l'état. Ne cachez pas les défauts — la transparence crée la confiance."
+        },
+        {
+          "title": "Publiez votre annonce",
+          "body": "Remplissez le formulaire d'annonce avec tous les détails : année, modèle, kilométrage, prix, lieu et état. Téléchargez vos photos organisées par catégorie (carrosserie, moteur, intérieur, détails). Vérifiez et publiez votre annonce.",
+          "tipLabel": "Astuce prix :",
+          "tip": "Renseignez-vous sur des Minis similaires pour fixer un prix juste. Tenez compte de l'état de votre Mini, de ses modifications et des éventuels extras inclus."
+        },
+        {
+          "title": "Répondez aux demandes",
+          "body": "Lorsque les acheteurs vous écrivent avec des questions, répondez rapidement et honnêtement. Soyez prêt à fournir des photos supplémentaires, à répondre à des questions détaillées et à organiser des visites pour les acheteurs sérieux.",
+          "tipLabel": "Astuce communication :",
+          "tip": "Des réponses rapides et honnêtes aident à conclure plus vite. Soyez transparent sur les défauts et fixez des attentes claires."
+        },
+        {
+          "title": "Concluez la vente",
+          "body": "Une fois le bon acheteur trouvé et les conditions convenues, organisez un lieu de rencontre sûr pour l'échange. Après la vente, marquez votre annonce comme vendue pour informer les autres acheteurs intéressés.",
+          "tipLabel": "La sécurité avant tout :",
+          "tip": "Rencontrez-vous dans des lieux publics pour les visites. Acceptez des moyens de paiement sûrs et transférez la carte grise correctement selon la réglementation locale."
+        }
+      ]
+    },
+    "faq": {
+      "title": "Foire aux questions",
+      "items": [
+        {
+          "question": "The Mini Exchange est-il gratuit ?",
+          "answer": "Oui ! Créer un compte, parcourir les annonces et publier les vôtres est entièrement gratuit. Nous construisons cette plateforme pour la communauté Mini."
+        },
+        {
+          "question": "Comment fonctionnent les paiements ?",
+          "answer": "The Mini Exchange est une plateforme de petites annonces — nous ne traitons pas les paiements. Acheteurs et vendeurs organisent le paiement et le transfert directement. Nous recommandons des moyens de paiement sûrs comme les virements bancaires ou les services d'entiercement pour les transactions de grande valeur."
+        },
+        {
+          "question": "Que faire en cas de litige avec un acheteur ou un vendeur ?",
+          "answer": "Bien que nous fournissions la plateforme de mise en relation, les transactions se font directement entre acheteurs et vendeurs. Nous encourageons la transparence, une communication approfondie et les inspections en personne. Si vous constatez une activité frauduleuse, signalez-la-nous immédiatement."
+        },
+        {
+          "question": "Puis-je modifier mon annonce après publication ?",
+          "answer": "Absolument ! Vous pouvez modifier les détails de votre annonce, ajouter ou supprimer des photos, mettre à jour le prix ou la marquer comme vendue à tout moment depuis votre tableau de bord."
+        },
+        {
+          "question": "Expédiez-vous les Classic Minis ou aidez-vous au transport ?",
+          "answer": "Nous ne proposons pas de service d'expédition, mais de nombreux acheteurs et vendeurs organisent le transport via des entreprises spécialisées dans les voitures de collection. Acheteurs et vendeurs coordonnent le transport et les coûts directement."
+        },
+        {
+          "question": "Quels types de Classic Minis puis-je publier ?",
+          "answer": "Toutes les Classic Minis de 1959 à 2000 sont les bienvenues ! Cela inclut les Minis d'origine, les modèles Cooper S, les breaks Clubman, les Travellers, les Pickups, les fourgonnettes, les éditions limitées et les voitures à restaurer. Si c'est une Classic Mini, elle a sa place ici."
+        },
+        {
+          "question": "Quelles pièces et accessoires puis-je publier ?",
+          "answer": "Nous acceptons toutes les pièces et accessoires utiles aux propriétaires de Classic Mini — pas seulement les pièces d'origine ou de première monte. Les améliorations de seconde monte, les outils de réglage, les jauges, les pièces de performance et les accessoires couramment utilisés sur les Classic Minis sont tous appropriés. Par exemple, un contrôleur wideband Innovate utilisé pour le réglage du carburateur a tout à fait sa place ici. L'essentiel est la pertinence : si un propriétaire de Mini le trouve utile, publiez-le ! Nous demandons simplement que les annonces restent pertinentes pour la communauté Classic Mini et évitent les articles automobiles généraux totalement sans rapport."
+        }
+      ]
+    },
+    "questions": {
+      "title": "Encore des questions ?",
+      "body": "Nous sommes là pour vous aider. Contactez-nous si vous avez besoin d'aide ou des suggestions pour améliorer la plateforme.",
+      "button": "Nous contacter"
+    },
+    "seo": {
+      "title": "Comment ça marche - The Mini Exchange",
+      "description": "Découvrez comment acheter et vendre sur The Mini Exchange. Un guide simple pour publier votre Classic Mini, vos pièces ou votre moteur.",
+      "ogDescription": "Un guide simple pour acheter et vendre des Classic Minis, des pièces et des moteurs sur The Mini Exchange."
+    }
+  },
+  "de": {
+    "hero": {
+      "title": "So funktioniert es",
+      "subtitle": "Eine einfache, unkomplizierte Plattform zum Kauf und Verkauf von Classic Minis"
+    },
+    "tabs": { "buyers": "Für Käufer", "sellers": "Für Verkäufer" },
+    "buyers": {
+      "srTitle": "Schritte für Käufer",
+      "cta": "Inserate durchstöbern",
+      "steps": [
+        {
+          "title": "Inserate durchstöbern",
+          "body": "Entdecke unsere Sammlung von Classic Minis aus aller Welt. Nutze Filter, um nach Modell, Baujahr, Standort, Preisspanne und Zustand einzugrenzen.",
+          "tipLabel": "Profi-Tipp:",
+          "tip": "Füge Inserate zu deiner Merkliste hinzu, um Preisänderungen zu verfolgen und benachrichtigt zu werden, wenn Verkäufer auf deine Nachrichten antworten."
+        },
+        {
+          "title": "Detaillierte Inserate ansehen",
+          "body": "Jedes Inserat enthält umfassende Details: vollständige Spezifikationen, Umbauhistorie, mehrere Fotogalerien (Karosserie, Motor, Innenraum, Details) und Verkäufernotizen zu Zustand und Historie.",
+          "tipLabel": "Worauf du achten solltest:",
+          "tip": "Sieh dir die Fotos genau an, lies die Zustandsnotizen des Verkäufers und achte auf Umbauten oder nicht originale Teile. Frag nach, wenn etwas unklar ist."
+        },
+        {
+          "title": "Kontaktiere den Verkäufer",
+          "body": "Nutze unser integriertes Nachrichtensystem, um Fragen zu stellen, weitere Fotos anzufordern oder eine Besichtigung zu vereinbaren. Die gesamte Kommunikation bleibt auf der Plattform, bis du bereit bist, dich direkt zu vernetzen.",
+          "tipLabel": "Sicherheit zuerst:",
+          "tip": "Besichtige das Auto nach Möglichkeit immer persönlich und nimm am besten einen sachkundigen Freund oder Mechaniker mit. Schicke niemals Geld, bevor du das Fahrzeug gesehen hast."
+        },
+        {
+          "title": "Geschäft abschließen",
+          "body": "Sobald du den Mini besichtigt und die Konditionen vereinbart hast, schließe den Kauf ab. Der Verkäufer kann das Inserat als verkauft markieren und du kannst eine Bewertung zu deiner Erfahrung hinterlassen.",
+          "tipLabel": "Nach dem Kauf:",
+          "tip": "Werde Teil der Community! Teile die Geschichte deines neuen Minis, bitte um Rat und vernetze dich mit anderen Enthusiasten."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "Schritte für Verkäufer",
+      "cta": "Inserat erstellen",
+      "steps": [
+        {
+          "title": "Konto erstellen",
+          "body": "Registriere dich mit deiner E-Mail-Adresse, um loszulegen. Richte dein Profil mit deinem Standort und einem Anzeigenamen ein. Dein Profil hilft Käufern zu verstehen, mit wem sie es zu tun haben.",
+          "tipLabel": "Profil-Tipp:",
+          "tip": "Ein vollständiges Profil mit Profilbild schafft Vertrauen bei potenziellen Käufern."
+        },
+        {
+          "title": "Inserat vorbereiten",
+          "body": "Mach hochwertige Fotos aus allen Blickwinkeln: Karosserie außen, Motorraum, Innenraum, Unterboden und besondere Details oder Mängel. Schreibe eine ausführliche Beschreibung mit Historie, Umbauten, Zustandsnotizen und dem, was deinen Mini besonders macht.",
+          "tipLabel": "Foto-Tipps:",
+          "tip": "Reinige deinen Mini vor dem Fotografieren. Gute Beleuchtung und mehrere Blickwinkel helfen Käufern, den Zustand zu verstehen. Verschweige keine Mängel — Transparenz schafft Vertrauen."
+        },
+        {
+          "title": "Inserat veröffentlichen",
+          "body": "Fülle das Inseratsformular mit allen Angaben aus: Baujahr, Modell, Laufleistung, Preis, Standort und Zustand. Lade deine Fotos nach Kategorie geordnet hoch (Karosserie, Motor, Innenraum, Details). Prüfe dein Inserat und veröffentliche es.",
+          "tipLabel": "Preis-Tipp:",
+          "tip": "Recherchiere ähnliche Minis, um einen fairen Preis festzulegen. Berücksichtige den Zustand deines Minis, seine Umbauten und alle enthaltenen Extras."
+        },
+        {
+          "title": "Auf Anfragen antworten",
+          "body": "Wenn Käufer dir Fragen schicken, antworte zügig und ehrlich. Sei bereit, weitere Fotos zu liefern, detaillierte Fragen zu beantworten und Besichtigungen mit ernsthaften Käufern zu vereinbaren.",
+          "tipLabel": "Kommunikations-Tipp:",
+          "tip": "Schnelle, ehrliche Antworten helfen, schneller abzuschließen. Sei offen über Mängel und setze klare Erwartungen."
+        },
+        {
+          "title": "Verkauf abschließen",
+          "body": "Sobald du den richtigen Käufer gefunden und die Konditionen vereinbart hast, vereinbare einen sicheren Treffpunkt für die Übergabe. Markiere dein Inserat nach dem Verkauf als verkauft, um andere Interessenten zu informieren.",
+          "tipLabel": "Sicherheit zuerst:",
+          "tip": "Triff dich für Besichtigungen an öffentlichen Orten. Akzeptiere sichere Zahlungsmethoden und übertrage die Zulassung ordnungsgemäß gemäß den örtlichen Vorschriften."
+        }
+      ]
+    },
+    "faq": {
+      "title": "Häufig gestellte Fragen",
+      "items": [
+        {
+          "question": "Ist The Mini Exchange kostenlos nutzbar?",
+          "answer": "Ja! Ein Konto erstellen, Inserate durchstöbern und eigene Inserate veröffentlichen ist völlig kostenlos. Wir bauen diese Plattform für die Mini-Community."
+        },
+        {
+          "question": "Wie funktionieren Zahlungen?",
+          "answer": "The Mini Exchange ist eine Marktplatzplattform — wir wickeln keine Zahlungen ab. Käufer und Verkäufer regeln Zahlung und Übergabe direkt. Wir empfehlen sichere Zahlungsmethoden wie Banküberweisungen oder Treuhanddienste für hochwertige Transaktionen."
+        },
+        {
+          "question": "Was passiert bei einer Streitigkeit mit einem Käufer oder Verkäufer?",
+          "answer": "Wir stellen die Plattform für die Kontaktaufnahme bereit, doch die Transaktionen finden direkt zwischen Käufern und Verkäufern statt. Wir empfehlen Transparenz, gründliche Kommunikation und Besichtigungen vor Ort. Wenn du auf betrügerische Aktivitäten stößt, melde sie uns bitte sofort."
+        },
+        {
+          "question": "Kann ich mein Inserat nach der Veröffentlichung bearbeiten?",
+          "answer": "Auf jeden Fall! Du kannst die Details deines Inserats bearbeiten, Fotos hinzufügen oder entfernen, den Preis aktualisieren oder es jederzeit über dein Dashboard als verkauft markieren."
+        },
+        {
+          "question": "Versendet ihr Classic Minis oder helft beim Transport?",
+          "answer": "Wir bieten keine Versanddienste an, aber viele Käufer und Verkäufer organisieren den Transport über spezialisierte Oldtimer-Speditionen. Käufer und Verkäufer koordinieren Transport und Kosten direkt."
+        },
+        {
+          "question": "Welche Arten von Classic Minis kann ich inserieren?",
+          "answer": "Alle Classic Minis von 1959 bis 2000 sind willkommen! Dazu gehören originale Minis, Cooper-S-Modelle, Clubman-Kombis, Travellers, Pickups, Lieferwagen, Sondereditionen und Projektfahrzeuge. Wenn es ein Classic Mini ist, gehört er hierher."
+        },
+        {
+          "question": "Welche Teile und Zubehör kann ich inserieren?",
+          "answer": "Wir nehmen alle Teile und Zubehörteile an, die für Classic-Mini-Besitzer nützlich sind — nicht nur originale oder Erstausrüsterteile. Nachrüstverbesserungen, Abstimmwerkzeuge, Instrumente, Performance-Teile und bei Classic Minis übliches Zubehör sind alle passend. Zum Beispiel gehört ein Innovate-Breitband-Controller, den du zur Vergaserabstimmung verwendet hast, absolut hierher. Entscheidend ist die Relevanz: Wenn ein Mini-Besitzer es nützlich findet, inseriere es! Wir bitten nur darum, dass Inserate für die Classic-Mini-Community relevant bleiben und völlig themenfremde allgemeine Kfz-Artikel vermieden werden."
+        }
+      ]
+    },
+    "questions": {
+      "title": "Noch Fragen?",
+      "body": "Wir helfen gern. Melde dich, wenn du Unterstützung brauchst oder Vorschläge zur Verbesserung der Plattform hast.",
+      "button": "Kontaktiere uns"
+    },
+    "seo": {
+      "title": "So funktioniert es - The Mini Exchange",
+      "description": "Erfahre, wie du bei The Mini Exchange kaufst und verkaufst. Eine einfache Anleitung zum Inserieren deines Classic Mini, deiner Teile oder deines Motors.",
+      "ogDescription": "Eine einfache Anleitung zum Kauf und Verkauf von Classic Minis, Teilen und Motoren bei The Mini Exchange."
+    }
+  },
+  "it": {
+    "hero": {
+      "title": "Come funziona",
+      "subtitle": "Una piattaforma semplice e diretta per comprare e vendere Classic Mini"
+    },
+    "tabs": { "buyers": "Per chi compra", "sellers": "Per chi vende" },
+    "buyers": {
+      "srTitle": "Passaggi per chi compra",
+      "cta": "Inizia a sfogliare gli annunci",
+      "steps": [
+        {
+          "title": "Sfoglia gli annunci",
+          "body": "Esplora la nostra collezione di Classic Mini da tutto il mondo. Usa i filtri per restringere per modello, anno, località, fascia di prezzo e condizioni.",
+          "tipLabel": "Consiglio:",
+          "tip": "Aggiungi gli annunci alla tua lista di osservati per monitorare le variazioni di prezzo ed essere avvisato quando i venditori rispondono ai tuoi messaggi."
+        },
+        {
+          "title": "Visualizza gli annunci dettagliati",
+          "body": "Ogni annuncio include dettagli completi: specifiche complete, storico delle modifiche, più gallerie di foto (carrozzeria, motore, interni, dettagli) e note del venditore su condizioni e storia.",
+          "tipLabel": "Cosa controllare:",
+          "tip": "Esamina con attenzione le foto, leggi le note sulle condizioni del venditore e nota eventuali modifiche o parti non originali. Fai domande se qualcosa non è chiaro."
+        },
+        {
+          "title": "Contatta il venditore",
+          "body": "Usa il nostro sistema di messaggistica integrato per fare domande, richiedere altre foto o organizzare una visione. Tutta la comunicazione resta sulla piattaforma finché non sei pronto a metterti in contatto direttamente.",
+          "tipLabel": "Prima la sicurezza:",
+          "tip": "Quando possibile, ispeziona sempre l'auto di persona e valuta di portare con te un amico o un meccanico esperto. Non inviare mai il pagamento prima di vedere il veicolo."
+        },
+        {
+          "title": "Concludi l'affare",
+          "body": "Dopo aver ispezionato la Mini e concordato le condizioni, finalizza l'acquisto. Il venditore può contrassegnare l'annuncio come venduto e tu puoi lasciare un giudizio sulla tua esperienza.",
+          "tipLabel": "Dopo l'acquisto:",
+          "tip": "Unisciti alla community! Condividi la storia della tua nuova Mini, chiedi consigli e connettiti con altri appassionati."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "Passaggi per chi vende",
+      "cta": "Crea il tuo annuncio",
+      "steps": [
+        {
+          "title": "Crea il tuo account",
+          "body": "Registrati con il tuo indirizzo email per iniziare. Configura il tuo profilo con la località e un nome visualizzato. Il tuo profilo aiuta gli acquirenti a capire con chi hanno a che fare.",
+          "tipLabel": "Consiglio sul profilo:",
+          "tip": "Un profilo completo con foto crea fiducia nei potenziali acquirenti."
+        },
+        {
+          "title": "Prepara il tuo annuncio",
+          "body": "Scatta foto di qualità da tutte le angolazioni: esterno della carrozzeria, vano motore, interni, sottoscocca ed eventuali dettagli o difetti particolari. Scrivi una descrizione dettagliata con storia, modifiche, note sulle condizioni e ciò che rende speciale la tua Mini.",
+          "tipLabel": "Consigli sulle foto:",
+          "tip": "Pulisci la tua Mini prima di fotografarla. Una buona illuminazione e più angolazioni aiutano gli acquirenti a capire le condizioni. Non nascondere i difetti: la trasparenza crea fiducia."
+        },
+        {
+          "title": "Pubblica il tuo annuncio",
+          "body": "Compila il modulo dell'annuncio con tutti i dettagli: anno, modello, chilometraggio, prezzo, località e condizioni. Carica le tue foto organizzate per categoria (carrozzeria, motore, interni, dettagli). Controlla e pubblica il tuo annuncio.",
+          "tipLabel": "Consiglio sul prezzo:",
+          "tip": "Informati su Mini simili per fissare un prezzo equo. Considera le condizioni della tua Mini, le modifiche ed eventuali extra inclusi."
+        },
+        {
+          "title": "Rispondi alle richieste",
+          "body": "Quando gli acquirenti ti scrivono con domande, rispondi prontamente e con onestà. Sii pronto a fornire altre foto, rispondere a domande dettagliate e organizzare visioni per gli acquirenti seri.",
+          "tipLabel": "Consiglio sulla comunicazione:",
+          "tip": "Risposte rapide e oneste aiutano a chiudere prima gli affari. Sii trasparente sui difetti e stabilisci aspettative chiare."
+        },
+        {
+          "title": "Concludi la vendita",
+          "body": "Quando hai trovato l'acquirente giusto e concordato le condizioni, organizza un luogo d'incontro sicuro per lo scambio. Dopo la vendita, contrassegna il tuo annuncio come venduto per avvisare gli altri acquirenti interessati.",
+          "tipLabel": "Prima la sicurezza:",
+          "tip": "Incontratevi in luoghi pubblici per le visioni. Accetta metodi di pagamento sicuri e trasferisci il libretto correttamente secondo le normative locali."
+        }
+      ]
+    },
+    "faq": {
+      "title": "Domande frequenti",
+      "items": [
+        {
+          "question": "The Mini Exchange è gratuito?",
+          "answer": "Sì! Creare un account, sfogliare gli annunci e pubblicare i propri è completamente gratuito. Stiamo costruendo questa piattaforma per la community Mini."
+        },
+        {
+          "question": "Come funzionano i pagamenti?",
+          "answer": "The Mini Exchange è una piattaforma di annunci — non elaboriamo pagamenti. Acquirenti e venditori organizzano pagamento e trasferimento direttamente. Consigliamo metodi di pagamento sicuri come bonifici bancari o servizi di deposito a garanzia per le transazioni di alto valore."
+        },
+        {
+          "question": "Cosa succede in caso di controversia con un acquirente o venditore?",
+          "answer": "Pur fornendo la piattaforma per i contatti, le transazioni avvengono direttamente tra acquirenti e venditori. Incoraggiamo la trasparenza, una comunicazione approfondita e le ispezioni di persona. Se riscontri attività fraudolente, segnalacele immediatamente."
+        },
+        {
+          "question": "Posso modificare il mio annuncio dopo la pubblicazione?",
+          "answer": "Assolutamente! Puoi modificare i dettagli dell'annuncio, aggiungere o rimuovere foto, aggiornare il prezzo o contrassegnarlo come venduto in qualsiasi momento dalla tua dashboard."
+        },
+        {
+          "question": "Spedite le Classic Mini o aiutate con il trasporto?",
+          "answer": "Non forniamo servizi di spedizione, ma molti acquirenti e venditori organizzano il trasporto tramite aziende specializzate nelle auto d'epoca. Acquirenti e venditori coordinano trasporto e costi direttamente."
+        },
+        {
+          "question": "Quali tipi di Classic Mini posso pubblicare?",
+          "answer": "Tutte le Classic Mini dal 1959 al 2000 sono benvenute! Questo include Mini originali, modelli Cooper S, station wagon Clubman, Traveller, Pickup, furgoni, edizioni limitate e auto da restaurare. Se è una Classic Mini, il suo posto è qui."
+        },
+        {
+          "question": "Quali ricambi e accessori posso pubblicare?",
+          "answer": "Accettiamo tutti i ricambi e gli accessori utili ai proprietari di Classic Mini — non solo i pezzi originali o di primo equipaggiamento. Upgrade aftermarket, strumenti di messa a punto, strumentazione, parti per prestazioni e accessori comunemente usati sulle Classic Mini sono tutti appropriati. Per esempio, un controller wideband Innovate usato per la regolazione del carburatore ci sta benissimo. La chiave è la pertinenza: se un proprietario di Mini lo trova utile, pubblicalo! Chiediamo solo che gli annunci restino pertinenti alla community Classic Mini ed evitino articoli automobilistici generici completamente estranei."
+        }
+      ]
+    },
+    "questions": {
+      "title": "Hai ancora domande?",
+      "body": "Siamo qui per aiutarti. Contattaci se hai bisogno di assistenza o hai suggerimenti per migliorare la piattaforma.",
+      "button": "Contattaci"
+    },
+    "seo": {
+      "title": "Come funziona - The Mini Exchange",
+      "description": "Scopri come comprare e vendere su The Mini Exchange. Una guida semplice per pubblicare la tua Classic Mini, i ricambi o il motore.",
+      "ogDescription": "Una guida semplice per comprare e vendere Classic Mini, ricambi e motori su The Mini Exchange."
+    }
+  },
+  "pt": {
+    "hero": {
+      "title": "Como funciona",
+      "subtitle": "Uma plataforma simples e direta para comprar e vender Classic Minis"
+    },
+    "tabs": { "buyers": "Para compradores", "sellers": "Para vendedores" },
+    "buyers": {
+      "srTitle": "Passos para compradores",
+      "cta": "Começar a explorar anúncios",
+      "steps": [
+        {
+          "title": "Explore os anúncios",
+          "body": "Conheça nossa coleção de Classic Minis de todo o mundo. Use os filtros para refinar por modelo, ano, localização, faixa de preço e estado.",
+          "tipLabel": "Dica:",
+          "tip": "Adicione anúncios à sua lista de observação para acompanhar mudanças de preço e ser avisado quando os vendedores responderem às suas mensagens."
+        },
+        {
+          "title": "Veja os anúncios detalhados",
+          "body": "Cada anúncio inclui detalhes completos: especificações completas, histórico de modificações, várias galerias de fotos (carroceria, motor, interior, detalhes) e notas do vendedor sobre estado e história.",
+          "tipLabel": "O que observar:",
+          "tip": "Verifique as fotos com cuidado, leia as notas de estado do vendedor e observe quaisquer modificações ou peças não originais. Faça perguntas se algo não estiver claro."
+        },
+        {
+          "title": "Entre em contato com o vendedor",
+          "body": "Use nosso sistema de mensagens integrado para tirar dúvidas, pedir mais fotos ou marcar uma visita. Toda a comunicação fica na plataforma até você estar pronto para se conectar diretamente.",
+          "tipLabel": "Segurança em primeiro lugar:",
+          "tip": "Sempre que possível, inspecione o carro pessoalmente e considere levar um amigo ou mecânico experiente. Nunca envie pagamento antes de ver o veículo."
+        },
+        {
+          "title": "Conclua o negócio",
+          "body": "Depois de inspecionar o Mini e acertar os termos, finalize a compra. O vendedor pode marcar o anúncio como vendido e você pode deixar uma avaliação sobre sua experiência.",
+          "tipLabel": "Após a compra:",
+          "tip": "Junte-se à comunidade! Compartilhe a história do seu novo Mini, peça conselhos e conecte-se com outros entusiastas."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "Passos para vendedores",
+      "cta": "Crie seu anúncio",
+      "steps": [
+        {
+          "title": "Crie sua conta",
+          "body": "Cadastre-se com seu e-mail para começar. Configure seu perfil com sua localização e um nome de exibição. Seu perfil ajuda os compradores a entender com quem estão lidando.",
+          "tipLabel": "Dica de perfil:",
+          "tip": "Um perfil completo com foto gera confiança nos compradores em potencial."
+        },
+        {
+          "title": "Prepare seu anúncio",
+          "body": "Tire fotos de qualidade de todos os ângulos: exterior da carroceria, compartimento do motor, interior, parte inferior e quaisquer detalhes ou problemas especiais. Escreva uma descrição detalhada incluindo histórico, modificações, notas de estado e o que torna seu Mini especial.",
+          "tipLabel": "Dicas de fotos:",
+          "tip": "Limpe seu Mini antes de fotografar. Boa iluminação e vários ângulos ajudam os compradores a entender o estado. Não esconda problemas — a transparência gera confiança."
+        },
+        {
+          "title": "Publique seu anúncio",
+          "body": "Preencha o formulário do anúncio com todos os detalhes: ano, modelo, quilometragem, preço, localização e estado. Envie suas fotos organizadas por categoria (carroceria, motor, interior, detalhes). Revise e publique seu anúncio.",
+          "tipLabel": "Dica de preço:",
+          "tip": "Pesquise Minis semelhantes para definir um preço justo. Considere o estado do seu Mini, as modificações e quaisquer extras incluídos."
+        },
+        {
+          "title": "Responda às consultas",
+          "body": "Quando os compradores enviarem perguntas, responda com rapidez e honestidade. Esteja preparado para fornecer mais fotos, responder perguntas detalhadas e marcar visitas para compradores sérios.",
+          "tipLabel": "Dica de comunicação:",
+          "tip": "Respostas rápidas e honestas ajudam a fechar negócios mais depressa. Seja transparente sobre quaisquer problemas e estabeleça expectativas claras."
+        },
+        {
+          "title": "Feche a venda",
+          "body": "Depois de encontrar o comprador certo e acertar os termos, combine um local de encontro seguro para a troca. Após a venda, marque seu anúncio como vendido para avisar outros compradores interessados.",
+          "tipLabel": "Segurança em primeiro lugar:",
+          "tip": "Encontrem-se em locais públicos para as visitas. Aceite métodos de pagamento seguros e transfira a documentação corretamente de acordo com as normas locais."
+        }
+      ]
+    },
+    "faq": {
+      "title": "Perguntas frequentes",
+      "items": [
+        {
+          "question": "O The Mini Exchange é gratuito?",
+          "answer": "Sim! Criar uma conta, explorar anúncios e publicar os seus é totalmente gratuito. Estamos construindo esta plataforma para a comunidade Mini."
+        },
+        {
+          "question": "Como funcionam os pagamentos?",
+          "answer": "O The Mini Exchange é uma plataforma de anúncios — não processamos pagamentos. Compradores e vendedores combinam pagamento e transferência diretamente. Recomendamos métodos de pagamento seguros, como transferências bancárias ou serviços de custódia, para transações de alto valor."
+        },
+        {
+          "question": "E se houver uma disputa com um comprador ou vendedor?",
+          "answer": "Embora forneçamos a plataforma para conexões, as transações acontecem diretamente entre compradores e vendedores. Incentivamos a transparência, a comunicação completa e as inspeções presenciais. Se você encontrar atividade fraudulenta, denuncie a nós imediatamente."
+        },
+        {
+          "question": "Posso editar meu anúncio depois de publicar?",
+          "answer": "Com certeza! Você pode editar os detalhes do anúncio, adicionar ou remover fotos, atualizar o preço ou marcá-lo como vendido a qualquer momento no seu painel."
+        },
+        {
+          "question": "Vocês enviam Classic Minis ou ajudam com o transporte?",
+          "answer": "Não oferecemos serviços de envio, mas muitos compradores e vendedores organizam o transporte por meio de empresas especializadas em carros clássicos. Compradores e vendedores coordenam transporte e custos diretamente."
+        },
+        {
+          "question": "Que tipos de Classic Minis posso anunciar?",
+          "answer": "Todos os Classic Minis de 1959 a 2000 são bem-vindos! Isso inclui Minis originais, modelos Cooper S, peruas Clubman, Travellers, Pickups, vans, edições limitadas e carros de projeto. Se é um Classic Mini, o lugar dele é aqui."
+        },
+        {
+          "question": "Que peças e acessórios posso anunciar?",
+          "answer": "Aceitamos todas as peças e acessórios úteis aos donos de Classic Mini — não apenas peças originais ou de primeira linha. Upgrades de reposição, ferramentas de acerto, instrumentos, peças de desempenho e acessórios comumente usados em Classic Minis são todos apropriados. Por exemplo, um controlador wideband Innovate que você usou para acertar o carburador cabe perfeitamente aqui. O importante é a relevância: se um dono de Mini achar útil, anuncie! Pedimos apenas que os anúncios sejam relevantes para a comunidade Classic Mini e evitem itens automotivos gerais totalmente sem relação."
+        }
+      ]
+    },
+    "questions": {
+      "title": "Ainda tem dúvidas?",
+      "body": "Estamos aqui para ajudar. Fale conosco se precisar de ajuda ou tiver sugestões para melhorar a plataforma.",
+      "button": "Fale conosco"
+    },
+    "seo": {
+      "title": "Como funciona - The Mini Exchange",
+      "description": "Saiba como comprar e vender no The Mini Exchange. Um guia simples para anunciar seu Classic Mini, peças ou motor.",
+      "ogDescription": "Um guia simples para comprar e vender Classic Minis, peças e motores no The Mini Exchange."
+    }
+  },
+  "ru": {
+    "hero": {
+      "title": "Как это работает",
+      "subtitle": "Простая и понятная площадка для покупки и продажи Classic Mini"
+    },
+    "tabs": { "buyers": "Для покупателей", "sellers": "Для продавцов" },
+    "buyers": {
+      "srTitle": "Шаги для покупателей",
+      "cta": "Начать просмотр объявлений",
+      "steps": [
+        {
+          "title": "Просматривайте объявления",
+          "body": "Изучайте нашу подборку Classic Mini со всего мира. Используйте фильтры, чтобы сузить выбор по модели, году, местоположению, диапазону цен и состоянию.",
+          "tipLabel": "Совет:",
+          "tip": "Добавляйте объявления в список отслеживания, чтобы следить за изменением цен и получать уведомления, когда продавцы отвечают на ваши сообщения."
+        },
+        {
+          "title": "Изучайте подробные объявления",
+          "body": "Каждое объявление содержит исчерпывающую информацию: полные характеристики, историю доработок, несколько фотогалерей (кузов, двигатель, салон, детали) и заметки продавца о состоянии и истории.",
+          "tipLabel": "На что обратить внимание:",
+          "tip": "Внимательно изучите фотографии, прочитайте заметки продавца о состоянии и отметьте любые доработки или неоригинальные детали. Задавайте вопросы, если что-то неясно."
+        },
+        {
+          "title": "Свяжитесь с продавцом",
+          "body": "Используйте встроенную систему сообщений, чтобы задать вопросы, запросить дополнительные фотографии или договориться об осмотре. Всё общение остаётся на площадке, пока вы не будете готовы связаться напрямую.",
+          "tipLabel": "Безопасность прежде всего:",
+          "tip": "По возможности всегда осматривайте машину лично и подумайте о том, чтобы взять с собой знающего друга или механика. Никогда не отправляйте оплату до осмотра автомобиля."
+        },
+        {
+          "title": "Завершите сделку",
+          "body": "Осмотрев Mini и согласовав условия, завершите покупку. Продавец может отметить объявление как проданное, а вы — оставить отзыв о своём опыте.",
+          "tipLabel": "После покупки:",
+          "tip": "Присоединяйтесь к сообществу! Поделитесь историей своего нового Mini, попросите совета и познакомьтесь с другими энтузиастами."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "Шаги для продавцов",
+      "cta": "Создать объявление",
+      "steps": [
+        {
+          "title": "Создайте аккаунт",
+          "body": "Зарегистрируйтесь по электронной почте, чтобы начать. Заполните профиль с указанием местоположения и отображаемого имени. Профиль помогает покупателям понять, с кем они имеют дело.",
+          "tipLabel": "Совет по профилю:",
+          "tip": "Полный профиль с фотографией вызывает доверие у потенциальных покупателей."
+        },
+        {
+          "title": "Подготовьте объявление",
+          "body": "Сделайте качественные фотографии со всех ракурсов: кузов снаружи, моторный отсек, салон, днище и любые особые детали или дефекты. Напишите подробное описание с историей, доработками, заметками о состоянии и тем, что делает ваш Mini особенным.",
+          "tipLabel": "Советы по фото:",
+          "tip": "Помойте Mini перед съёмкой. Хорошее освещение и несколько ракурсов помогают покупателям понять состояние. Не скрывайте дефекты — открытость вызывает доверие."
+        },
+        {
+          "title": "Опубликуйте объявление",
+          "body": "Заполните форму объявления всеми данными: год, модель, пробег, цена, местоположение и состояние. Загрузите фотографии, сгруппированные по категориям (кузов, двигатель, салон, детали). Проверьте и опубликуйте объявление.",
+          "tipLabel": "Совет по цене:",
+          "tip": "Изучите похожие Mini, чтобы назначить справедливую цену. Учитывайте состояние своего Mini, доработки и любые входящие в комплект дополнения."
+        },
+        {
+          "title": "Отвечайте на запросы",
+          "body": "Когда покупатели пишут вам с вопросами, отвечайте быстро и честно. Будьте готовы предоставить дополнительные фото, ответить на подробные вопросы и организовать осмотр для серьёзных покупателей.",
+          "tipLabel": "Совет по общению:",
+          "tip": "Быстрые и честные ответы помогают быстрее закрывать сделки. Честно сообщайте о дефектах и задавайте ясные ожидания."
+        },
+        {
+          "title": "Завершите продажу",
+          "body": "Найдя подходящего покупателя и согласовав условия, договоритесь о безопасном месте встречи для передачи. После продажи отметьте объявление как проданное, чтобы оповестить других заинтересованных покупателей.",
+          "tipLabel": "Безопасность прежде всего:",
+          "tip": "Для осмотров встречайтесь в общественных местах. Принимайте безопасные способы оплаты и оформляйте переоформление надлежащим образом в соответствии с местными правилами."
+        }
+      ]
+    },
+    "faq": {
+      "title": "Часто задаваемые вопросы",
+      "items": [
+        {
+          "question": "Пользоваться The Mini Exchange бесплатно?",
+          "answer": "Да! Создание аккаунта, просмотр объявлений и публикация собственных объявлений полностью бесплатны. Мы создаём эту площадку для сообщества Mini."
+        },
+        {
+          "question": "Как работают платежи?",
+          "answer": "The Mini Exchange — это площадка-маркетплейс: мы не обрабатываем платежи. Покупатели и продавцы договариваются об оплате и передаче напрямую. Для дорогих сделок мы рекомендуем безопасные способы оплаты, например банковские переводы или эскроу-сервисы."
+        },
+        {
+          "question": "Что делать при споре с покупателем или продавцом?",
+          "answer": "Мы предоставляем площадку для контактов, но сделки происходят напрямую между покупателями и продавцами. Мы призываем к прозрачности, тщательному общению и личным осмотрам. Если вы столкнулись с мошеннической деятельностью, немедленно сообщите нам об этом."
+        },
+        {
+          "question": "Можно ли редактировать объявление после публикации?",
+          "answer": "Конечно! Вы можете в любое время изменить данные объявления, добавить или удалить фотографии, обновить цену или отметить его как проданное в своей панели управления."
+        },
+        {
+          "question": "Доставляете ли вы Classic Mini или помогаете с перевозкой?",
+          "answer": "Мы не предоставляем услуги доставки, но многие покупатели и продавцы организуют перевозку через специализированные компании по транспортировке классических автомобилей. Покупатели и продавцы согласовывают перевозку и расходы напрямую."
+        },
+        {
+          "question": "Какие типы Classic Mini можно размещать?",
+          "answer": "Приветствуются все Classic Mini с 1959 по 2000 год! Это включает оригинальные Mini, модели Cooper S, универсалы Clubman, Traveller, пикапы, фургоны, ограниченные серии и проектные автомобили. Если это Classic Mini, ему здесь самое место."
+        },
+        {
+          "question": "Какие детали и аксессуары можно размещать?",
+          "answer": "Мы принимаем все детали и аксессуары, полезные владельцам Classic Mini, — не только оригинальные или заводские детали Mini. Доработки сторонних производителей, инструменты для настройки, приборы, тюнинговые детали и аксессуары, широко используемые на Classic Mini, — всё это уместно. Например, широкополосный контроллер Innovate, который вы использовали для настройки карбюратора, безусловно, сюда подходит. Главное — это уместность: если владельцу Mini это будет полезно, размещайте! Мы лишь просим, чтобы объявления оставались актуальными для сообщества Classic Mini и избегали совершенно не связанных с темой общеавтомобильных товаров."
+        }
+      ]
+    },
+    "questions": {
+      "title": "Остались вопросы?",
+      "body": "Мы готовы помочь. Свяжитесь с нами, если вам нужна помощь или есть предложения по улучшению площадки.",
+      "button": "Связаться с нами"
+    },
+    "seo": {
+      "title": "Как это работает - The Mini Exchange",
+      "description": "Узнайте, как покупать и продавать на The Mini Exchange. Простое руководство по размещению вашего Classic Mini, запчастей или двигателя.",
+      "ogDescription": "Простое руководство по покупке и продаже Classic Mini, запчастей и двигателей на The Mini Exchange."
+    }
+  },
+  "ja": {
+    "hero": {
+      "title": "ご利用の流れ",
+      "subtitle": "Classic Mini を売買するためのシンプルで分かりやすいプラットフォーム"
+    },
+    "tabs": { "buyers": "購入する方へ", "sellers": "販売する方へ" },
+    "buyers": {
+      "srTitle": "購入の手順",
+      "cta": "出品を見てみる",
+      "steps": [
+        {
+          "title": "出品を探す",
+          "body": "世界中の Classic Mini のコレクションを探せます。フィルターを使って、モデル、年式、地域、価格帯、状態で絞り込めます。",
+          "tipLabel": "ワンポイント：",
+          "tip": "出品をウォッチリストに追加すると、価格の変動を追跡でき、出品者がメッセージに返信した際に通知を受け取れます。"
+        },
+        {
+          "title": "詳細な出品を見る",
+          "body": "各出品には充実した情報が含まれます。詳細なスペック、改造履歴、複数の写真ギャラリー（ボディ、エンジン、内装、ディテール）、状態や履歴に関する出品者のメモなどです。",
+          "tipLabel": "確認すべき点：",
+          "tip": "写真をよく確認し、出品者の状態メモを読み、改造や非純正部品に注意しましょう。不明な点があれば質問してください。"
+        },
+        {
+          "title": "出品者に連絡する",
+          "body": "組み込みのメッセージ機能を使って質問したり、追加の写真を依頼したり、現車確認の日程を調整したりできます。直接やり取りする準備ができるまで、すべての連絡はプラットフォーム上に残ります。",
+          "tipLabel": "安全第一：",
+          "tip": "可能な限り必ず現車を直接確認し、詳しい友人や整備士に同行してもらうことを検討してください。車両を見る前に支払いを送ってはいけません。"
+        },
+        {
+          "title": "取引を完了する",
+          "body": "Mini を確認し条件に合意したら、購入を確定します。出品者は出品を売却済みにでき、あなたは取引の感想を残せます。",
+          "tipLabel": "購入後は：",
+          "tip": "コミュニティに参加しましょう！新しい Mini のストーリーを共有し、アドバイスを求め、他の愛好家とつながりましょう。"
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "販売の手順",
+      "cta": "出品を作成する",
+      "steps": [
+        {
+          "title": "アカウントを作成する",
+          "body": "メールアドレスで登録して始めましょう。所在地と表示名でプロフィールを設定します。プロフィールは、買い手が誰と取引しているかを理解する助けになります。",
+          "tipLabel": "プロフィールのコツ：",
+          "tip": "プロフィール写真付きの充実したプロフィールは、見込み客の信頼を高めます。"
+        },
+        {
+          "title": "出品を準備する",
+          "body": "あらゆる角度から高品質な写真を撮りましょう。ボディの外観、エンジンルーム、内装、車体下部、特別なディテールや不具合などです。履歴、改造、状態メモ、そしてあなたの Mini を特別にしている点を含む詳細な説明を書きましょう。",
+          "tipLabel": "写真のコツ：",
+          "tip": "撮影前に Mini を清掃しましょう。良い照明と複数の角度は、買い手が状態を理解するのに役立ちます。不具合を隠さないこと——透明性が信頼を生みます。"
+        },
+        {
+          "title": "出品を投稿する",
+          "body": "出品フォームにすべての詳細を記入します。年式、モデル、走行距離、価格、所在地、状態などです。カテゴリ別（ボディ、エンジン、内装、ディテール）に整理した写真をアップロードします。内容を確認して出品を公開しましょう。",
+          "tipLabel": "価格設定のコツ：",
+          "tip": "適正価格を設定するために類似の Mini を調べましょう。あなたの Mini の状態、改造、付属する付属品を考慮してください。"
+        },
+        {
+          "title": "問い合わせに対応する",
+          "body": "買い手から質問のメッセージが届いたら、迅速かつ正直に対応しましょう。追加の写真の提供、詳細な質問への回答、本気の買い手との現車確認の調整に備えてください。",
+          "tipLabel": "コミュニケーションのコツ：",
+          "tip": "迅速で正直な返信は取引を早くまとめる助けになります。不具合については率直に伝え、明確な期待値を設定しましょう。"
+        },
+        {
+          "title": "販売を成立させる",
+          "body": "適切な買い手が見つかり条件に合意したら、受け渡しのための安全な待ち合わせ場所を手配しましょう。販売後は、他の関心のある買い手に知らせるため、出品を売却済みにしましょう。",
+          "tipLabel": "安全第一：",
+          "tip": "現車確認は公共の場所で行いましょう。安全な支払い方法を受け入れ、現地の規則に従って名義変更を適切に行ってください。"
+        }
+      ]
+    },
+    "faq": {
+      "title": "よくある質問",
+      "items": [
+        {
+          "question": "The Mini Exchange は無料で利用できますか？",
+          "answer": "はい！アカウントの作成、出品の閲覧、自分の出品の投稿はすべて無料です。私たちは Mini コミュニティのためにこのプラットフォームを構築しています。"
+        },
+        {
+          "question": "支払いはどのように行われますか？",
+          "answer": "The Mini Exchange はマーケットプレイス・プラットフォームであり、支払いの処理は行いません。買い手と売り手が直接、支払いと受け渡しを取り決めます。高額の取引には、銀行振込やエスクローサービスなどの安全な支払い方法をおすすめします。"
+        },
+        {
+          "question": "買い手や売り手との間でトラブルが起きたら？",
+          "answer": "私たちは接点となるプラットフォームを提供していますが、取引は買い手と売り手の間で直接行われます。透明性、十分なやり取り、現車確認をおすすめします。不正行為に遭遇した場合は、直ちにご報告ください。"
+        },
+        {
+          "question": "投稿後に出品を編集できますか？",
+          "answer": "もちろんです！ダッシュボードからいつでも、出品の詳細を編集したり、写真を追加・削除したり、価格を更新したり、売却済みにしたりできます。"
+        },
+        {
+          "question": "Classic Mini の配送や輸送の手配はしてもらえますか？",
+          "answer": "配送サービスは提供していませんが、多くの買い手と売り手はクラシックカー専門の輸送会社を通じて輸送を手配しています。買い手と売り手が直接、輸送と費用を調整します。"
+        },
+        {
+          "question": "どんな種類の Classic Mini を出品できますか？",
+          "answer": "1959年から2000年までのすべての Classic Mini を歓迎します！オリジナルの Mini、Cooper S、Clubman エステート、Traveller、ピックアップ、バン、限定モデル、プロジェクトカーなどが含まれます。Classic Mini なら、ここがその居場所です。"
+        },
+        {
+          "question": "どんな部品やアクセサリーを出品できますか？",
+          "answer": "Classic Mini オーナーに役立つ部品やアクセサリーはすべて歓迎します——純正品や一次サプライヤーの Mini 部品に限りません。社外品のアップグレード、調整用ツール、メーター、パフォーマンス部品、Classic Mini でよく使われるアクセサリーはすべて適切です。たとえば、キャブ調整に使った Innovate のワイドバンドコントローラーは間違いなくここに合っています。重要なのは関連性です。Mini オーナーが役立つと思うものなら、出品してください！ただ、出品は Classic Mini コミュニティに関連するものに保ち、まったく関係のない一般的な自動車用品は避けてください。"
+        }
+      ]
+    },
+    "questions": {
+      "title": "まだ質問がありますか？",
+      "body": "私たちがお手伝いします。サポートが必要な場合や、プラットフォームの改善に関するご提案があれば、お気軽にご連絡ください。",
+      "button": "お問い合わせ"
+    },
+    "seo": {
+      "title": "ご利用の流れ - The Mini Exchange",
+      "description": "The Mini Exchange での売買方法をご紹介します。Classic Mini、部品、エンジンを出品するためのシンプルなガイドです。",
+      "ogDescription": "The Mini Exchange で Classic Mini や部品、エンジンを売買するためのシンプルなガイド。"
+    }
+  },
+  "zh": {
+    "hero": {
+      "title": "运作方式",
+      "subtitle": "一个简单直接的 Classic Mini 买卖平台"
+    },
+    "tabs": { "buyers": "买家专区", "sellers": "卖家专区" },
+    "buyers": {
+      "srTitle": "买家步骤",
+      "cta": "开始浏览刊登",
+      "steps": [
+        {
+          "title": "浏览刊登",
+          "body": "探索我们来自世界各地的 Classic Mini 收藏。使用筛选条件按车型、年份、所在地、价格区间和车况缩小范围。",
+          "tipLabel": "小贴士：",
+          "tip": "将刊登加入关注列表，即可追踪价格变化，并在卖家回复你的消息时收到通知。"
+        },
+        {
+          "title": "查看详细刊登",
+          "body": "每条刊登都包含全面的信息：完整规格、改装历史、多个图片库（车身、发动机、内饰、细节），以及卖家关于车况和历史的说明。",
+          "tipLabel": "需留意的方面：",
+          "tip": "仔细查看照片，阅读卖家的车况说明，并留意任何改装或非原厂部件。如有不清楚的地方请提问。"
+        },
+        {
+          "title": "联系卖家",
+          "body": "使用我们内置的消息系统提问、索取更多照片或安排看车。在你准备好直接联系之前，所有沟通都会保留在平台上。",
+          "tipLabel": "安全第一：",
+          "tip": "尽可能始终亲自检查车辆，并考虑带上懂行的朋友或技师。在看到车辆之前，切勿付款。"
+        },
+        {
+          "title": "完成交易",
+          "body": "在你检查 Mini 并就条款达成一致后，完成购买。卖家可将刊登标记为已售出，你也可以对自己的体验留下评价。",
+          "tipLabel": "购买之后：",
+          "tip": "加入社区吧！分享你新 Mini 的故事，寻求建议，并与其他爱好者交流。"
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "卖家步骤",
+      "cta": "创建你的刊登",
+      "steps": [
+        {
+          "title": "创建账户",
+          "body": "用你的电子邮箱注册即可开始。设置个人资料，填写所在地和显示名称。你的资料有助于买家了解他们在与谁打交道。",
+          "tipLabel": "资料贴士：",
+          "tip": "一份带头像的完整资料能增进潜在买家的信任。"
+        },
+        {
+          "title": "准备你的刊登",
+          "body": "从各个角度拍摄高质量照片：车身外观、发动机舱、内饰、底盘，以及任何特殊细节或问题。撰写详细描述，包括历史、改装、车况说明，以及你的 Mini 的特别之处。",
+          "tipLabel": "拍照贴士：",
+          "tip": "拍照前请清洁你的 Mini。良好的光线和多个角度能帮助买家了解车况。不要隐瞒问题——透明能建立信任。"
+        },
+        {
+          "title": "发布你的刊登",
+          "body": "在刊登表单中填写所有细节：年份、车型、里程、价格、所在地和车况。按类别（车身、发动机、内饰、细节）整理并上传照片。检查并发布你的刊登。",
+          "tipLabel": "定价贴士：",
+          "tip": "研究类似的 Mini 以制定公平的价格。考虑你 Mini 的车况、改装以及任何附带的额外配件。"
+        },
+        {
+          "title": "回复咨询",
+          "body": "当买家发来问题时，请及时且诚实地回复。准备好提供更多照片、回答详细问题，并为认真的买家安排看车。",
+          "tipLabel": "沟通贴士：",
+          "tip": "迅速、诚实的回复有助于更快达成交易。坦诚说明任何问题，并设定清晰的预期。"
+        },
+        {
+          "title": "完成销售",
+          "body": "在找到合适的买家并就条款达成一致后，安排一个安全的见面地点进行交接。销售完成后，将你的刊登标记为已售出，以告知其他感兴趣的买家。",
+          "tipLabel": "安全第一：",
+          "tip": "在公共场所见面看车。接受安全的付款方式，并按照当地法规妥善办理过户。"
+        }
+      ]
+    },
+    "faq": {
+      "title": "常见问题",
+      "items": [
+        {
+          "question": "使用 The Mini Exchange 收费吗？",
+          "answer": "免费！创建账户、浏览刊登以及发布自己的刊登都完全免费。我们正在为 Mini 社区打造这个平台。"
+        },
+        {
+          "question": "付款是如何进行的？",
+          "answer": "The Mini Exchange 是一个市场平台——我们不处理付款。买卖双方直接安排付款和交接。对于高价值交易，我们建议使用银行转账或第三方托管服务等安全的付款方式。"
+        },
+        {
+          "question": "如果与买家或卖家发生纠纷怎么办？",
+          "answer": "虽然我们提供联系平台，但交易直接在买卖双方之间进行。我们鼓励透明、充分的沟通和当面检查。如果你遇到欺诈行为，请立即向我们举报。"
+        },
+        {
+          "question": "发布后可以编辑我的刊登吗？",
+          "answer": "当然可以！你可以随时在控制面板中编辑刊登详情、添加或删除照片、更新价格，或将其标记为已售出。"
+        },
+        {
+          "question": "你们运送 Classic Mini 或协助运输吗？",
+          "answer": "我们不提供运输服务，但许多买家和卖家会通过专门的经典车运输公司安排运输。买卖双方直接协调运输和费用。"
+        },
+        {
+          "question": "我可以刊登哪些类型的 Classic Mini？",
+          "answer": "欢迎所有 1959 至 2000 年的 Classic Mini！这包括原版 Mini、Cooper S 车型、Clubman 旅行版、Traveller、皮卡、厢式车、限量版以及待修复的项目车。只要是 Classic Mini，这里就是它的归属。"
+        },
+        {
+          "question": "我可以刊登哪些零件和配件？",
+          "answer": "我们欢迎所有对 Classic Mini 车主有用的零件和配件——不仅限于原厂或一线 Mini 零件。售后升级件、调校工具、仪表、性能件以及 Classic Mini 上常用的配件都很合适。例如，你用来调校化油器的 Innovate 宽频控制器绝对适合放在这里。关键在于相关性：只要 Mini 车主觉得有用，就刊登吧！我们只要求刊登与 Classic Mini 社区相关，避免完全无关的通用汽车用品。"
+        }
+      ]
+    },
+    "questions": {
+      "title": "还有疑问吗？",
+      "body": "我们随时为你提供帮助。如果你需要协助，或对改进平台有任何建议，请与我们联系。",
+      "button": "联系我们"
+    },
+    "seo": {
+      "title": "运作方式 - The Mini Exchange",
+      "description": "了解如何在 The Mini Exchange 上买卖。一份刊登你的 Classic Mini、零件或发动机的简单指南。",
+      "ogDescription": "一份在 The Mini Exchange 上买卖 Classic Mini、零件和发动机的简单指南。"
+    }
+  },
+  "ko": {
+    "hero": {
+      "title": "이용 방법",
+      "subtitle": "Classic Mini를 사고팔 수 있는 간단하고 직관적인 플랫폼"
+    },
+    "tabs": { "buyers": "구매자용", "sellers": "판매자용" },
+    "buyers": {
+      "srTitle": "구매자 단계",
+      "cta": "매물 둘러보기 시작",
+      "steps": [
+        {
+          "title": "매물 둘러보기",
+          "body": "전 세계의 Classic Mini 컬렉션을 살펴보세요. 필터를 사용해 모델, 연식, 위치, 가격대, 상태로 범위를 좁힐 수 있습니다.",
+          "tipLabel": "팁:",
+          "tip": "매물을 관심 목록에 추가하면 가격 변동을 추적하고 판매자가 메시지에 답하면 알림을 받을 수 있습니다."
+        },
+        {
+          "title": "상세 매물 보기",
+          "body": "각 매물에는 상세한 정보가 담겨 있습니다. 전체 사양, 개조 이력, 여러 사진 갤러리(차체, 엔진, 실내, 디테일), 그리고 상태와 이력에 대한 판매자 메모가 포함됩니다.",
+          "tipLabel": "확인할 점:",
+          "tip": "사진을 꼼꼼히 확인하고 판매자의 상태 메모를 읽으며 개조나 비순정 부품이 있는지 살펴보세요. 불분명한 점이 있으면 질문하세요."
+        },
+        {
+          "title": "판매자에게 연락하기",
+          "body": "내장 메시지 시스템을 사용해 질문하거나, 추가 사진을 요청하거나, 실차 확인 일정을 잡으세요. 직접 연락할 준비가 될 때까지 모든 소통은 플랫폼 안에서 유지됩니다.",
+          "tipLabel": "안전이 우선:",
+          "tip": "가능하면 항상 직접 차량을 점검하고, 잘 아는 친구나 정비사를 데려가는 것을 고려하세요. 차량을 보기 전에는 절대 대금을 보내지 마세요."
+        },
+        {
+          "title": "거래 완료하기",
+          "body": "Mini를 점검하고 조건에 합의했다면 구매를 마무리하세요. 판매자는 매물을 판매 완료로 표시할 수 있고, 여러분은 경험에 대한 후기를 남길 수 있습니다.",
+          "tipLabel": "구매 후에는:",
+          "tip": "커뮤니티에 참여하세요! 새 Mini 이야기를 공유하고, 조언을 구하며, 다른 애호가들과 교류하세요."
+        }
+      ]
+    },
+    "sellers": {
+      "srTitle": "판매자 단계",
+      "cta": "매물 등록하기",
+      "steps": [
+        {
+          "title": "계정 만들기",
+          "body": "이메일 주소로 가입해 시작하세요. 위치와 표시 이름으로 프로필을 설정하세요. 프로필은 구매자가 누구와 거래하는지 이해하는 데 도움이 됩니다.",
+          "tipLabel": "프로필 팁:",
+          "tip": "프로필 사진이 있는 완성된 프로필은 잠재 구매자의 신뢰를 높입니다."
+        },
+        {
+          "title": "매물 준비하기",
+          "body": "모든 각도에서 고품질 사진을 촬영하세요. 차체 외관, 엔진룸, 실내, 하부, 그리고 특별한 디테일이나 문제점입니다. 이력, 개조, 상태 메모, 그리고 여러분의 Mini가 특별한 이유를 포함한 상세 설명을 작성하세요.",
+          "tipLabel": "사진 팁:",
+          "tip": "촬영 전에 Mini를 청소하세요. 좋은 조명과 여러 각도는 구매자가 상태를 이해하는 데 도움이 됩니다. 문제점을 숨기지 마세요——투명성이 신뢰를 만듭니다."
+        },
+        {
+          "title": "매물 게시하기",
+          "body": "매물 양식에 모든 세부 정보를 입력하세요. 연식, 모델, 주행거리, 가격, 위치, 상태입니다. 카테고리별(차체, 엔진, 실내, 디테일)로 정리한 사진을 업로드하세요. 검토 후 매물을 게시하세요.",
+          "tipLabel": "가격 책정 팁:",
+          "tip": "공정한 가격을 정하기 위해 비슷한 Mini를 조사하세요. Mini의 상태, 개조, 포함된 추가 구성품을 고려하세요."
+        },
+        {
+          "title": "문의에 응답하기",
+          "body": "구매자가 질문 메시지를 보내면 신속하고 정직하게 응답하세요. 추가 사진 제공, 상세한 질문에 대한 답변, 진지한 구매자를 위한 실차 확인 일정 조율에 대비하세요.",
+          "tipLabel": "소통 팁:",
+          "tip": "빠르고 정직한 응답은 거래를 더 빨리 성사시키는 데 도움이 됩니다. 모든 문제점을 솔직히 밝히고 명확한 기대치를 설정하세요."
+        },
+        {
+          "title": "판매 마무리하기",
+          "body": "적합한 구매자를 찾고 조건에 합의했다면 안전한 만남 장소를 정해 인도를 진행하세요. 판매 후에는 다른 관심 있는 구매자에게 알리기 위해 매물을 판매 완료로 표시하세요.",
+          "tipLabel": "안전이 우선:",
+          "tip": "실차 확인은 공공장소에서 만나세요. 안전한 결제 방법을 수락하고, 현지 규정에 따라 명의 이전을 적절히 진행하세요."
+        }
+      ]
+    },
+    "faq": {
+      "title": "자주 묻는 질문",
+      "items": [
+        {
+          "question": "The Mini Exchange는 무료로 이용할 수 있나요?",
+          "answer": "네! 계정 생성, 매물 둘러보기, 자신의 매물 게시는 모두 완전히 무료입니다. 우리는 Mini 커뮤니티를 위해 이 플랫폼을 만들고 있습니다."
+        },
+        {
+          "question": "결제는 어떻게 이루어지나요?",
+          "answer": "The Mini Exchange는 마켓플레이스 플랫폼으로, 결제를 처리하지 않습니다. 구매자와 판매자가 직접 결제와 인도를 정합니다. 고액 거래의 경우 계좌 이체나 에스크로 서비스 같은 안전한 결제 방법을 권장합니다."
+        },
+        {
+          "question": "구매자나 판매자와 분쟁이 생기면 어떻게 하나요?",
+          "answer": "우리는 연결을 위한 플랫폼을 제공하지만, 거래는 구매자와 판매자 사이에서 직접 이루어집니다. 투명성, 충분한 소통, 직접 점검을 권장합니다. 사기 행위를 발견하면 즉시 신고해 주세요."
+        },
+        {
+          "question": "게시 후에 매물을 수정할 수 있나요?",
+          "answer": "물론입니다! 대시보드에서 언제든지 매물 정보를 수정하고, 사진을 추가 또는 삭제하고, 가격을 변경하거나, 판매 완료로 표시할 수 있습니다."
+        },
+        {
+          "question": "Classic Mini를 배송하거나 운송을 도와주나요?",
+          "answer": "배송 서비스는 제공하지 않지만, 많은 구매자와 판매자가 전문 클래식 카 운송 업체를 통해 운송을 준비합니다. 구매자와 판매자가 직접 운송과 비용을 조율합니다."
+        },
+        {
+          "question": "어떤 종류의 Classic Mini를 등록할 수 있나요?",
+          "answer": "1959년부터 2000년까지의 모든 Classic Mini를 환영합니다! 여기에는 오리지널 Mini, Cooper S 모델, Clubman 에스테이트, Traveller, 픽업, 밴, 한정판, 그리고 프로젝트 카가 포함됩니다. Classic Mini라면 이곳이 제자리입니다."
+        },
+        {
+          "question": "어떤 부품과 액세서리를 등록할 수 있나요?",
+          "answer": "Classic Mini 소유자에게 유용한 모든 부품과 액세서리를 환영합니다——순정이나 1차 공급사 Mini 부품에만 국한되지 않습니다. 애프터마켓 업그레이드, 튜닝 도구, 계기, 퍼포먼스 부품, Classic Mini에 흔히 사용되는 액세서리는 모두 적합합니다. 예를 들어, 카뷰레터 튜닝에 사용한 Innovate 와이드밴드 컨트롤러는 분명히 여기에 어울립니다. 핵심은 연관성입니다. Mini 소유자가 유용하다고 느낄 만한 것이라면 등록하세요! 다만 매물이 Classic Mini 커뮤니티와 관련성을 유지하고, 전혀 무관한 일반 자동차 용품은 피해 주시기를 요청드립니다."
+        }
+      ]
+    },
+    "questions": {
+      "title": "아직 궁금한 점이 있으신가요?",
+      "body": "저희가 도와드리겠습니다. 도움이 필요하거나 플랫폼 개선에 대한 제안이 있으면 연락 주세요.",
+      "button": "문의하기"
+    },
+    "seo": {
+      "title": "이용 방법 - The Mini Exchange",
+      "description": "The Mini Exchange에서 사고파는 방법을 알아보세요. Classic Mini, 부품 또는 엔진을 등록하기 위한 간단한 가이드입니다.",
+      "ogDescription": "The Mini Exchange에서 Classic Mini, 부품, 엔진을 사고파는 간단한 가이드."
+    }
+  }
+}
+</i18n>

--- a/app/pages/exchange/messages/index.vue
+++ b/app/pages/exchange/messages/index.vue
@@ -42,7 +42,7 @@
         </div>
 
         <!-- Tabs -->
-        <div role="tablist" class="tabs tabs-bordered mb-4">
+        <div role="tablist" class="tabs tabs-border mb-4">
           <button
             v-for="tab in tabs"
             :key="tab.key"

--- a/app/pages/exchange/safety.vue
+++ b/app/pages/exchange/safety.vue
@@ -1,0 +1,824 @@
+<template>
+  <div>
+    <!-- Hero -->
+    <section class="bg-base-100 border-b border-base-300 py-12">
+      <div class="container">
+        <div class="max-w-3xl">
+          <div class="flex items-center gap-3 mb-4">
+            <i class="fas fa-shield-halved text-3xl text-primary"></i>
+            <h1 class="text-4xl font-bold">{{ t('hero.title') }}</h1>
+          </div>
+          <p class="text-lg text-base-content/70">{{ t('hero.subtitle') }}</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Content -->
+    <section class="py-12">
+      <div class="container">
+        <div class="max-w-3xl space-y-12">
+          <!-- Meeting In Person -->
+          <div>
+            <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">
+              <i class="fas fa-location-dot text-primary"></i>
+              {{ t('meeting.title') }}
+            </h2>
+            <div class="space-y-3">
+              <div v-for="(tip, i) in tm('inPersonTips')" :key="i" class="flex gap-3 items-start">
+                <i class="fas fa-circle-check text-success shrink-0 mt-0.5"></i>
+                <p class="text-base-content/80">{{ rt(tip) }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Payment Safety -->
+          <div>
+            <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">
+              <i class="fas fa-money-bills text-primary"></i>
+              {{ t('payment.title') }}
+            </h2>
+
+            <div class="mb-6">
+              <h3 class="font-semibold text-lg mb-3 text-success">{{ t('payment.recommendedHeading') }}</h3>
+              <div class="grid sm:grid-cols-2 gap-3">
+                <div v-for="(method, i) in tm('recommendedPayments')" :key="i" class="card bg-success/10 p-4">
+                  <div class="font-medium text-success">{{ rt(method.name) }}</div>
+                  <div class="text-sm text-base-content/70 mt-1">{{ rt(method.reason) }}</div>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <h3 class="font-semibold text-lg mb-3 text-error">{{ t('payment.avoidHeading') }}</h3>
+              <div class="grid sm:grid-cols-2 gap-3">
+                <div v-for="(method, i) in tm('riskyPayments')" :key="i" class="card bg-error/10 p-4">
+                  <div class="font-medium text-error">{{ rt(method.name) }}</div>
+                  <div class="text-sm text-base-content/70 mt-1">{{ rt(method.reason) }}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Buying a Classic Mini -->
+          <div>
+            <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">
+              <i class="fas fa-magnifying-glass text-primary"></i>
+              {{ t('buying.title') }}
+            </h2>
+            <div class="space-y-3">
+              <div v-for="(tip, i) in tm('buyingTips')" :key="i" class="flex gap-3 items-start">
+                <i class="fas fa-circle-check text-info shrink-0 mt-0.5"></i>
+                <p class="text-base-content/80">{{ rt(tip) }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Selling Tips -->
+          <div>
+            <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">
+              <i class="fas fa-tag text-primary"></i>
+              {{ t('selling.title') }}
+            </h2>
+            <div class="space-y-3">
+              <div v-for="(tip, i) in tm('sellingTips')" :key="i" class="flex gap-3 items-start">
+                <i class="fas fa-circle-check text-info shrink-0 mt-0.5"></i>
+                <p class="text-base-content/80">{{ rt(tip) }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Shipping Safety -->
+          <div>
+            <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">
+              <i class="fas fa-truck text-primary"></i>
+              {{ t('shipping.title') }}
+            </h2>
+            <div class="space-y-3">
+              <div v-for="(tip, i) in tm('shippingTips')" :key="i" class="flex gap-3 items-start">
+                <i class="fas fa-circle-check text-warning shrink-0 mt-0.5"></i>
+                <p class="text-base-content/80">{{ rt(tip) }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Red Flags -->
+          <div>
+            <h2 class="text-2xl font-bold mb-4 flex items-center gap-2">
+              <i class="fas fa-triangle-exclamation text-error"></i>
+              {{ t('redFlagsHeading') }}
+            </h2>
+            <div class="space-y-3">
+              <div v-for="(flag, i) in tm('redFlags')" :key="i" class="flex gap-3 items-start">
+                <i class="fas fa-circle-xmark text-error shrink-0 mt-0.5"></i>
+                <p class="text-base-content/80">{{ rt(flag) }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Reporting -->
+          <div class="card bg-base-200 shadow-sm">
+            <div class="card-body">
+              <h2 class="card-title flex items-center gap-2">
+                <i class="fas fa-flag text-primary"></i>
+                {{ t('report.title') }}
+              </h2>
+              <p class="text-base-content/70">{{ t('report.body') }}</p>
+              <div class="card-actions mt-4">
+                <NuxtLink to="/contact" class="btn btn-primary">
+                  <i class="fas fa-envelope"></i>
+                  {{ t('report.button') }}
+                </NuxtLink>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t, tm, rt } = useI18n();
+
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.title'),
+    ogDescription: () => t('seo.ogDescription'),
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "hero": { "title": "Safety Guide", "subtitle": "Tips for buying and selling Classic Minis safely on The Mini Exchange." },
+    "meeting": { "title": "Meeting In Person" },
+    "payment": { "title": "Payment Safety", "recommendedHeading": "Recommended Payment Methods", "avoidHeading": "Payment Methods to Avoid" },
+    "buying": { "title": "Buying Tips" },
+    "selling": { "title": "Selling Tips" },
+    "shipping": { "title": "Shipping Safety" },
+    "redFlagsHeading": "Red Flags to Watch For",
+    "report": { "title": "Report Suspicious Activity", "body": "If you encounter suspicious behaviour, scam attempts, or fraudulent listings, please report them immediately. You can report individual messages within conversations, or contact us directly.", "button": "Contact Us" },
+    "inPersonTips": [
+      "Meet in a well-lit, public place such as a car park, petrol station, or police station.",
+      "Bring a friend or family member along for the viewing.",
+      "Let someone know where you are going and when you expect to be back.",
+      "Do the inspection during daylight hours so you can see the car properly.",
+      "If buying a vehicle, ask to see the V5C (logbook) or title document and verify it matches the VIN/chassis number.",
+      "Take your time — a legitimate seller will not rush you into a decision."
+    ],
+    "recommendedPayments": [
+      { "name": "Bank Transfer", "reason": "Direct, traceable, and widely accepted. Verify the recipient details carefully before sending." },
+      { "name": "PayPal Goods & Services", "reason": "Offers buyer protection for items not received or significantly not as described." },
+      { "name": "Cash (In Person)", "reason": "For local pickups only. Count carefully and consider a counterfeit detection pen for large amounts." },
+      { "name": "Escrow Services", "reason": "For high-value transactions, an escrow service holds payment until both parties are satisfied." }
+    ],
+    "riskyPayments": [
+      { "name": "Wire Transfer (Western Union, MoneyGram)", "reason": "Almost impossible to recover once sent. A favourite method of scammers." },
+      { "name": "Gift Cards or Cryptocurrency", "reason": "Untraceable and irreversible. No legitimate seller will insist on these." },
+      { "name": "PayPal Friends & Family", "reason": "No buyer protection — treated as a gift, not a purchase." },
+      { "name": "Cheques / Money Orders", "reason": "Can be forged. If you must accept one, wait for it to fully clear before releasing the item." }
+    ],
+    "buyingTips": [
+      "Research the fair market value before making an offer. Check sold listings on The Mini Exchange for comparable prices.",
+      "Ask for detailed photos of known Mini rust spots: subframes, A-panels, front floor pans, sills, and rear valance.",
+      "Request the Heritage Certificate number and verify it if the seller claims the car is matching-numbers.",
+      "For engines and major components, ask for the engine plate number and verify the series matches the claimed displacement.",
+      "If the deal seems too good to be true, it probably is. A pristine 1275 Cooper S for under market value deserves extra scrutiny.",
+      "Consider getting a pre-purchase inspection from a Classic Mini specialist before committing to a vehicle purchase.",
+      "Check the seller's profile — how long have they been a member? Do they have completed sales?"
+    ],
+    "sellingTips": [
+      "Take clear, well-lit photos from multiple angles. Buyers trust detailed, honest photography.",
+      "Be upfront about any issues, rust, or modifications. Honesty builds trust and avoids disputes later.",
+      "Respond to inquiries promptly — buyers often purchase from the first seller who replies.",
+      "Set a fair asking price based on comparable sold listings. Overpricing leads to stale listings.",
+      "Never share personal financial details (bank login, full card numbers) with buyers.",
+      "For shipped items, always use tracked and insured shipping. Share the tracking number with the buyer."
+    ],
+    "shippingTips": [
+      "Always use tracked and insured shipping for parts and engines.",
+      "Take photos of the item packed and ready to ship as proof of condition at dispatch.",
+      "For vehicles, use a reputable enclosed transport service and get a Bill of Lading.",
+      "Agree on who pays shipping costs before finalising the deal.",
+      "Share the tracking number in your Mini Exchange conversation for a clear record.",
+      "Never ship an item before confirming payment has cleared."
+    ],
+    "redFlags": [
+      "The seller refuses to meet in person or show the vehicle before payment.",
+      "Pressure to pay immediately or \"someone else is about to buy it\" urgency tactics.",
+      "Requests for unusual payment methods like gift cards, crypto, or wire transfers.",
+      "The price is significantly below market value with no clear explanation.",
+      "Poor-quality or stock photos that don't match the description.",
+      "The seller avoids answering specific questions about the car's history or condition.",
+      "Requests to move the conversation off The Mini Exchange to email, WhatsApp, or text.",
+      "A newly created account with no profile information or listing history.",
+      "The VIN/chassis number doesn't match the Heritage Certificate or V5C logbook."
+    ],
+    "seo": { "title": "Safety Guide - The Mini Exchange", "description": "Tips for safely buying and selling Classic Minis on The Mini Exchange. Learn about safe payment methods, meeting in person, and spotting red flags.", "ogDescription": "Stay safe when buying and selling Classic Minis online." }
+  },
+  "es": {
+    "hero": { "title": "Guía de seguridad", "subtitle": "Consejos para comprar y vender Classic Minis de forma segura en The Mini Exchange." },
+    "meeting": { "title": "Reunirse en persona" },
+    "payment": { "title": "Seguridad en los pagos", "recommendedHeading": "Métodos de pago recomendados", "avoidHeading": "Métodos de pago a evitar" },
+    "buying": { "title": "Consejos para comprar" },
+    "selling": { "title": "Consejos para vender" },
+    "shipping": { "title": "Seguridad en los envíos" },
+    "redFlagsHeading": "Señales de alerta a tener en cuenta",
+    "report": { "title": "Denuncia actividad sospechosa", "body": "Si detectas comportamientos sospechosos, intentos de estafa o anuncios fraudulentos, denúncialos de inmediato. Puedes denunciar mensajes concretos dentro de las conversaciones o contactarnos directamente.", "button": "Contáctanos" },
+    "inPersonTips": [
+      "Reúnete en un lugar público y bien iluminado, como un aparcamiento, una gasolinera o una comisaría.",
+      "Lleva a un amigo o familiar a la visita.",
+      "Avisa a alguien de adónde vas y a qué hora esperas volver.",
+      "Haz la inspección a la luz del día para poder ver bien el coche.",
+      "Si compras un vehículo, pide ver el permiso de circulación (V5C) o el título y verifica que coincide con el número de bastidor/VIN.",
+      "Tómate tu tiempo: un vendedor legítimo no te meterá prisa para decidir."
+    ],
+    "recommendedPayments": [
+      { "name": "Transferencia bancaria", "reason": "Directa, rastreable y ampliamente aceptada. Verifica con cuidado los datos del destinatario antes de enviar." },
+      { "name": "PayPal Bienes y Servicios", "reason": "Ofrece protección al comprador para artículos no recibidos o muy distintos a lo descrito." },
+      { "name": "Efectivo (en persona)", "reason": "Solo para recogidas locales. Cuenta con cuidado y plantéate un rotulador detector de billetes falsos para grandes cantidades." },
+      { "name": "Servicios de depósito en garantía (escrow)", "reason": "Para transacciones de alto valor, un servicio de escrow retiene el pago hasta que ambas partes queden satisfechas." }
+    ],
+    "riskyPayments": [
+      { "name": "Giro postal (Western Union, MoneyGram)", "reason": "Casi imposible de recuperar una vez enviado. El método favorito de los estafadores." },
+      { "name": "Tarjetas de regalo o criptomonedas", "reason": "Irrastreables e irreversibles. Ningún vendedor legítimo insistirá en ellas." },
+      { "name": "PayPal Amigos y Familia", "reason": "Sin protección al comprador: se trata como un regalo, no como una compra." },
+      { "name": "Cheques / órdenes de pago", "reason": "Pueden falsificarse. Si debes aceptar uno, espera a que se haga efectivo del todo antes de entregar el artículo." }
+    ],
+    "buyingTips": [
+      "Investiga el valor justo de mercado antes de hacer una oferta. Consulta los anuncios vendidos en The Mini Exchange para comparar precios.",
+      "Pide fotos detalladas de los puntos de óxido típicos del Mini: subchasis, paneles A, suelos delanteros, faldones y panel trasero.",
+      "Solicita el número del Certificado Heritage y verifícalo si el vendedor afirma que el coche conserva los números originales.",
+      "Para motores y componentes importantes, pide el número de la placa del motor y comprueba que la serie coincide con la cilindrada indicada.",
+      "Si la oferta parece demasiado buena para ser verdad, probablemente lo sea. Un 1275 Cooper S impecable por debajo del precio de mercado merece especial atención.",
+      "Plantéate una inspección previa a la compra por un especialista en Classic Mini antes de comprometerte a comprar un vehículo.",
+      "Revisa el perfil del vendedor: ¿cuánto tiempo lleva como miembro? ¿Tiene ventas completadas?"
+    ],
+    "sellingTips": [
+      "Haz fotos nítidas y bien iluminadas desde varios ángulos. Los compradores confían en una fotografía detallada y honesta.",
+      "Sé claro sobre cualquier problema, óxido o modificación. La honestidad genera confianza y evita disputas después.",
+      "Responde a las consultas con rapidez: los compradores suelen comprar al primer vendedor que responde.",
+      "Fija un precio justo basado en anuncios vendidos comparables. Un precio excesivo deja el anuncio estancado.",
+      "Nunca compartas datos financieros personales (acceso bancario, números completos de tarjeta) con los compradores.",
+      "Para artículos enviados, usa siempre un envío con seguimiento y seguro. Comparte el número de seguimiento con el comprador."
+    ],
+    "shippingTips": [
+      "Usa siempre envíos con seguimiento y seguro para piezas y motores.",
+      "Haz fotos del artículo embalado y listo para enviar como prueba de su estado en el momento del envío.",
+      "Para vehículos, usa un servicio de transporte cerrado de confianza y obtén un conocimiento de embarque (Bill of Lading).",
+      "Acordad quién paga los gastos de envío antes de cerrar el trato.",
+      "Comparte el número de seguimiento en tu conversación de Mini Exchange para dejar constancia clara.",
+      "Nunca envíes un artículo antes de confirmar que el pago se ha hecho efectivo."
+    ],
+    "redFlags": [
+      "El vendedor se niega a reunirse en persona o a mostrar el vehículo antes del pago.",
+      "Presión para pagar de inmediato o tácticas de urgencia del tipo «otra persona está a punto de comprarlo».",
+      "Solicitudes de métodos de pago inusuales como tarjetas de regalo, cripto o giros postales.",
+      "El precio está muy por debajo del valor de mercado sin una explicación clara.",
+      "Fotos de mala calidad o de catálogo que no coinciden con la descripción.",
+      "El vendedor evita responder a preguntas concretas sobre el historial o el estado del coche.",
+      "Solicitudes de trasladar la conversación fuera de The Mini Exchange a correo, WhatsApp o SMS.",
+      "Una cuenta recién creada sin información de perfil ni historial de anuncios.",
+      "El número de bastidor/VIN no coincide con el Certificado Heritage o el permiso de circulación V5C."
+    ],
+    "seo": { "title": "Guía de seguridad - The Mini Exchange", "description": "Consejos para comprar y vender Classic Minis de forma segura en The Mini Exchange. Aprende sobre métodos de pago seguros, encuentros en persona y cómo detectar señales de alerta.", "ogDescription": "Mantente seguro al comprar y vender Classic Minis por internet." }
+  },
+  "fr": {
+    "hero": { "title": "Guide de sécurité", "subtitle": "Conseils pour acheter et vendre des Classic Minis en toute sécurité sur The Mini Exchange." },
+    "meeting": { "title": "Se rencontrer en personne" },
+    "payment": { "title": "Sécurité des paiements", "recommendedHeading": "Moyens de paiement recommandés", "avoidHeading": "Moyens de paiement à éviter" },
+    "buying": { "title": "Conseils d'achat" },
+    "selling": { "title": "Conseils de vente" },
+    "shipping": { "title": "Sécurité d'expédition" },
+    "redFlagsHeading": "Signaux d'alerte à surveiller",
+    "report": { "title": "Signaler une activité suspecte", "body": "Si vous constatez un comportement suspect, une tentative d'escroquerie ou une annonce frauduleuse, signalez-la immédiatement. Vous pouvez signaler des messages individuels dans les conversations ou nous contacter directement.", "button": "Nous contacter" },
+    "inPersonTips": [
+      "Rencontrez-vous dans un lieu public et bien éclairé, comme un parking, une station-service ou un commissariat.",
+      "Faites-vous accompagner d'un ami ou d'un proche lors de la visite.",
+      "Prévenez quelqu'un de l'endroit où vous allez et de l'heure prévue de votre retour.",
+      "Faites l'inspection en journée afin de bien voir la voiture.",
+      "Si vous achetez un véhicule, demandez à voir la carte grise (V5C) ou le titre et vérifiez qu'elle correspond au numéro de châssis/VIN.",
+      "Prenez votre temps : un vendeur honnête ne vous poussera pas à décider dans la précipitation."
+    ],
+    "recommendedPayments": [
+      { "name": "Virement bancaire", "reason": "Direct, traçable et largement accepté. Vérifiez soigneusement les coordonnées du destinataire avant d'envoyer." },
+      { "name": "PayPal Biens et Services", "reason": "Offre une protection acheteur pour les articles non reçus ou nettement non conformes à la description." },
+      { "name": "Espèces (en personne)", "reason": "Pour les retraits locaux uniquement. Comptez soigneusement et envisagez un stylo détecteur de faux billets pour les grosses sommes." },
+      { "name": "Services d'entiercement (escrow)", "reason": "Pour les transactions de grande valeur, un service d'entiercement conserve le paiement jusqu'à satisfaction des deux parties." }
+    ],
+    "riskyPayments": [
+      { "name": "Transfert d'argent (Western Union, MoneyGram)", "reason": "Quasi impossible à récupérer une fois envoyé. Le moyen préféré des escrocs." },
+      { "name": "Cartes cadeaux ou cryptomonnaie", "reason": "Intraçables et irréversibles. Aucun vendeur honnête n'insistera pour les utiliser." },
+      { "name": "PayPal Amis et Famille", "reason": "Aucune protection acheteur : traité comme un cadeau, pas un achat." },
+      { "name": "Chèques / mandats", "reason": "Peuvent être falsifiés. Si vous devez en accepter un, attendez son encaissement complet avant de remettre l'article." }
+    ],
+    "buyingTips": [
+      "Renseignez-vous sur la juste valeur marchande avant de faire une offre. Consultez les annonces vendues sur The Mini Exchange pour comparer les prix.",
+      "Demandez des photos détaillées des zones de rouille connues du Mini : berceaux, panneaux A, planchers avant, bas de caisse et panneau arrière.",
+      "Demandez le numéro du Certificat Heritage et vérifiez-le si le vendeur affirme que la voiture est d'origine (matching numbers).",
+      "Pour les moteurs et composants majeurs, demandez le numéro de plaque moteur et vérifiez que la série correspond à la cylindrée annoncée.",
+      "Si l'affaire semble trop belle pour être vraie, c'est probablement le cas. Une 1275 Cooper S impeccable sous le prix du marché mérite une attention particulière.",
+      "Envisagez une inspection avant achat par un spécialiste Classic Mini avant de vous engager sur un véhicule.",
+      "Vérifiez le profil du vendeur : depuis combien de temps est-il membre ? A-t-il des ventes réalisées ?"
+    ],
+    "sellingTips": [
+      "Prenez des photos nettes et bien éclairées sous plusieurs angles. Les acheteurs font confiance à une photographie détaillée et honnête.",
+      "Soyez transparent sur les défauts, la rouille ou les modifications. L'honnêteté crée la confiance et évite les litiges ultérieurs.",
+      "Répondez rapidement aux demandes : les acheteurs achètent souvent au premier vendeur qui répond.",
+      "Fixez un prix juste d'après les annonces vendues comparables. Un prix trop élevé fait stagner l'annonce.",
+      "Ne partagez jamais d'informations financières personnelles (identifiants bancaires, numéros de carte complets) avec les acheteurs.",
+      "Pour les articles expédiés, utilisez toujours un envoi suivi et assuré. Communiquez le numéro de suivi à l'acheteur."
+    ],
+    "shippingTips": [
+      "Utilisez toujours un envoi suivi et assuré pour les pièces et les moteurs.",
+      "Prenez des photos de l'article emballé et prêt à expédier comme preuve de son état au départ.",
+      "Pour les véhicules, faites appel à un transporteur fermé réputé et obtenez un connaissement (Bill of Lading).",
+      "Convenez de qui paie les frais d'expédition avant de finaliser la transaction.",
+      "Communiquez le numéro de suivi dans votre conversation Mini Exchange pour garder une trace claire.",
+      "N'expédiez jamais un article avant d'avoir confirmé que le paiement a été encaissé."
+    ],
+    "redFlags": [
+      "Le vendeur refuse de vous rencontrer en personne ou de montrer le véhicule avant le paiement.",
+      "Pression pour payer immédiatement ou tactiques d'urgence du type « quelqu'un d'autre est sur le point de l'acheter ».",
+      "Demandes de moyens de paiement inhabituels comme des cartes cadeaux, de la crypto ou des transferts d'argent.",
+      "Le prix est nettement inférieur à la valeur du marché sans explication claire.",
+      "Photos de mauvaise qualité ou de catalogue qui ne correspondent pas à la description.",
+      "Le vendeur évite de répondre à des questions précises sur l'historique ou l'état de la voiture.",
+      "Demandes de déplacer la conversation hors de The Mini Exchange vers l'e-mail, WhatsApp ou les SMS.",
+      "Un compte récemment créé sans informations de profil ni historique d'annonces.",
+      "Le numéro de châssis/VIN ne correspond pas au Certificat Heritage ou à la carte grise V5C."
+    ],
+    "seo": { "title": "Guide de sécurité - The Mini Exchange", "description": "Conseils pour acheter et vendre des Classic Minis en toute sécurité sur The Mini Exchange. Découvrez les moyens de paiement sûrs, les rencontres en personne et comment repérer les signaux d'alerte.", "ogDescription": "Restez en sécurité lors de l'achat et de la vente de Classic Minis en ligne." }
+  },
+  "de": {
+    "hero": { "title": "Sicherheitsleitfaden", "subtitle": "Tipps für den sicheren Kauf und Verkauf von Classic Minis auf The Mini Exchange." },
+    "meeting": { "title": "Persönliches Treffen" },
+    "payment": { "title": "Zahlungssicherheit", "recommendedHeading": "Empfohlene Zahlungsmethoden", "avoidHeading": "Zu vermeidende Zahlungsmethoden" },
+    "buying": { "title": "Kauftipps" },
+    "selling": { "title": "Verkaufstipps" },
+    "shipping": { "title": "Versandsicherheit" },
+    "redFlagsHeading": "Warnsignale, auf die du achten solltest",
+    "report": { "title": "Verdächtige Aktivität melden", "body": "Wenn dir verdächtiges Verhalten, Betrugsversuche oder betrügerische Inserate auffallen, melde sie bitte sofort. Du kannst einzelne Nachrichten innerhalb von Unterhaltungen melden oder uns direkt kontaktieren.", "button": "Kontaktiere uns" },
+    "inPersonTips": [
+      "Triff dich an einem gut beleuchteten, öffentlichen Ort wie einem Parkplatz, einer Tankstelle oder einer Polizeiwache.",
+      "Nimm zur Besichtigung einen Freund oder ein Familienmitglied mit.",
+      "Sag jemandem, wohin du gehst und wann du zurück sein willst.",
+      "Mach die Besichtigung bei Tageslicht, damit du das Auto richtig sehen kannst.",
+      "Beim Fahrzeugkauf: Lass dir den Fahrzeugbrief (V5C) oder das Titeldokument zeigen und prüfe, ob es mit der Fahrgestellnummer/VIN übereinstimmt.",
+      "Lass dir Zeit — ein seriöser Verkäufer drängt dich nicht zu einer Entscheidung."
+    ],
+    "recommendedPayments": [
+      { "name": "Banküberweisung", "reason": "Direkt, nachvollziehbar und weit verbreitet. Prüfe die Empfängerdaten vor dem Senden sorgfältig." },
+      { "name": "PayPal Waren & Dienstleistungen", "reason": "Bietet Käuferschutz für nicht erhaltene oder erheblich abweichende Artikel." },
+      { "name": "Bargeld (persönlich)", "reason": "Nur für lokale Abholungen. Zähle sorgfältig und erwäge bei großen Beträgen einen Geldscheinprüfstift." },
+      { "name": "Treuhanddienste (Escrow)", "reason": "Bei hochwertigen Transaktionen hält ein Treuhanddienst die Zahlung zurück, bis beide Parteien zufrieden sind." }
+    ],
+    "riskyPayments": [
+      { "name": "Bargeldtransfer (Western Union, MoneyGram)", "reason": "Nach dem Senden kaum zurückzuholen. Eine bevorzugte Methode von Betrügern." },
+      { "name": "Geschenkkarten oder Kryptowährung", "reason": "Nicht nachverfolgbar und unumkehrbar. Kein seriöser Verkäufer besteht darauf." },
+      { "name": "PayPal Freunde & Familie", "reason": "Kein Käuferschutz — wird als Geschenk behandelt, nicht als Kauf." },
+      { "name": "Schecks / Zahlungsanweisungen", "reason": "Können gefälscht werden. Wenn du einen annehmen musst, warte auf die vollständige Gutschrift, bevor du den Artikel herausgibst." }
+    ],
+    "buyingTips": [
+      "Recherchiere den fairen Marktwert, bevor du ein Angebot machst. Sieh dir verkaufte Inserate auf The Mini Exchange zum Preisvergleich an.",
+      "Bitte um detaillierte Fotos der bekannten Mini-Roststellen: Hilfsrahmen, A-Säulen-Bleche, vordere Bodenbleche, Schweller und hintere Schürze.",
+      "Frage nach der Nummer des Heritage-Zertifikats und prüfe sie, wenn der Verkäufer behauptet, das Auto sei matching numbers.",
+      "Bei Motoren und großen Komponenten: Frage nach der Motornummer und prüfe, ob die Serie zum angegebenen Hubraum passt.",
+      "Wenn das Angebot zu gut klingt, um wahr zu sein, ist es das wahrscheinlich. Ein makelloser 1275 Cooper S unter Marktwert verdient besondere Aufmerksamkeit.",
+      "Erwäge vor dem Kauf eines Fahrzeugs eine Ankaufsuntersuchung durch einen Classic-Mini-Spezialisten.",
+      "Prüfe das Profil des Verkäufers — wie lange ist er schon Mitglied? Hat er abgeschlossene Verkäufe?"
+    ],
+    "sellingTips": [
+      "Mach klare, gut beleuchtete Fotos aus mehreren Blickwinkeln. Käufer vertrauen detaillierter, ehrlicher Fotografie.",
+      "Sei offen über Mängel, Rost oder Umbauten. Ehrlichkeit schafft Vertrauen und vermeidet spätere Streitigkeiten.",
+      "Antworte zügig auf Anfragen — Käufer kaufen oft beim ersten Verkäufer, der antwortet.",
+      "Setze einen fairen Preis auf Basis vergleichbarer verkaufter Inserate. Überteuerte Inserate bleiben liegen.",
+      "Teile niemals persönliche Finanzdaten (Bank-Login, vollständige Kartennummern) mit Käufern.",
+      "Bei versendeten Artikeln immer verfolgten und versicherten Versand nutzen. Teile dem Käufer die Sendungsnummer mit."
+    ],
+    "shippingTips": [
+      "Nutze für Teile und Motoren immer verfolgten und versicherten Versand.",
+      "Mach Fotos des verpackten, versandfertigen Artikels als Nachweis des Zustands beim Versand.",
+      "Für Fahrzeuge einen seriösen geschlossenen Transportdienst nutzen und einen Frachtbrief (Bill of Lading) erhalten.",
+      "Einigt euch vor Abschluss des Geschäfts darüber, wer die Versandkosten trägt.",
+      "Teile die Sendungsnummer in deiner Mini-Exchange-Unterhaltung, um eine klare Dokumentation zu haben.",
+      "Versende einen Artikel niemals, bevor die Zahlung bestätigt eingegangen ist."
+    ],
+    "redFlags": [
+      "Der Verkäufer weigert sich, sich persönlich zu treffen oder das Fahrzeug vor der Zahlung zu zeigen.",
+      "Druck, sofort zu zahlen, oder Dringlichkeitstaktiken wie „jemand anderes will es gleich kaufen“.",
+      "Anfragen nach ungewöhnlichen Zahlungsmethoden wie Geschenkkarten, Krypto oder Bargeldtransfer.",
+      "Der Preis liegt ohne klare Erklärung deutlich unter dem Marktwert.",
+      "Schlechte oder Katalogfotos, die nicht zur Beschreibung passen.",
+      "Der Verkäufer weicht konkreten Fragen zur Historie oder zum Zustand des Autos aus.",
+      "Aufforderungen, die Unterhaltung außerhalb von The Mini Exchange per E-Mail, WhatsApp oder SMS fortzusetzen.",
+      "Ein neu erstelltes Konto ohne Profilangaben oder Inseratshistorie.",
+      "Die Fahrgestellnummer/VIN stimmt nicht mit dem Heritage-Zertifikat oder dem V5C-Fahrzeugbrief überein."
+    ],
+    "seo": { "title": "Sicherheitsleitfaden - The Mini Exchange", "description": "Tipps für den sicheren Kauf und Verkauf von Classic Minis auf The Mini Exchange. Erfahre mehr über sichere Zahlungsmethoden, persönliche Treffen und das Erkennen von Warnsignalen.", "ogDescription": "Bleib sicher beim Kauf und Verkauf von Classic Minis im Internet." }
+  },
+  "it": {
+    "hero": { "title": "Guida alla sicurezza", "subtitle": "Consigli per comprare e vendere Classic Mini in sicurezza su The Mini Exchange." },
+    "meeting": { "title": "Incontrarsi di persona" },
+    "payment": { "title": "Sicurezza dei pagamenti", "recommendedHeading": "Metodi di pagamento consigliati", "avoidHeading": "Metodi di pagamento da evitare" },
+    "buying": { "title": "Consigli per l'acquisto" },
+    "selling": { "title": "Consigli per la vendita" },
+    "shipping": { "title": "Sicurezza nelle spedizioni" },
+    "redFlagsHeading": "Segnali d'allarme a cui prestare attenzione",
+    "report": { "title": "Segnala attività sospette", "body": "Se noti comportamenti sospetti, tentativi di truffa o annunci fraudolenti, segnalali immediatamente. Puoi segnalare singoli messaggi all'interno delle conversazioni o contattarci direttamente.", "button": "Contattaci" },
+    "inPersonTips": [
+      "Incontratevi in un luogo pubblico e ben illuminato, come un parcheggio, una stazione di servizio o una stazione di polizia.",
+      "Porta con te un amico o un familiare alla visione.",
+      "Avvisa qualcuno di dove stai andando e a che ora prevedi di tornare.",
+      "Fai l'ispezione durante le ore diurne per poter vedere bene l'auto.",
+      "Se acquisti un veicolo, chiedi di vedere il libretto (V5C) o il documento di proprietà e verifica che corrisponda al numero di telaio/VIN.",
+      "Prenditi il tuo tempo: un venditore serio non ti metterà fretta nel decidere."
+    ],
+    "recommendedPayments": [
+      { "name": "Bonifico bancario", "reason": "Diretto, tracciabile e ampiamente accettato. Verifica con attenzione i dati del destinatario prima di inviare." },
+      { "name": "PayPal Beni e Servizi", "reason": "Offre protezione all'acquirente per articoli non ricevuti o notevolmente diversi da quanto descritto." },
+      { "name": "Contanti (di persona)", "reason": "Solo per ritiri locali. Conta con attenzione e valuta una penna rilevatore di banconote false per importi elevati." },
+      { "name": "Servizi di deposito a garanzia (escrow)", "reason": "Per transazioni di alto valore, un servizio di escrow trattiene il pagamento finché entrambe le parti sono soddisfatte." }
+    ],
+    "riskyPayments": [
+      { "name": "Trasferimento di denaro (Western Union, MoneyGram)", "reason": "Quasi impossibile da recuperare una volta inviato. Il metodo preferito dai truffatori." },
+      { "name": "Carte regalo o criptovalute", "reason": "Non tracciabili e irreversibili. Nessun venditore serio insisterà per usarle." },
+      { "name": "PayPal Amici e Famiglia", "reason": "Nessuna protezione per l'acquirente: trattato come un regalo, non un acquisto." },
+      { "name": "Assegni / vaglia", "reason": "Possono essere falsificati. Se devi accettarne uno, attendi che sia completamente liquidato prima di consegnare l'articolo." }
+    ],
+    "buyingTips": [
+      "Informati sul giusto valore di mercato prima di fare un'offerta. Controlla gli annunci venduti su The Mini Exchange per confrontare i prezzi.",
+      "Chiedi foto dettagliate dei punti di ruggine tipici del Mini: telaietti, pannelli A, pianali anteriori, sottoporta e pannello posteriore.",
+      "Richiedi il numero del Certificato Heritage e verificalo se il venditore afferma che l'auto è matching-numbers.",
+      "Per motori e componenti importanti, chiedi il numero della targhetta motore e verifica che la serie corrisponda alla cilindrata dichiarata.",
+      "Se l'affare sembra troppo bello per essere vero, probabilmente lo è. Una 1275 Cooper S immacolata sotto il prezzo di mercato merita attenzione particolare.",
+      "Valuta un'ispezione pre-acquisto da parte di uno specialista Classic Mini prima di impegnarti nell'acquisto di un veicolo.",
+      "Controlla il profilo del venditore: da quanto tempo è membro? Ha vendite completate?"
+    ],
+    "sellingTips": [
+      "Scatta foto nitide e ben illuminate da più angolazioni. Gli acquirenti si fidano di una fotografia dettagliata e onesta.",
+      "Sii trasparente su eventuali difetti, ruggine o modifiche. L'onestà crea fiducia ed evita contestazioni in seguito.",
+      "Rispondi prontamente alle richieste: gli acquirenti spesso comprano dal primo venditore che risponde.",
+      "Fissa un prezzo equo in base ad annunci venduti comparabili. Un prezzo troppo alto fa ristagnare l'annuncio.",
+      "Non condividere mai dati finanziari personali (accesso bancario, numeri completi di carta) con gli acquirenti.",
+      "Per gli articoli spediti, usa sempre una spedizione tracciata e assicurata. Comunica il numero di tracciamento all'acquirente."
+    ],
+    "shippingTips": [
+      "Usa sempre spedizioni tracciate e assicurate per ricambi e motori.",
+      "Scatta foto dell'articolo imballato e pronto per la spedizione come prova delle condizioni alla partenza.",
+      "Per i veicoli, usa un servizio di trasporto chiuso affidabile e ottieni una polizza di carico (Bill of Lading).",
+      "Accordatevi su chi paga le spese di spedizione prima di concludere l'affare.",
+      "Condividi il numero di tracciamento nella tua conversazione Mini Exchange per avere una traccia chiara.",
+      "Non spedire mai un articolo prima di aver confermato che il pagamento è andato a buon fine."
+    ],
+    "redFlags": [
+      "Il venditore rifiuta di incontrarsi di persona o di mostrare il veicolo prima del pagamento.",
+      "Pressioni a pagare subito o tattiche d'urgenza del tipo «qualcun altro sta per comprarlo».",
+      "Richieste di metodi di pagamento insoliti come carte regalo, cripto o trasferimenti di denaro.",
+      "Il prezzo è nettamente inferiore al valore di mercato senza una spiegazione chiara.",
+      "Foto di scarsa qualità o di repertorio che non corrispondono alla descrizione.",
+      "Il venditore evita di rispondere a domande precise sulla storia o sulle condizioni dell'auto.",
+      "Richieste di spostare la conversazione fuori da The Mini Exchange su e-mail, WhatsApp o SMS.",
+      "Un account creato di recente senza informazioni di profilo né storico di annunci.",
+      "Il numero di telaio/VIN non corrisponde al Certificato Heritage o al libretto V5C."
+    ],
+    "seo": { "title": "Guida alla sicurezza - The Mini Exchange", "description": "Consigli per comprare e vendere Classic Mini in sicurezza su The Mini Exchange. Scopri i metodi di pagamento sicuri, gli incontri di persona e come riconoscere i segnali d'allarme.", "ogDescription": "Resta al sicuro quando compri e vendi Classic Mini online." }
+  },
+  "pt": {
+    "hero": { "title": "Guia de segurança", "subtitle": "Dicas para comprar e vender Classic Minis com segurança no The Mini Exchange." },
+    "meeting": { "title": "Encontrar-se pessoalmente" },
+    "payment": { "title": "Segurança nos pagamentos", "recommendedHeading": "Métodos de pagamento recomendados", "avoidHeading": "Métodos de pagamento a evitar" },
+    "buying": { "title": "Dicas de compra" },
+    "selling": { "title": "Dicas de venda" },
+    "shipping": { "title": "Segurança no envio" },
+    "redFlagsHeading": "Sinais de alerta a observar",
+    "report": { "title": "Denuncie atividade suspeita", "body": "Se encontrar comportamento suspeito, tentativas de golpe ou anúncios fraudulentos, denuncie imediatamente. Você pode denunciar mensagens individuais dentro das conversas ou entrar em contato conosco diretamente.", "button": "Fale conosco" },
+    "inPersonTips": [
+      "Encontre-se em um local público e bem iluminado, como um estacionamento, posto de combustível ou delegacia.",
+      "Leve um amigo ou familiar para a visita.",
+      "Avise alguém para onde você vai e a que horas pretende voltar.",
+      "Faça a inspeção à luz do dia para conseguir ver bem o carro.",
+      "Se comprar um veículo, peça para ver o documento (V5C/CRLV) ou título e verifique se corresponde ao número de chassi/VIN.",
+      "Não tenha pressa — um vendedor legítimo não vai apressar a sua decisão."
+    ],
+    "recommendedPayments": [
+      { "name": "Transferência bancária", "reason": "Direta, rastreável e amplamente aceita. Verifique os dados do destinatário com cuidado antes de enviar." },
+      { "name": "PayPal Bens e Serviços", "reason": "Oferece proteção ao comprador para itens não recebidos ou muito diferentes do descrito." },
+      { "name": "Dinheiro (pessoalmente)", "reason": "Apenas para retiradas locais. Conte com cuidado e considere uma caneta detectora de notas falsas para grandes quantias." },
+      { "name": "Serviços de custódia (escrow)", "reason": "Para transações de alto valor, um serviço de escrow retém o pagamento até que ambas as partes estejam satisfeitas." }
+    ],
+    "riskyPayments": [
+      { "name": "Transferência de dinheiro (Western Union, MoneyGram)", "reason": "Quase impossível de recuperar depois de enviada. O método favorito dos golpistas." },
+      { "name": "Cartões-presente ou criptomoedas", "reason": "Irrastreáveis e irreversíveis. Nenhum vendedor legítimo insistirá nesses meios." },
+      { "name": "PayPal Amigos e Família", "reason": "Sem proteção ao comprador — tratado como presente, não como compra." },
+      { "name": "Cheques / ordens de pagamento", "reason": "Podem ser falsificados. Se precisar aceitar um, espere a compensação total antes de entregar o item." }
+    ],
+    "buyingTips": [
+      "Pesquise o valor justo de mercado antes de fazer uma oferta. Confira anúncios vendidos no The Mini Exchange para comparar preços.",
+      "Peça fotos detalhadas dos pontos de ferrugem conhecidos do Mini: subchassis, painéis A, assoalhos dianteiros, soleiras e painel traseiro.",
+      "Solicite o número do Certificado Heritage e verifique-o se o vendedor afirmar que o carro é matching-numbers.",
+      "Para motores e componentes principais, peça o número da placa do motor e verifique se a série corresponde à cilindrada informada.",
+      "Se o negócio parece bom demais para ser verdade, provavelmente é. Um 1275 Cooper S impecável abaixo do preço de mercado merece atenção extra.",
+      "Considere uma inspeção pré-compra por um especialista em Classic Mini antes de se comprometer com a compra de um veículo.",
+      "Verifique o perfil do vendedor — há quanto tempo é membro? Tem vendas concluídas?"
+    ],
+    "sellingTips": [
+      "Tire fotos nítidas e bem iluminadas de vários ângulos. Os compradores confiam em uma fotografia detalhada e honesta.",
+      "Seja transparente sobre quaisquer problemas, ferrugem ou modificações. A honestidade gera confiança e evita disputas depois.",
+      "Responda às perguntas com rapidez — os compradores muitas vezes compram do primeiro vendedor que responde.",
+      "Defina um preço justo com base em anúncios vendidos comparáveis. Preços altos demais deixam o anúncio parado.",
+      "Nunca compartilhe dados financeiros pessoais (acesso bancário, números completos de cartão) com os compradores.",
+      "Para itens enviados, use sempre envio rastreado e segurado. Compartilhe o número de rastreamento com o comprador."
+    ],
+    "shippingTips": [
+      "Use sempre envio rastreado e segurado para peças e motores.",
+      "Tire fotos do item embalado e pronto para envio como prova das condições na expedição.",
+      "Para veículos, use um serviço de transporte fechado confiável e obtenha um conhecimento de embarque (Bill of Lading).",
+      "Combinem quem paga o frete antes de fechar o negócio.",
+      "Compartilhe o número de rastreamento na sua conversa do Mini Exchange para manter um registro claro.",
+      "Nunca envie um item antes de confirmar que o pagamento foi compensado."
+    ],
+    "redFlags": [
+      "O vendedor se recusa a encontrar-se pessoalmente ou a mostrar o veículo antes do pagamento.",
+      "Pressão para pagar imediatamente ou táticas de urgência do tipo «outra pessoa está prestes a comprar».",
+      "Pedidos de métodos de pagamento incomuns como cartões-presente, cripto ou transferências de dinheiro.",
+      "O preço está muito abaixo do valor de mercado sem uma explicação clara.",
+      "Fotos de baixa qualidade ou de catálogo que não correspondem à descrição.",
+      "O vendedor evita responder a perguntas específicas sobre o histórico ou o estado do carro.",
+      "Pedidos para mover a conversa para fora do The Mini Exchange para e-mail, WhatsApp ou mensagem.",
+      "Uma conta recém-criada sem informações de perfil nem histórico de anúncios.",
+      "O número de chassi/VIN não corresponde ao Certificado Heritage ou ao documento V5C."
+    ],
+    "seo": { "title": "Guia de segurança - The Mini Exchange", "description": "Dicas para comprar e vender Classic Minis com segurança no The Mini Exchange. Saiba mais sobre métodos de pagamento seguros, encontros pessoais e como identificar sinais de alerta.", "ogDescription": "Mantenha-se seguro ao comprar e vender Classic Minis online." }
+  },
+  "ru": {
+    "hero": { "title": "Руководство по безопасности", "subtitle": "Советы по безопасной покупке и продаже Classic Mini на The Mini Exchange." },
+    "meeting": { "title": "Личная встреча" },
+    "payment": { "title": "Безопасность платежей", "recommendedHeading": "Рекомендуемые способы оплаты", "avoidHeading": "Способы оплаты, которых стоит избегать" },
+    "buying": { "title": "Советы покупателю" },
+    "selling": { "title": "Советы продавцу" },
+    "shipping": { "title": "Безопасность доставки" },
+    "redFlagsHeading": "Тревожные признаки, на которые стоит обратить внимание",
+    "report": { "title": "Сообщить о подозрительной активности", "body": "Если вы столкнулись с подозрительным поведением, попытками мошенничества или поддельными объявлениями, немедленно сообщите об этом. Вы можете пожаловаться на отдельные сообщения в переписке или связаться с нами напрямую.", "button": "Связаться с нами" },
+    "inPersonTips": [
+      "Встречайтесь в хорошо освещённом общественном месте — на парковке, заправке или у отделения полиции.",
+      "Возьмите с собой на осмотр друга или родственника.",
+      "Сообщите кому-нибудь, куда вы едете и когда планируете вернуться.",
+      "Проводите осмотр в светлое время суток, чтобы хорошо рассмотреть машину.",
+      "При покупке автомобиля попросите показать техпаспорт (V5C) или документ о праве собственности и убедитесь, что он совпадает с номером кузова/VIN.",
+      "Не торопитесь — добросовестный продавец не будет подгонять вас с решением."
+    ],
+    "recommendedPayments": [
+      { "name": "Банковский перевод", "reason": "Прямой, отслеживаемый и широко принимаемый. Перед отправкой тщательно проверьте реквизиты получателя." },
+      { "name": "PayPal «Товары и услуги»", "reason": "Обеспечивает защиту покупателя для не полученных или существенно не соответствующих описанию товаров." },
+      { "name": "Наличные (лично)", "reason": "Только для местных сделок. Считайте внимательно и при крупных суммах используйте детектор фальшивых купюр." },
+      { "name": "Эскроу-сервисы", "reason": "Для дорогих сделок эскроу удерживает платёж, пока обе стороны не будут удовлетворены." }
+    ],
+    "riskyPayments": [
+      { "name": "Денежные переводы (Western Union, MoneyGram)", "reason": "После отправки вернуть почти невозможно. Любимый способ мошенников." },
+      { "name": "Подарочные карты или криптовалюта", "reason": "Не отслеживаются и необратимы. Ни один добросовестный продавец не настаивает на них." },
+      { "name": "PayPal «Друзьям и близким»", "reason": "Без защиты покупателя — считается подарком, а не покупкой." },
+      { "name": "Чеки / денежные ордера", "reason": "Могут быть поддельными. Если приходится принять, дождитесь полного зачисления, прежде чем отдавать товар." }
+    ],
+    "buyingTips": [
+      "Изучите справедливую рыночную цену перед тем, как сделать предложение. Сравните цены по проданным объявлениям на The Mini Exchange.",
+      "Попросите подробные фото известных мест коррозии Mini: подрамников, панелей A, передних полов, порогов и задней панели.",
+      "Запросите номер сертификата Heritage и проверьте его, если продавец утверждает, что у машины оригинальные номера.",
+      "Для двигателей и крупных узлов попросите номер на табличке двигателя и проверьте, соответствует ли серия заявленному объёму.",
+      "Если сделка кажется слишком выгодной, чтобы быть правдой, скорее всего, так и есть. Безупречный 1275 Cooper S по цене ниже рыночной требует особого внимания.",
+      "Перед покупкой автомобиля подумайте о предпродажной проверке у специалиста по Classic Mini.",
+      "Проверьте профиль продавца — как давно он зарегистрирован? Есть ли у него завершённые продажи?"
+    ],
+    "sellingTips": [
+      "Делайте чёткие, хорошо освещённые фото с разных ракурсов. Покупатели доверяют подробной и честной съёмке.",
+      "Честно расскажите о любых проблемах, коррозии или доработках. Честность вызывает доверие и предотвращает споры в дальнейшем.",
+      "Отвечайте на запросы быстро — покупатели часто берут у первого ответившего продавца.",
+      "Установите справедливую цену на основе сопоставимых проданных объявлений. Завышенная цена приводит к «зависанию» объявления.",
+      "Никогда не сообщайте покупателям личные финансовые данные (доступ к банку, полные номера карт).",
+      "Для отправляемых товаров всегда используйте доставку с отслеживанием и страховкой. Сообщите покупателю трек-номер."
+    ],
+    "shippingTips": [
+      "Для запчастей и двигателей всегда используйте доставку с отслеживанием и страховкой.",
+      "Сфотографируйте упакованный и готовый к отправке товар как доказательство его состояния при отправке.",
+      "Для автомобилей используйте надёжную закрытую транспортную службу и получите транспортную накладную (Bill of Lading).",
+      "Договоритесь, кто оплачивает доставку, до завершения сделки.",
+      "Сообщите трек-номер в переписке Mini Exchange, чтобы оставить чёткую запись.",
+      "Никогда не отправляйте товар до подтверждения зачисления оплаты."
+    ],
+    "redFlags": [
+      "Продавец отказывается встретиться лично или показать автомобиль до оплаты.",
+      "Давление с требованием оплатить немедленно или приёмы срочности вроде «кто-то другой вот-вот купит».",
+      "Просьбы об необычных способах оплаты — подарочных картах, крипте или денежных переводах.",
+      "Цена значительно ниже рыночной без внятного объяснения.",
+      "Некачественные или стоковые фото, не соответствующие описанию.",
+      "Продавец уходит от конкретных вопросов об истории или состоянии машины.",
+      "Просьбы перенести общение за пределы The Mini Exchange — в почту, WhatsApp или СМС.",
+      "Недавно созданный аккаунт без информации в профиле и истории объявлений.",
+      "Номер кузова/VIN не совпадает с сертификатом Heritage или техпаспортом V5C."
+    ],
+    "seo": { "title": "Руководство по безопасности - The Mini Exchange", "description": "Советы по безопасной покупке и продаже Classic Mini на The Mini Exchange. Узнайте о безопасных способах оплаты, личных встречах и распознавании тревожных признаков.", "ogDescription": "Будьте в безопасности при покупке и продаже Classic Mini онлайн." }
+  },
+  "ja": {
+    "hero": { "title": "安全ガイド", "subtitle": "The Mini Exchange で Classic Mini を安全に売買するためのヒント。" },
+    "meeting": { "title": "直接会うとき" },
+    "payment": { "title": "支払いの安全", "recommendedHeading": "推奨される支払い方法", "avoidHeading": "避けるべき支払い方法" },
+    "buying": { "title": "購入のヒント" },
+    "selling": { "title": "販売のヒント" },
+    "shipping": { "title": "配送の安全" },
+    "redFlagsHeading": "注意すべき危険サイン",
+    "report": { "title": "不審な行為を報告する", "body": "不審な行動、詐欺の試み、または虚偽の出品を見つけた場合は、すぐに報告してください。会話内の個々のメッセージを報告するか、直接お問い合わせいただけます。", "button": "お問い合わせ" },
+    "inPersonTips": [
+      "駐車場、ガソリンスタンド、警察署など、明るく人目のある公共の場所で会いましょう。",
+      "下見には友人や家族に同行してもらいましょう。",
+      "どこへ行き、いつ戻る予定かを誰かに伝えておきましょう。",
+      "車をきちんと確認できるよう、日中の明るい時間に点検しましょう。",
+      "車両を購入する場合は登録証（V5C）または所有権書類を見せてもらい、車台番号/VIN と一致するか確認しましょう。",
+      "焦らず時間をかけましょう。まともな売り手が決断を急かすことはありません。"
+    ],
+    "recommendedPayments": [
+      { "name": "銀行振込", "reason": "直接的で追跡可能、広く受け入れられています。送金前に受取人情報を慎重に確認しましょう。" },
+      { "name": "PayPal（商品・サービス）", "reason": "商品が届かない場合や説明と大きく異なる場合に購入者保護が受けられます。" },
+      { "name": "現金（手渡し）", "reason": "地元での引き取りのみ。慎重に数え、高額の場合は偽造紙幣検知ペンの利用を検討しましょう。" },
+      { "name": "エスクローサービス", "reason": "高額取引では、両者が納得するまでエスクローが代金を預かります。" }
+    ],
+    "riskyPayments": [
+      { "name": "送金サービス（Western Union、MoneyGram）", "reason": "送金後の回収はほぼ不可能。詐欺師が好む手口です。" },
+      { "name": "ギフトカードや暗号資産", "reason": "追跡不能で取り消し不可。まともな売り手が要求することはありません。" },
+      { "name": "PayPal（友人・家族）", "reason": "購入者保護なし。購入ではなく贈与として扱われます。" },
+      { "name": "小切手／マネーオーダー", "reason": "偽造される恐れがあります。受け取らざるを得ない場合は、完全に決済されてから商品を渡しましょう。" }
+    ],
+    "buyingTips": [
+      "オファーを出す前に適正な市場価格を調べましょう。The Mini Exchange の売却済み出品で相場を確認できます。",
+      "サブフレーム、A パネル、フロントフロア、シル、リアバランスなど、Mini で錆びやすい箇所の詳細な写真を求めましょう。",
+      "売り手がマッチングナンバーだと主張する場合は、Heritage 証明書の番号を求めて確認しましょう。",
+      "エンジンや主要部品については、エンジンプレート番号を求め、シリーズが表示の排気量と一致するか確認しましょう。",
+      "話がうますぎる場合は、たいてい裏があります。相場以下の極上 1275 Cooper S は特に注意が必要です。",
+      "車両購入を決める前に、Classic Mini 専門家による購入前点検を検討しましょう。",
+      "売り手のプロフィールを確認しましょう。会員歴はどれくらいか、取引成立の実績はあるか。"
+    ],
+    "sellingTips": [
+      "複数の角度から、明るく鮮明な写真を撮りましょう。買い手は詳細で正直な写真を信頼します。",
+      "不具合、錆、改造などは正直に伝えましょう。誠実さは信頼を生み、後のトラブルを防ぎます。",
+      "問い合わせには素早く返信しましょう。買い手は最初に返信した売り手から購入することが多いです。",
+      "売却済みの類似出品を参考に適正価格を設定しましょう。高すぎる価格は出品の停滞を招きます。",
+      "銀行ログインやカード番号全桁など、個人の金融情報を買い手に決して教えないでください。",
+      "発送品には必ず追跡・保険付きの配送を使い、追跡番号を買い手と共有しましょう。"
+    ],
+    "shippingTips": [
+      "部品やエンジンには必ず追跡・保険付きの配送を使いましょう。",
+      "発送時の状態の証拠として、梱包して発送準備が整った商品の写真を撮りましょう。",
+      "車両には信頼できる密閉型輸送サービスを使い、船荷証券（Bill of Lading）を取得しましょう。",
+      "取引を確定する前に、送料をどちらが負担するか合意しましょう。",
+      "明確な記録のため、追跡番号を Mini Exchange の会話内で共有しましょう。",
+      "支払いの入金が確認できるまで、決して商品を発送しないでください。"
+    ],
+    "redFlags": [
+      "売り手が支払い前に直接会うことや車両を見せることを拒む。",
+      "すぐ支払うよう迫る、または「他の人が今にも買おうとしている」といった切迫感をあおる手口。",
+      "ギフトカード、暗号資産、送金サービスなど、通常と異なる支払い方法を要求する。",
+      "明確な理由もなく価格が市場価値を大きく下回っている。",
+      "説明と一致しない、低品質または既製の写真。",
+      "車の来歴や状態に関する具体的な質問への回答を避ける。",
+      "会話を The Mini Exchange の外（メール、WhatsApp、SMS）へ移そうとする。",
+      "プロフィール情報も出品履歴もない、新規作成されたばかりのアカウント。",
+      "車台番号/VIN が Heritage 証明書や V5C 登録証と一致しない。"
+    ],
+    "seo": { "title": "安全ガイド - The Mini Exchange", "description": "The Mini Exchange で Classic Mini を安全に売買するためのヒント。安全な支払い方法、対面での取引、危険サインの見分け方を解説します。", "ogDescription": "オンラインで Classic Mini を売買する際に安全を守りましょう。" }
+  },
+  "zh": {
+    "hero": { "title": "安全指南", "subtitle": "在 The Mini Exchange 上安全买卖 Classic Mini 的实用建议。" },
+    "meeting": { "title": "当面交易" },
+    "payment": { "title": "支付安全", "recommendedHeading": "推荐的支付方式", "avoidHeading": "应避免的支付方式" },
+    "buying": { "title": "购买建议" },
+    "selling": { "title": "出售建议" },
+    "shipping": { "title": "运输安全" },
+    "redFlagsHeading": "需要警惕的危险信号",
+    "report": { "title": "举报可疑活动", "body": "如果你遇到可疑行为、诈骗企图或虚假商品，请立即举报。你可以在对话中举报单条消息，或直接联系我们。", "button": "联系我们" },
+    "inPersonTips": [
+      "在光线充足的公共场所见面，例如停车场、加油站或警察局。",
+      "看车时带上一位朋友或家人。",
+      "告诉他人你要去哪里以及预计何时返回。",
+      "在白天进行检查，以便看清车辆。",
+      "购买车辆时，要求查看行驶证（V5C）或所有权文件，并核对其与车架号/VIN 是否一致。",
+      "不要着急——正规卖家不会催你做决定。"
+    ],
+    "recommendedPayments": [
+      { "name": "银行转账", "reason": "直接、可追踪且被广泛接受。转账前请仔细核对收款人信息。" },
+      { "name": "PayPal 商品与服务", "reason": "对未收到或与描述严重不符的商品提供买家保护。" },
+      { "name": "现金（当面）", "reason": "仅限本地自提。仔细清点，大额时可考虑使用验钞笔。" },
+      { "name": "第三方托管服务", "reason": "对于高价值交易，托管服务会保留款项，直到双方都满意为止。" }
+    ],
+    "riskyPayments": [
+      { "name": "汇款（Western Union、MoneyGram）", "reason": "一旦汇出几乎无法追回，是骗子最常用的手段。" },
+      { "name": "礼品卡或加密货币", "reason": "无法追踪且不可逆。正规卖家不会坚持使用这些方式。" },
+      { "name": "PayPal 亲友付款", "reason": "没有买家保护——会被视为赠与而非购买。" },
+      { "name": "支票／汇票", "reason": "可能被伪造。如果必须接受，请等到完全到账后再交付商品。" }
+    ],
+    "buyingTips": [
+      "出价前先了解公允的市场价值。可在 The Mini Exchange 上查看已售商品以比较价格。",
+      "索取 Mini 已知锈点的详细照片：副车架、A 柱板、前地板、门槛和后裙板。",
+      "如果卖家声称车辆为原厂编号一致（matching-numbers），请索取并核实 Heritage 证书编号。",
+      "对于发动机和主要部件，索取发动机铭牌号，并核对系列是否与所称排量相符。",
+      "如果交易好得令人难以置信，那多半有问题。一辆低于市价的完美 1275 Cooper S 值得格外审查。",
+      "在决定购买车辆前，可考虑请 Classic Mini 专家进行购前检查。",
+      "查看卖家资料——他成为会员多久了？是否有已完成的交易？"
+    ],
+    "sellingTips": [
+      "从多个角度拍摄清晰、光线充足的照片。买家信任细致、诚实的照片。",
+      "如实说明任何问题、锈蚀或改装。诚实能建立信任，避免日后纠纷。",
+      "及时回复咨询——买家往往会向第一个回复的卖家购买。",
+      "参考可比的已售商品设定合理售价。定价过高会让商品长期无人问津。",
+      "切勿向买家透露个人财务信息（银行登录、完整卡号）。",
+      "对于寄送的商品，务必使用可追踪并投保的运输，并将运单号告知买家。"
+    ],
+    "shippingTips": [
+      "零件和发动机始终使用可追踪并投保的运输。",
+      "拍摄已包装、准备发货的商品照片，作为发货时状态的证明。",
+      "对于车辆，使用信誉良好的封闭式运输服务，并取得提单（Bill of Lading）。",
+      "在敲定交易前先就运费由谁承担达成一致。",
+      "在 Mini Exchange 对话中共享运单号，以便留下清晰记录。",
+      "在确认款项到账前，切勿发货。"
+    ],
+    "redFlags": [
+      "卖家拒绝当面交易或在付款前展示车辆。",
+      "施压要求立即付款，或使用「别人马上就要买了」之类的紧迫话术。",
+      "要求使用礼品卡、加密货币或汇款等异常的支付方式。",
+      "价格明显低于市场价值却没有合理解释。",
+      "照片质量差或为网络图片，与描述不符。",
+      "卖家回避关于车辆历史或状况的具体问题。",
+      "要求将对话转移到 The Mini Exchange 之外，如邮件、WhatsApp 或短信。",
+      "新创建的账户，没有任何资料信息或商品历史。",
+      "车架号/VIN 与 Heritage 证书或 V5C 行驶证不符。"
+    ],
+    "seo": { "title": "安全指南 - The Mini Exchange", "description": "在 The Mini Exchange 上安全买卖 Classic Mini 的实用建议。了解安全的支付方式、当面交易以及如何识别危险信号。", "ogDescription": "在网上买卖 Classic Mini 时保持安全。" }
+  },
+  "ko": {
+    "hero": { "title": "안전 가이드", "subtitle": "The Mini Exchange에서 Classic Mini를 안전하게 사고팔기 위한 팁." },
+    "meeting": { "title": "직접 만나기" },
+    "payment": { "title": "결제 안전", "recommendedHeading": "권장 결제 수단", "avoidHeading": "피해야 할 결제 수단" },
+    "buying": { "title": "구매 팁" },
+    "selling": { "title": "판매 팁" },
+    "shipping": { "title": "배송 안전" },
+    "redFlagsHeading": "주의해야 할 위험 신호",
+    "report": { "title": "의심스러운 활동 신고", "body": "의심스러운 행동, 사기 시도 또는 허위 매물을 발견하면 즉시 신고해 주세요. 대화 내 개별 메시지를 신고하거나 저희에게 직접 문의하실 수 있습니다.", "button": "문의하기" },
+    "inPersonTips": [
+      "주차장, 주유소, 경찰서처럼 밝고 사람이 많은 공공장소에서 만나세요.",
+      "차를 보러 갈 때는 친구나 가족과 함께 가세요.",
+      "어디로 가는지, 언제 돌아올 예정인지 누군가에게 알려두세요.",
+      "차를 제대로 볼 수 있도록 낮 시간에 점검하세요.",
+      "차량을 구매한다면 등록증(V5C)이나 소유권 서류를 보여달라고 요청하고, 차대번호/VIN과 일치하는지 확인하세요.",
+      "서두르지 마세요. 정직한 판매자는 결정을 재촉하지 않습니다."
+    ],
+    "recommendedPayments": [
+      { "name": "계좌 이체", "reason": "직접적이고 추적 가능하며 널리 사용됩니다. 보내기 전에 수취인 정보를 꼼꼼히 확인하세요." },
+      { "name": "PayPal 상품 및 서비스", "reason": "물품 미수령 또는 설명과 크게 다른 경우 구매자 보호를 제공합니다." },
+      { "name": "현금(직접)", "reason": "현지 수령에만 사용하세요. 신중히 세고, 큰 금액일 때는 위조지폐 감별 펜을 고려하세요." },
+      { "name": "에스크로 서비스", "reason": "고액 거래에서는 양측이 만족할 때까지 에스크로가 대금을 보관합니다." }
+    ],
+    "riskyPayments": [
+      { "name": "송금 서비스(Western Union, MoneyGram)", "reason": "보낸 뒤에는 회수가 거의 불가능합니다. 사기꾼이 선호하는 방법입니다." },
+      { "name": "기프트 카드 또는 암호화폐", "reason": "추적 불가능하고 되돌릴 수 없습니다. 정직한 판매자는 이를 고집하지 않습니다." },
+      { "name": "PayPal 친구 및 가족", "reason": "구매자 보호가 없습니다. 구매가 아닌 선물로 처리됩니다." },
+      { "name": "수표 / 우편환", "reason": "위조될 수 있습니다. 부득이 받아야 한다면 완전히 결제된 뒤에 물품을 넘기세요." }
+    ],
+    "buyingTips": [
+      "제안하기 전에 적정 시세를 조사하세요. The Mini Exchange의 판매 완료 매물에서 가격을 비교할 수 있습니다.",
+      "서브프레임, A 패널, 앞 바닥, 사이드실, 뒤 밸런스 등 Mini의 알려진 부식 부위 사진을 자세히 요청하세요.",
+      "판매자가 매칭 넘버라고 주장하면 Heritage 인증서 번호를 요청하고 확인하세요.",
+      "엔진과 주요 부품의 경우 엔진 플레이트 번호를 요청하고, 시리즈가 표시된 배기량과 일치하는지 확인하세요.",
+      "거래가 너무 좋아 보이면 대개 함정이 있습니다. 시세보다 싼 완벽한 1275 Cooper S는 특히 주의 깊게 살펴보세요.",
+      "차량 구매를 결정하기 전에 Classic Mini 전문가의 구매 전 점검을 고려하세요.",
+      "판매자 프로필을 확인하세요. 회원 가입 기간은 얼마나 되는지, 완료된 판매 내역이 있는지 살펴보세요."
+    ],
+    "sellingTips": [
+      "여러 각도에서 선명하고 밝은 사진을 찍으세요. 구매자는 자세하고 정직한 사진을 신뢰합니다.",
+      "결함, 부식, 개조 사항을 솔직하게 밝히세요. 정직함은 신뢰를 쌓고 나중의 분쟁을 막아줍니다.",
+      "문의에 신속히 답하세요. 구매자는 종종 먼저 답한 판매자에게서 구매합니다.",
+      "비슷한 판매 완료 매물을 참고해 합리적인 가격을 정하세요. 너무 비싸면 매물이 묵게 됩니다.",
+      "은행 로그인, 전체 카드 번호 등 개인 금융 정보를 절대 구매자와 공유하지 마세요.",
+      "배송 물품에는 항상 추적 및 보험이 포함된 배송을 사용하고, 운송장 번호를 구매자와 공유하세요."
+    ],
+    "shippingTips": [
+      "부품과 엔진에는 항상 추적 및 보험이 포함된 배송을 사용하세요.",
+      "발송 시 상태 증거로 포장되어 배송 준비가 된 물품의 사진을 찍으세요.",
+      "차량의 경우 신뢰할 수 있는 밀폐형 운송 서비스를 이용하고 선하증권(Bill of Lading)을 받으세요.",
+      "거래를 확정하기 전에 배송비를 누가 부담할지 합의하세요.",
+      "명확한 기록을 위해 Mini Exchange 대화에서 운송장 번호를 공유하세요.",
+      "결제가 완료된 것을 확인하기 전에는 절대 물품을 발송하지 마세요."
+    ],
+    "redFlags": [
+      "판매자가 직접 만나기를 거부하거나 결제 전에 차량 보여주기를 거부합니다.",
+      "즉시 결제하라는 압박, 또는 '다른 사람이 곧 사려 한다'는 식의 긴박감 조성 수법.",
+      "기프트 카드, 암호화폐, 송금 등 비정상적인 결제 수단 요청.",
+      "명확한 설명 없이 가격이 시세보다 크게 낮습니다.",
+      "설명과 일치하지 않는 저화질 또는 인터넷 사진.",
+      "판매자가 차량 이력이나 상태에 대한 구체적인 질문을 회피합니다.",
+      "대화를 이메일, WhatsApp, 문자 등 The Mini Exchange 밖으로 옮기려는 요청.",
+      "프로필 정보나 매물 이력이 전혀 없는 갓 만든 계정.",
+      "차대번호/VIN이 Heritage 인증서나 V5C 등록증과 일치하지 않습니다."
+    ],
+    "seo": { "title": "안전 가이드 - The Mini Exchange", "description": "The Mini Exchange에서 Classic Mini를 안전하게 사고팔기 위한 팁. 안전한 결제 수단, 대면 거래, 위험 신호 식별 방법을 알아보세요.", "ogDescription": "온라인에서 Classic Mini를 사고팔 때 안전을 지키세요." }
+  }
+}
+</i18n>

--- a/app/pages/exchange/social/index.vue
+++ b/app/pages/exchange/social/index.vue
@@ -1,0 +1,594 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <section class="bg-base-100 border-b border-base-300 py-12">
+      <div class="container">
+        <div class="text-center">
+          <h1 class="text-4xl font-bold mb-3">{{ t('header.title') }}</h1>
+          <p class="text-base-content/70 mb-6 max-w-lg mx-auto">
+            {{ t('header.subtitle') }}
+          </p>
+          <div class="flex justify-center gap-4">
+            <a
+              href="https://www.instagram.com/theminiexchange"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="btn btn-ghost btn-sm"
+              :aria-label="t('follow.instagram')"
+            >
+              <i class="fab fa-instagram"></i>
+              Instagram
+            </a>
+            <a
+              href="https://www.facebook.com/theminiexchange"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="btn btn-ghost btn-sm"
+              :aria-label="t('follow.facebook')"
+            >
+              <i class="fab fa-facebook"></i>
+              Facebook
+            </a>
+            <a
+              href="https://bsky.app/profile/theminiexchange.bsky.social"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="btn btn-ghost btn-sm"
+              :aria-label="t('follow.bluesky')"
+            >
+              <i class="fab fa-bluesky"></i>
+              Bluesky
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Main Content -->
+    <section class="py-8">
+      <div class="container">
+        <!-- Results Header -->
+        <div class="flex items-center justify-between mb-6">
+          <p class="text-base-content/70">
+            <span v-if="loading">{{ t('results.loading') }}</span>
+            <span v-else-if="totalCount > 0">
+              {{ t('results.count', { count: totalCount }, totalCount) }}
+            </span>
+            <span v-else>{{ t('results.none') }}</span>
+          </p>
+        </div>
+
+        <!-- Loading State -->
+        <div v-if="loading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div v-for="i in 6" :key="i" class="skeleton h-80 w-full rounded-xl"></div>
+        </div>
+
+        <!-- Listings Grid -->
+        <div v-else-if="listings.length > 0">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div v-for="listing in listings" :key="listing.id" class="relative">
+              <!-- "Posted X ago" badge -->
+              <div class="absolute top-3 left-3 z-10">
+                <span class="badge badge-neutral badge-sm shadow">
+                  <i class="fas fa-bullhorn mr-1"></i>
+                  {{ formatPostedDate(listing.promoted_on_social_at) }}
+                </span>
+              </div>
+              <ExchangeListingsListingCard :listing="listing" :show-seller-info="false" />
+            </div>
+          </div>
+
+          <!-- Pagination -->
+          <div v-if="totalPages > 1" class="flex justify-center mt-8">
+            <div class="join">
+              <button class="join-item btn btn-sm" :disabled="currentPage <= 1" @click="goToPage(currentPage - 1)">
+                <i class="fas fa-chevron-left"></i>
+              </button>
+              <button
+                v-for="page in visiblePages"
+                :key="page"
+                class="join-item btn btn-sm"
+                :class="{ 'btn-active': page === currentPage }"
+                @click="goToPage(page)"
+              >
+                {{ page }}
+              </button>
+              <button
+                class="join-item btn btn-sm"
+                :disabled="currentPage >= totalPages"
+                @click="goToPage(currentPage + 1)"
+              >
+                <i class="fas fa-chevron-right"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Empty State -->
+        <div v-else class="text-center py-16">
+          <i class="fas fa-bullhorn text-6xl mx-auto mb-4 text-base-content/30"></i>
+          <h3 class="text-xl font-semibold mb-2">{{ t('empty.title') }}</h3>
+          <p class="text-base-content/70 mb-6">
+            {{ t('empty.body') }}
+          </p>
+          <NuxtLink to="/exchange/listings" class="btn btn-primary">{{ t('empty.cta') }}</NuxtLink>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { ListingWithPhotos } from '~/composables/useListings';
+
+  const { t } = useI18n();
+
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.title'),
+    ogDescription: () => t('seo.description'),
+  });
+
+  const supabase = useSupabase();
+
+  const PAGE_SIZE = 12;
+  const listings = ref<ListingWithPhotos[]>([]);
+  const loading = ref(true);
+  const totalCount = ref(0);
+  const currentPage = ref(1);
+
+  const totalPages = computed(() => Math.ceil(totalCount.value / PAGE_SIZE));
+
+  // Show at most 5 page buttons around the current page
+  const visiblePages = computed(() => {
+    const total = totalPages.value;
+    const current = currentPage.value;
+    const delta = 2;
+    const pages: number[] = [];
+
+    const start = Math.max(1, current - delta);
+    const end = Math.min(total, current + delta);
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+    return pages;
+  });
+
+  const formatPostedDate = (dateString: string | null): string => {
+    if (!dateString) return t('posted.featured');
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return t('posted.today');
+    if (diffDays === 1) return t('posted.yesterday');
+    if (diffDays < 7) return t('posted.days', { n: diffDays });
+    if (diffDays < 30) return t('posted.weeks', { n: Math.floor(diffDays / 7) });
+    if (diffDays < 365) return t('posted.months', { n: Math.floor(diffDays / 30) });
+    return t('posted.years', { n: Math.floor(diffDays / 365) });
+  };
+
+  const fetchSocialListings = async () => {
+    loading.value = true;
+
+    try {
+      const start = (currentPage.value - 1) * PAGE_SIZE;
+      const end = start + PAGE_SIZE - 1;
+
+      const { data, error, count } = await applyPhotoOrdering(
+        supabase
+          .from('listings')
+          .select(
+            `
+            id,
+            title,
+            slug,
+            description,
+            price,
+            currency,
+            year,
+            model,
+            manufacturer,
+            location,
+            city,
+            state_province,
+            country,
+            status,
+            tier,
+            featured_until,
+            final_price,
+            listing_category,
+            condition,
+            promoted_on_social_at,
+            listing_photos (
+              id,
+              storage_path,
+              display_order,
+              category,
+              caption,
+              is_primary
+            )
+          `,
+            { count: 'exact' }
+          )
+          .eq('promoted_on_social', true)
+          .eq('status', 'active')
+          .not('status', 'in', '("example_free","example_paid")')
+          .order('promoted_on_social_at', { ascending: false })
+      ).range(start, end);
+
+      if (error) throw error;
+
+      listings.value = (data as ListingWithPhotos[]) || [];
+      totalCount.value = count || 0;
+    } catch (error) {
+      console.error('Failed to fetch social listings:', error);
+      listings.value = [];
+      totalCount.value = 0;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const goToPage = (page: number) => {
+    if (page < 1 || page > totalPages.value) return;
+    currentPage.value = page;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  watch(currentPage, () => {
+    fetchSocialListings();
+  });
+
+  onMounted(() => {
+    fetchSocialListings();
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "header": {
+      "title": "As Seen on Our Socials",
+      "subtitle": "Browse the Classic Mini listings we've featured on our social media accounts."
+    },
+    "follow": {
+      "instagram": "Follow us on Instagram",
+      "facebook": "Follow us on Facebook",
+      "bluesky": "Follow us on Bluesky"
+    },
+    "results": {
+      "loading": "Loading...",
+      "count": "{count} listing featured on socials | {count} listings featured on socials",
+      "none": "No social posts yet"
+    },
+    "posted": {
+      "featured": "Featured",
+      "today": "Posted today",
+      "yesterday": "Posted yesterday",
+      "days": "Posted {n}d ago",
+      "weeks": "Posted {n}w ago",
+      "months": "Posted {n}mo ago",
+      "years": "Posted {n}y ago"
+    },
+    "empty": {
+      "title": "No Social Posts Yet",
+      "body": "Check back soon — we regularly feature listings on our social accounts.",
+      "cta": "Browse All Listings"
+    },
+    "seo": {
+      "title": "As Seen on Our Socials | The Mini Exchange",
+      "description": "Browse Classic Mini listings featured on our social media accounts."
+    }
+  },
+  "es": {
+    "header": {
+      "title": "Visto en nuestras redes",
+      "subtitle": "Explora los anuncios de Classic Mini que hemos destacado en nuestras redes sociales."
+    },
+    "follow": {
+      "instagram": "Síguenos en Instagram",
+      "facebook": "Síguenos en Facebook",
+      "bluesky": "Síguenos en Bluesky"
+    },
+    "results": {
+      "loading": "Cargando...",
+      "count": "{count} anuncio destacado en redes | {count} anuncios destacados en redes",
+      "none": "Aún no hay publicaciones en redes"
+    },
+    "posted": {
+      "featured": "Destacado",
+      "today": "Publicado hoy",
+      "yesterday": "Publicado ayer",
+      "days": "Publicado hace {n} d",
+      "weeks": "Publicado hace {n} sem",
+      "months": "Publicado hace {n} mes",
+      "years": "Publicado hace {n} a"
+    },
+    "empty": {
+      "title": "Aún no hay publicaciones en redes",
+      "body": "Vuelve pronto: destacamos anuncios en nuestras redes con regularidad.",
+      "cta": "Explorar todos los anuncios"
+    },
+    "seo": {
+      "title": "Visto en nuestras redes | The Mini Exchange",
+      "description": "Explora los anuncios de Classic Mini destacados en nuestras redes sociales."
+    }
+  },
+  "fr": {
+    "header": {
+      "title": "Vu sur nos réseaux",
+      "subtitle": "Parcourez les annonces Classic Mini mises en avant sur nos réseaux sociaux."
+    },
+    "follow": {
+      "instagram": "Suivez-nous sur Instagram",
+      "facebook": "Suivez-nous sur Facebook",
+      "bluesky": "Suivez-nous sur Bluesky"
+    },
+    "results": {
+      "loading": "Chargement...",
+      "count": "{count} annonce mise en avant sur les réseaux | {count} annonces mises en avant sur les réseaux",
+      "none": "Aucune publication sur les réseaux pour le moment"
+    },
+    "posted": {
+      "featured": "À la une",
+      "today": "Publié aujourd'hui",
+      "yesterday": "Publié hier",
+      "days": "Publié il y a {n} j",
+      "weeks": "Publié il y a {n} sem",
+      "months": "Publié il y a {n} mois",
+      "years": "Publié il y a {n} an(s)"
+    },
+    "empty": {
+      "title": "Aucune publication sur les réseaux pour le moment",
+      "body": "Revenez bientôt : nous mettons régulièrement des annonces en avant sur nos réseaux.",
+      "cta": "Parcourir toutes les annonces"
+    },
+    "seo": {
+      "title": "Vu sur nos réseaux | The Mini Exchange",
+      "description": "Parcourez les annonces Classic Mini mises en avant sur nos réseaux sociaux."
+    }
+  },
+  "de": {
+    "header": {
+      "title": "Gesehen auf unseren Kanälen",
+      "subtitle": "Stöbere durch die Classic-Mini-Inserate, die wir auf unseren Social-Media-Kanälen vorgestellt haben."
+    },
+    "follow": {
+      "instagram": "Folge uns auf Instagram",
+      "facebook": "Folge uns auf Facebook",
+      "bluesky": "Folge uns auf Bluesky"
+    },
+    "results": {
+      "loading": "Wird geladen...",
+      "count": "{count} auf Social Media vorgestelltes Inserat | {count} auf Social Media vorgestellte Inserate",
+      "none": "Noch keine Social-Media-Beiträge"
+    },
+    "posted": {
+      "featured": "Vorgestellt",
+      "today": "Heute gepostet",
+      "yesterday": "Gestern gepostet",
+      "days": "Vor {n} T gepostet",
+      "weeks": "Vor {n} Wo gepostet",
+      "months": "Vor {n} Mon gepostet",
+      "years": "Vor {n} J gepostet"
+    },
+    "empty": {
+      "title": "Noch keine Social-Media-Beiträge",
+      "body": "Schau bald wieder vorbei — wir stellen regelmäßig Inserate auf unseren Kanälen vor.",
+      "cta": "Alle Inserate durchsuchen"
+    },
+    "seo": {
+      "title": "Gesehen auf unseren Kanälen | The Mini Exchange",
+      "description": "Stöbere durch Classic-Mini-Inserate, die auf unseren Social-Media-Kanälen vorgestellt wurden."
+    }
+  },
+  "it": {
+    "header": {
+      "title": "Visti sui nostri social",
+      "subtitle": "Esplora gli annunci Classic Mini che abbiamo messo in evidenza sui nostri profili social."
+    },
+    "follow": {
+      "instagram": "Seguici su Instagram",
+      "facebook": "Seguici su Facebook",
+      "bluesky": "Seguici su Bluesky"
+    },
+    "results": {
+      "loading": "Caricamento...",
+      "count": "{count} annuncio in evidenza sui social | {count} annunci in evidenza sui social",
+      "none": "Ancora nessun post sui social"
+    },
+    "posted": {
+      "featured": "In evidenza",
+      "today": "Pubblicato oggi",
+      "yesterday": "Pubblicato ieri",
+      "days": "Pubblicato {n} g fa",
+      "weeks": "Pubblicato {n} sett fa",
+      "months": "Pubblicato {n} mes fa",
+      "years": "Pubblicato {n} a fa"
+    },
+    "empty": {
+      "title": "Ancora nessun post sui social",
+      "body": "Torna presto: mettiamo regolarmente in evidenza gli annunci sui nostri social.",
+      "cta": "Esplora tutti gli annunci"
+    },
+    "seo": {
+      "title": "Visti sui nostri social | The Mini Exchange",
+      "description": "Esplora gli annunci Classic Mini messi in evidenza sui nostri profili social."
+    }
+  },
+  "pt": {
+    "header": {
+      "title": "Visto nas nossas redes",
+      "subtitle": "Explore os anúncios de Classic Mini que destacámos nas nossas redes sociais."
+    },
+    "follow": {
+      "instagram": "Siga-nos no Instagram",
+      "facebook": "Siga-nos no Facebook",
+      "bluesky": "Siga-nos no Bluesky"
+    },
+    "results": {
+      "loading": "A carregar...",
+      "count": "{count} anúncio destacado nas redes | {count} anúncios destacados nas redes",
+      "none": "Ainda não há publicações nas redes"
+    },
+    "posted": {
+      "featured": "Destacado",
+      "today": "Publicado hoje",
+      "yesterday": "Publicado ontem",
+      "days": "Publicado há {n} d",
+      "weeks": "Publicado há {n} sem",
+      "months": "Publicado há {n} mês",
+      "years": "Publicado há {n} a"
+    },
+    "empty": {
+      "title": "Ainda não há publicações nas redes",
+      "body": "Volte em breve — destacamos anúncios nas nossas redes com regularidade.",
+      "cta": "Explorar todos os anúncios"
+    },
+    "seo": {
+      "title": "Visto nas nossas redes | The Mini Exchange",
+      "description": "Explore os anúncios de Classic Mini destacados nas nossas redes sociais."
+    }
+  },
+  "ru": {
+    "header": {
+      "title": "В наших соцсетях",
+      "subtitle": "Смотрите объявления о Classic Mini, которые мы публиковали в наших социальных сетях."
+    },
+    "follow": {
+      "instagram": "Подпишитесь на нас в Instagram",
+      "facebook": "Подпишитесь на нас в Facebook",
+      "bluesky": "Подпишитесь на нас в Bluesky"
+    },
+    "results": {
+      "loading": "Загрузка...",
+      "count": "{count} объявление в соцсетях | {count} объявлений в соцсетях",
+      "none": "Пока нет публикаций в соцсетях"
+    },
+    "posted": {
+      "featured": "В подборке",
+      "today": "Опубликовано сегодня",
+      "yesterday": "Опубликовано вчера",
+      "days": "Опубликовано {n} дн. назад",
+      "weeks": "Опубликовано {n} нед. назад",
+      "months": "Опубликовано {n} мес. назад",
+      "years": "Опубликовано {n} г. назад"
+    },
+    "empty": {
+      "title": "Пока нет публикаций в соцсетях",
+      "body": "Загляните позже — мы регулярно публикуем объявления в наших соцсетях.",
+      "cta": "Смотреть все объявления"
+    },
+    "seo": {
+      "title": "В наших соцсетях | The Mini Exchange",
+      "description": "Смотрите объявления о Classic Mini, опубликованные в наших социальных сетях."
+    }
+  },
+  "ja": {
+    "header": {
+      "title": "SNSで紹介した出品",
+      "subtitle": "SNSアカウントで紹介した Classic Mini の出品をご覧ください。"
+    },
+    "follow": {
+      "instagram": "Instagram でフォローする",
+      "facebook": "Facebook でフォローする",
+      "bluesky": "Bluesky でフォローする"
+    },
+    "results": {
+      "loading": "読み込み中...",
+      "count": "SNSで紹介した出品 {count} 件",
+      "none": "SNSの投稿はまだありません"
+    },
+    "posted": {
+      "featured": "紹介済み",
+      "today": "今日投稿",
+      "yesterday": "昨日投稿",
+      "days": "{n}日前に投稿",
+      "weeks": "{n}週間前に投稿",
+      "months": "{n}か月前に投稿",
+      "years": "{n}年前に投稿"
+    },
+    "empty": {
+      "title": "SNSの投稿はまだありません",
+      "body": "またチェックしてください。SNSアカウントで定期的に出品を紹介しています。",
+      "cta": "すべての出品を見る"
+    },
+    "seo": {
+      "title": "SNSで紹介した出品 | The Mini Exchange",
+      "description": "SNSアカウントで紹介した Classic Mini の出品をご覧ください。"
+    }
+  },
+  "zh": {
+    "header": {
+      "title": "我们社交平台精选",
+      "subtitle": "浏览我们在社交媒体账号上推荐过的 Classic Mini 商品。"
+    },
+    "follow": {
+      "instagram": "在 Instagram 关注我们",
+      "facebook": "在 Facebook 关注我们",
+      "bluesky": "在 Bluesky 关注我们"
+    },
+    "results": {
+      "loading": "加载中...",
+      "count": "{count} 个社交平台精选商品",
+      "none": "暂无社交平台帖子"
+    },
+    "posted": {
+      "featured": "已精选",
+      "today": "今天发布",
+      "yesterday": "昨天发布",
+      "days": "{n} 天前发布",
+      "weeks": "{n} 周前发布",
+      "months": "{n} 个月前发布",
+      "years": "{n} 年前发布"
+    },
+    "empty": {
+      "title": "暂无社交平台帖子",
+      "body": "请稍后再来——我们会定期在社交账号上推荐商品。",
+      "cta": "浏览全部商品"
+    },
+    "seo": {
+      "title": "我们社交平台精选 | The Mini Exchange",
+      "description": "浏览我们在社交媒体账号上推荐过的 Classic Mini 商品。"
+    }
+  },
+  "ko": {
+    "header": {
+      "title": "SNS에 소개된 매물",
+      "subtitle": "SNS 계정에서 소개한 Classic Mini 매물을 둘러보세요."
+    },
+    "follow": {
+      "instagram": "Instagram에서 팔로우하기",
+      "facebook": "Facebook에서 팔로우하기",
+      "bluesky": "Bluesky에서 팔로우하기"
+    },
+    "results": {
+      "loading": "불러오는 중...",
+      "count": "SNS에 소개된 매물 {count}개",
+      "none": "아직 SNS 게시물이 없습니다"
+    },
+    "posted": {
+      "featured": "소개됨",
+      "today": "오늘 게시",
+      "yesterday": "어제 게시",
+      "days": "{n}일 전 게시",
+      "weeks": "{n}주 전 게시",
+      "months": "{n}개월 전 게시",
+      "years": "{n}년 전 게시"
+    },
+    "empty": {
+      "title": "아직 SNS 게시물이 없습니다",
+      "body": "곧 다시 확인해 주세요. SNS 계정에서 정기적으로 매물을 소개합니다.",
+      "cta": "모든 매물 둘러보기"
+    },
+    "seo": {
+      "title": "SNS에 소개된 매물 | The Mini Exchange",
+      "description": "SNS 계정에서 소개한 Classic Mini 매물을 둘러보세요."
+    }
+  }
+}
+</i18n>

--- a/app/pages/exchange/watchlist/index.vue
+++ b/app/pages/exchange/watchlist/index.vue
@@ -1,0 +1,193 @@
+<template>
+  <div>
+    <!-- Page Header -->
+    <section class="bg-base-100 border-b border-base-300 py-12">
+      <div class="container">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 class="text-4xl font-bold mb-2">{{ t('header.title') }}</h1>
+            <p class="text-base-content/70">
+              {{ t('header.savedCount', { count: watchlistItems.length }, watchlistItems.length) }}
+            </p>
+          </div>
+          <NuxtLink to="/exchange/listings" class="btn btn-outline">
+            <i class="fas fa-magnifying-glass"></i>
+            {{ t('browse') }}
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <!-- Main Content -->
+    <section class="py-8">
+      <div class="container">
+        <!-- Loading State -->
+        <div v-if="loading" class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6">
+          <div v-for="i in 6" :key="i" class="skeleton h-80 w-full"></div>
+        </div>
+
+        <!-- Empty State -->
+        <div v-else-if="watchlistItems.length === 0" class="text-center py-16">
+          <i class="fas fa-heart text-6xl mb-4 text-base-content/30"></i>
+          <h3 class="text-xl font-semibold mb-2">{{ t('empty.title') }}</h3>
+          <p class="text-base-content/70 mb-6">{{ t('empty.body') }}</p>
+          <NuxtLink to="/exchange/listings" class="btn btn-primary">
+            <i class="fas fa-magnifying-glass"></i>
+            {{ t('browse') }}
+          </NuxtLink>
+        </div>
+
+        <!-- Watchlist Grid -->
+        <div v-else class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6">
+          <template v-for="item in watchlistItems" :key="item.listing_id">
+            <ExchangeListingsListingCard
+              v-if="item.listing"
+              :listing="item.listing"
+              :show-remove-button="true"
+              :remove-loading="removingId === item.listing_id"
+              :user-currency="userCurrency"
+              @remove="handleRemove(item.listing_id)"
+            />
+          </template>
+        </div>
+
+        <!-- Info Banner -->
+        <div v-if="!loading && watchlistItems.length > 0" class="alert alert-info mt-8">
+          <i class="fas fa-circle-info"></i>
+          <span>{{ t('info') }}</span>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { t } = useI18n();
+
+  definePageMeta({
+    middleware: 'exchange-auth',
+  });
+
+  const { watchlistItems, fetchWatchlist, removeFromWatchlist } = useWatchlist();
+  const { user } = useAuth();
+  const { capture } = usePostHog();
+  const loading = ref(true);
+  const removingId = ref<string | null>(null);
+  const hasTrackedView = ref(false);
+
+  const { userCurrency } = useCurrency();
+
+  // Fetch watchlist on mount
+  onMounted(async () => {
+    if (user.value) {
+      await fetchWatchlist();
+    }
+    loading.value = false;
+  });
+
+  // Track watchlist view once items are loaded
+  watch(
+    () => watchlistItems.value,
+    (items) => {
+      if (items && !loading.value && !hasTrackedView.value) {
+        capture('watchlist_viewed', {
+          item_count: items.length,
+        });
+        hasTrackedView.value = true;
+      }
+    },
+    { immediate: true }
+  );
+
+  // Handle removing an item
+  const handleRemove = async (listingId: string) => {
+    removingId.value = listingId;
+    try {
+      await removeFromWatchlist(listingId);
+    } finally {
+      removingId.value = null;
+    }
+  };
+
+  // SEO metadata - noindex for user-specific pages
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    robots: 'noindex, nofollow',
+  });
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "header": { "title": "My Watchlist", "savedCount": "{count} saved listing | {count} saved listings" },
+    "browse": "Browse Listings",
+    "empty": { "title": "No saved listings yet", "body": "Start browsing and save listings you're interested in" },
+    "info": "You'll be notified when prices change or listings are about to expire",
+    "seo": { "title": "My Watchlist - The Mini Exchange", "description": "View and manage your saved Classic Mini listings" }
+  },
+  "es": {
+    "header": { "title": "Mi lista de seguimiento", "savedCount": "{count} anuncio guardado | {count} anuncios guardados" },
+    "browse": "Explorar anuncios",
+    "empty": { "title": "Aún no tienes anuncios guardados", "body": "Empieza a explorar y guarda los anuncios que te interesen" },
+    "info": "Te avisaremos cuando cambien los precios o los anuncios estén a punto de expirar",
+    "seo": { "title": "Mi lista de seguimiento - The Mini Exchange", "description": "Consulta y gestiona tus anuncios guardados de Classic Mini" }
+  },
+  "fr": {
+    "header": { "title": "Ma liste de suivi", "savedCount": "{count} annonce enregistrée | {count} annonces enregistrées" },
+    "browse": "Parcourir les annonces",
+    "empty": { "title": "Aucune annonce enregistrée pour le moment", "body": "Commencez à parcourir et enregistrez les annonces qui vous intéressent" },
+    "info": "Vous serez averti lorsque les prix changent ou que les annonces sont sur le point d'expirer",
+    "seo": { "title": "Ma liste de suivi - The Mini Exchange", "description": "Consultez et gérez vos annonces Classic Mini enregistrées" }
+  },
+  "de": {
+    "header": { "title": "Meine Merkliste", "savedCount": "{count} gespeichertes Inserat | {count} gespeicherte Inserate" },
+    "browse": "Inserate durchsuchen",
+    "empty": { "title": "Noch keine gespeicherten Inserate", "body": "Stöbere los und speichere Inserate, die dich interessieren" },
+    "info": "Wir benachrichtigen dich, wenn sich Preise ändern oder Inserate bald ablaufen",
+    "seo": { "title": "Meine Merkliste - The Mini Exchange", "description": "Sieh dir deine gespeicherten Classic-Mini-Inserate an und verwalte sie" }
+  },
+  "it": {
+    "header": { "title": "I miei preferiti", "savedCount": "{count} annuncio salvato | {count} annunci salvati" },
+    "browse": "Esplora gli annunci",
+    "empty": { "title": "Nessun annuncio salvato", "body": "Inizia a esplorare e salva gli annunci che ti interessano" },
+    "info": "Ti avviseremo quando i prezzi cambiano o gli annunci stanno per scadere",
+    "seo": { "title": "I miei preferiti - The Mini Exchange", "description": "Visualizza e gestisci i tuoi annunci Classic Mini salvati" }
+  },
+  "pt": {
+    "header": { "title": "Minha lista de favoritos", "savedCount": "{count} anúncio salvo | {count} anúncios salvos" },
+    "browse": "Explorar anúncios",
+    "empty": { "title": "Nenhum anúncio salvo ainda", "body": "Comece a explorar e salve os anúncios do seu interesse" },
+    "info": "Você será notificado quando os preços mudarem ou os anúncios estiverem prestes a expirar",
+    "seo": { "title": "Minha lista de favoritos - The Mini Exchange", "description": "Veja e gerencie seus anúncios Classic Mini salvos" }
+  },
+  "ru": {
+    "header": { "title": "Мой список отслеживания", "savedCount": "{count} сохранённое объявление | {count} сохранённых объявлений" },
+    "browse": "Смотреть объявления",
+    "empty": { "title": "Пока нет сохранённых объявлений", "body": "Начните просматривать и сохраняйте интересные объявления" },
+    "info": "Мы уведомим вас об изменении цен или скором истечении объявлений",
+    "seo": { "title": "Мой список отслеживания - The Mini Exchange", "description": "Просматривайте и управляйте сохранёнными объявлениями Classic Mini" }
+  },
+  "ja": {
+    "header": { "title": "ウォッチリスト", "savedCount": "保存した出品 {count} 件" },
+    "browse": "出品を見る",
+    "empty": { "title": "保存した出品はまだありません", "body": "気になる出品を探して保存しましょう" },
+    "info": "価格の変更や出品の有効期限が近づくとお知らせします",
+    "seo": { "title": "ウォッチリスト - The Mini Exchange", "description": "保存した Classic Mini の出品を表示・管理できます" }
+  },
+  "zh": {
+    "header": { "title": "我的收藏", "savedCount": "已保存 {count} 个商品" },
+    "browse": "浏览商品",
+    "empty": { "title": "还没有收藏的商品", "body": "开始浏览并收藏你感兴趣的商品" },
+    "info": "当价格变动或商品即将过期时，我们会通知你",
+    "seo": { "title": "我的收藏 - The Mini Exchange", "description": "查看和管理你收藏的 Classic Mini 商品" }
+  },
+  "ko": {
+    "header": { "title": "내 관심 목록", "savedCount": "저장한 매물 {count}개" },
+    "browse": "매물 둘러보기",
+    "empty": { "title": "아직 저장한 매물이 없습니다", "body": "둘러보면서 관심 있는 매물을 저장해 보세요" },
+    "info": "가격이 변경되거나 매물이 곧 만료되면 알려드립니다",
+    "seo": { "title": "내 관심 목록 - The Mini Exchange", "description": "저장한 Classic Mini 매물을 확인하고 관리하세요" }
+  }
+}
+</i18n>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,6 +4,10 @@
   const route = useRoute();
   const router = useRouter();
 
+  // Logged-in users who haven't completed onboarding get the OnboardingNudge
+  // (mounted globally in app.vue) in the chat-overlay slot instead of the chat.
+  const { needsOnboarding } = useOnboardingGate();
+
   // The discord-claim Edge Function 302-redirects failed claims to
   // `/?discord_error=<code>` (keystone §12). Surface a friendly, dismissible
   // banner on the home page for the known codes; anything else gets a generic
@@ -300,8 +304,9 @@
     </div>
   </div>
 
-  <!-- Floating Chat Input -->
-  <FloatingChatInput />
+  <!-- Floating Chat Input — yields to the OnboardingNudge for logged-in users
+       who haven't finished onboarding (the nudge takes this corner slot). -->
+  <FloatingChatInput v-if="!needsOnboarding" />
 </template>
 
 <style lang="scss">

--- a/app/pages/onboarding.vue
+++ b/app/pages/onboarding.vue
@@ -205,13 +205,21 @@
               </label>
 
               <div class="flex flex-col items-center gap-4">
-                <div class="relative cursor-pointer group" @click="triggerFileUpload">
+                <div
+                  class="relative cursor-pointer group"
+                  role="button"
+                  tabindex="0"
+                  :aria-label="t('avatar.upload')"
+                  @click="triggerFileUpload"
+                  @keydown.enter.prevent="triggerFileUpload"
+                  @keydown.space.prevent="triggerFileUpload"
+                >
                   <div class="avatar">
                     <div class="w-32 h-32 rounded-full bg-neutral text-neutral-content">
                       <img
                         v-if="avatarPreview"
                         :src="avatarPreview"
-                        alt="Preview"
+                        :alt="t('avatar.label')"
                         class="w-full h-full object-cover"
                         loading="lazy"
                       />
@@ -224,7 +232,7 @@
                   <div
                     class="absolute inset-0 rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex flex-col items-center justify-center"
                   >
-                    <i class="fas fa-camera text-2xl text-white mb-1"></i>
+                    <i class="fas fa-camera text-2xl text-white mb-1" aria-hidden="true"></i>
                     <span class="text-sm font-medium text-white">{{ t('avatar.upload') }}</span>
                   </div>
                 </div>

--- a/app/pages/onboarding.vue
+++ b/app/pages/onboarding.vue
@@ -1,0 +1,476 @@
+<script setup lang="ts">
+  import type { CurrencyCode } from '~/composables/useCurrency';
+
+  definePageMeta({
+    middleware: 'exchange-auth',
+    layout: false,
+  });
+
+  const { t } = useI18n();
+  useSeoMeta({
+    title: () => t('seo.title'),
+    robots: 'noindex, nofollow',
+  });
+
+  const { user, fetchUserProfile } = useAuth();
+  const { uploadAvatar, completeOnboarding } = useProfile();
+  const { SUPPORTED_CURRENCIES, setUserCurrency } = useCurrency();
+  const supabase = useSupabase();
+  const toast = useToast();
+  const route = useRoute();
+
+  // Only honor internal redirect targets; default back into the exchange.
+  const redirectTarget = computed(() => {
+    const r = route.query.redirect;
+    if (typeof r === 'string' && r.startsWith('/') && !r.startsWith('//')) return r;
+    return '/exchange';
+  });
+
+  // If onboarding is already complete, don't show the form — bounce to the target.
+  onMounted(async () => {
+    if (!user.value?.id) return;
+    try {
+      const { data: profile, error } = await supabase
+        .from('profiles')
+        .select('onboarding_completed')
+        .eq('id', user.value.id)
+        .single();
+      if (!error && profile?.onboarding_completed) {
+        await navigateTo(redirectTarget.value);
+      }
+    } catch (error) {
+      console.warn('Failed to check onboarding status:', error);
+    }
+  });
+
+  // Form state
+  const displayName = ref('');
+  const bio = ref('');
+  const preferredCurrency = ref<CurrencyCode>('USD');
+  // Until the user explicitly picks a currency, it auto-follows the location country.
+  const currencyTouchedByUser = ref(false);
+  const uploadedFile = ref<File | null>(null);
+  const avatarPreview = ref<string | null>(null);
+  const fileInputRef = ref<HTMLInputElement | null>(null);
+  const isSubmitting = ref(false);
+
+  const locationData = ref({
+    city: '',
+    state_province: '',
+    country: '',
+    postal_code: '',
+    latitude: null as number | null,
+    longitude: null as number | null,
+    formatted_address: '',
+  });
+
+  // Auto-derive preferred currency from the selected country until overridden.
+  watch(
+    () => locationData.value.country,
+    (country) => {
+      if (currencyTouchedByUser.value) return;
+      const derived = currencyForCountry(country);
+      if (derived) {
+        preferredCurrency.value = derived;
+      }
+    }
+  );
+
+  const onCurrencyChange = () => {
+    currencyTouchedByUser.value = true;
+  };
+
+  // Validation
+  const displayNameError = ref('');
+  const locationError = ref('');
+
+  const validateForm = () => {
+    let isValid = true;
+
+    if (!displayName.value.trim()) {
+      displayNameError.value = t('displayName.errors.required');
+      isValid = false;
+    } else if (displayName.value.length < 2) {
+      displayNameError.value = t('displayName.errors.min');
+      isValid = false;
+    } else if (displayName.value.length > 50) {
+      displayNameError.value = t('displayName.errors.max');
+      isValid = false;
+    } else {
+      displayNameError.value = '';
+    }
+
+    if (!locationData.value.formatted_address.trim()) {
+      locationError.value = t('location.error');
+      isValid = false;
+    } else {
+      locationError.value = '';
+    }
+
+    return isValid;
+  };
+
+  const getEmailInitial = () => {
+    if (!user.value?.email) return '?';
+    return user.value.email.charAt(0).toUpperCase();
+  };
+
+  const triggerFileUpload = () => {
+    fileInputRef.value?.click();
+  };
+
+  const handleAvatarSelect = async (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const file = target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      toast.add({ title: t('toast.invalidType.title'), description: t('toast.invalidType.body'), color: 'error' });
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      toast.add({ title: t('toast.tooLarge.title'), description: t('toast.tooLarge.body'), color: 'error' });
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      avatarPreview.value = e.target?.result as string;
+    };
+    reader.readAsDataURL(file);
+    uploadedFile.value = file;
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForm()) return;
+    isSubmitting.value = true;
+
+    try {
+      let avatarUrl = null;
+      if (uploadedFile.value) {
+        avatarUrl = await uploadAvatar(uploadedFile.value);
+      }
+
+      await completeOnboarding({
+        display_name: displayName.value.trim(),
+        location: locationData.value.formatted_address.trim(),
+        bio: bio.value.trim() || undefined,
+        avatar_url: avatarUrl || undefined,
+        preferred_currency: preferredCurrency.value,
+      });
+
+      // Refresh shared auth profile so the nudge clears + the exchange unlocks.
+      if (user.value?.id) {
+        await fetchUserProfile(user.value.id);
+      }
+
+      // Sync viewer currency + localStorage. No userId — completeOnboarding
+      // already persisted preferred_currency, so passing one would double-write.
+      await setUserCurrency(preferredCurrency.value);
+
+      toast.add({ title: t('toast.success.title'), description: t('toast.success.body'), color: 'success' });
+
+      await navigateTo(redirectTarget.value);
+    } catch (error: any) {
+      toast.add({
+        title: t('toast.fail.title'),
+        description: error?.message || t('toast.fail.body'),
+        color: 'error',
+      });
+    } finally {
+      isSubmitting.value = false;
+    }
+  };
+</script>
+
+<template>
+  <div class="min-h-screen bg-base-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div class="max-w-2xl w-full">
+      <div class="card bg-base-100 shadow-xl">
+        <div class="card-body">
+          <!-- Header -->
+          <div class="text-center mb-8">
+            <h1 class="text-3xl font-bold mb-2">{{ t('header.title') }}</h1>
+            <p class="opacity-70">{{ t('header.subtitle') }}</p>
+          </div>
+
+          <!-- Form -->
+          <form @submit.prevent="handleSubmit" class="space-y-6">
+            <!-- Avatar Selection -->
+            <div>
+              <label class="label">
+                <span class="label-text font-medium">{{ t('avatar.label') }}</span>
+                <span class="label-text-alt opacity-70">{{ t('avatar.hint') }}</span>
+              </label>
+
+              <div class="flex flex-col items-center gap-4">
+                <div class="relative cursor-pointer group" @click="triggerFileUpload">
+                  <div class="avatar">
+                    <div class="w-32 h-32 rounded-full bg-neutral text-neutral-content">
+                      <img
+                        v-if="avatarPreview"
+                        :src="avatarPreview"
+                        alt="Preview"
+                        class="w-full h-full object-cover"
+                        loading="lazy"
+                      />
+                      <div v-else class="flex items-center justify-center h-full">
+                        <span class="text-5xl font-semibold">{{ getEmailInitial() }}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div
+                    class="absolute inset-0 rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex flex-col items-center justify-center"
+                  >
+                    <i class="fas fa-camera text-2xl text-white mb-1"></i>
+                    <span class="text-sm font-medium text-white">{{ t('avatar.upload') }}</span>
+                  </div>
+                </div>
+
+                <input ref="fileInputRef" type="file" accept="image/*" class="hidden" @change="handleAvatarSelect" />
+
+                <div class="text-center">
+                  <p class="text-sm opacity-70">
+                    {{ avatarPreview ? t('avatar.selected') : t('avatar.none') }}
+                  </p>
+                  <p class="text-xs opacity-60 mt-1">{{ t('avatar.constraints') }}</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="divider"></div>
+
+            <!-- Display Name -->
+            <fieldset>
+              <legend class="fieldset-legend">
+                <span class="label-text font-medium">
+                  {{ t('displayName.label') }}
+                  <span class="text-error">*</span>
+                </span>
+              </legend>
+              <input
+                v-model="displayName"
+                type="text"
+                :placeholder="t('displayName.placeholder')"
+                class="input input-bordered w-full"
+                :class="{ 'input-error': displayNameError }"
+                maxlength="50"
+                required
+                @input="displayNameError = ''"
+              />
+              <label v-if="displayNameError" class="label">
+                <span class="label-text-alt text-error">{{ displayNameError }}</span>
+              </label>
+              <label v-else class="label">
+                <span class="label-text-alt opacity-70">{{ t('displayName.hint') }}</span>
+              </label>
+            </fieldset>
+
+            <!-- Location -->
+            <div>
+              <div class="flex items-center gap-2 mb-2">
+                <h3 class="fieldset-legend">
+                  {{ t('location.label') }}
+                  <span class="text-error">*</span>
+                </h3>
+              </div>
+              <ExchangeListingsLocationAutocomplete v-model="locationData" />
+              <label v-if="locationError" class="label">
+                <span class="label-text-alt text-error">{{ locationError }}</span>
+              </label>
+              <label v-else class="label">
+                <span class="label-text-alt opacity-70">
+                  <i class="fas fa-circle-info"></i>
+                  {{ t('location.hint') }}
+                </span>
+              </label>
+            </div>
+
+            <!-- Preferred Currency -->
+            <fieldset>
+              <legend class="fieldset-legend">
+                <span class="label-text font-medium">{{ t('currency.label') }}</span>
+              </legend>
+              <select
+                v-model="preferredCurrency"
+                class="select select-bordered w-full"
+                :aria-label="t('currency.label')"
+                @change="onCurrencyChange"
+              >
+                <option v-for="currency in SUPPORTED_CURRENCIES" :key="currency.code" :value="currency.code">
+                  {{ currency.symbol }} {{ currency.name }} ({{ currency.code }})
+                </option>
+              </select>
+              <label class="label">
+                <span class="label-text-alt opacity-70">{{ t('currency.hint') }}</span>
+              </label>
+            </fieldset>
+
+            <!-- Bio (Optional) -->
+            <fieldset>
+              <legend class="fieldset-legend">
+                <span class="label-text font-medium">{{ t('bio.label') }}</span>
+                <span class="label-text-alt opacity-70">{{ t('bio.optional') }}</span>
+              </legend>
+              <textarea
+                v-model="bio"
+                class="textarea textarea-bordered w-full"
+                :placeholder="t('bio.placeholder')"
+                rows="4"
+                maxlength="500"
+              ></textarea>
+              <label class="label">
+                <span class="label-text-alt opacity-70">{{ t('bio.counter', { count: bio.length }) }}</span>
+              </label>
+            </fieldset>
+
+            <div class="divider"></div>
+
+            <!-- Submit Button -->
+            <div class="card-actions justify-end">
+              <button type="submit" class="btn btn-primary btn-lg w-full sm:w-auto" :disabled="isSubmitting">
+                <span v-if="isSubmitting" class="loading loading-spinner"></span>
+                <span v-else>{{ t('submit') }}</span>
+              </button>
+            </div>
+          </form>
+
+          <!-- Info Box -->
+          <div class="alert mt-6">
+            <i class="fas fa-circle-info"></i>
+            <div>
+              <p class="text-sm">{{ t('info') }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "seo": { "title": "Welcome - The Mini Exchange" },
+    "header": { "title": "Welcome to The Mini Exchange!", "subtitle": "Let's set up your profile to get started" },
+    "avatar": { "label": "Profile Picture", "hint": "Click to upload", "upload": "Upload", "selected": "Photo selected!", "none": "No photo - your email initial will be shown", "constraints": "Max 5MB • JPG, PNG, or WebP" },
+    "displayName": { "label": "Display Name", "placeholder": "How should we call you?", "hint": "This is how others will see your name", "errors": { "required": "Display name is required", "min": "Display name must be at least 2 characters", "max": "Display name must be less than 50 characters" } },
+    "location": { "label": "Location", "error": "Location is required", "hint": "Only your country will be shown publicly on your profile" },
+    "currency": { "label": "Preferred Currency", "hint": "Defaults to your country's currency. New listings will use this currency and prices will be shown converted for visitors using a different one." },
+    "bio": { "label": "Bio", "optional": "Optional", "placeholder": "Tell us about yourself and your Classic Mini passion...", "counter": "{count}/500 characters" },
+    "submit": "Complete Setup",
+    "info": "You can always update your profile later in your account settings.",
+    "toast": { "success": { "title": "Welcome to The Mini Exchange!", "body": "Your profile has been set up successfully." }, "fail": { "title": "Failed to complete setup", "body": "An error occurred" }, "invalidType": { "title": "Invalid file type", "body": "Please select an image file" }, "tooLarge": { "title": "File too large", "body": "Please select an image smaller than 5MB" } }
+  },
+  "es": {
+    "seo": { "title": "Bienvenido - The Mini Exchange" },
+    "header": { "title": "¡Bienvenido a The Mini Exchange!", "subtitle": "Configuremos tu perfil para empezar" },
+    "avatar": { "label": "Foto de perfil", "hint": "Haz clic para subir", "upload": "Subir", "selected": "¡Foto seleccionada!", "none": "Sin foto: se mostrará la inicial de tu correo", "constraints": "Máx. 5MB • JPG, PNG o WebP" },
+    "displayName": { "label": "Nombre visible", "placeholder": "¿Cómo quieres que te llamemos?", "hint": "Así es como otros verán tu nombre", "errors": { "required": "El nombre visible es obligatorio", "min": "El nombre visible debe tener al menos 2 caracteres", "max": "El nombre visible debe tener menos de 50 caracteres" } },
+    "location": { "label": "Ubicación", "error": "La ubicación es obligatoria", "hint": "Solo tu país se mostrará públicamente en tu perfil" },
+    "currency": { "label": "Moneda preferida", "hint": "Por defecto, la moneda de tu país. Los nuevos anuncios usarán esta moneda y los precios se mostrarán convertidos para visitantes que usen otra." },
+    "bio": { "label": "Biografía", "optional": "Opcional", "placeholder": "Cuéntanos sobre ti y tu pasión por el Classic Mini...", "counter": "{count}/500 caracteres" },
+    "submit": "Completar configuración",
+    "info": "Siempre puedes actualizar tu perfil más tarde en los ajustes de tu cuenta.",
+    "toast": { "success": { "title": "¡Bienvenido a The Mini Exchange!", "body": "Tu perfil se ha configurado correctamente." }, "fail": { "title": "No se pudo completar la configuración", "body": "Se produjo un error" }, "invalidType": { "title": "Tipo de archivo no válido", "body": "Selecciona un archivo de imagen" }, "tooLarge": { "title": "Archivo demasiado grande", "body": "Selecciona una imagen de menos de 5MB" } }
+  },
+  "fr": {
+    "seo": { "title": "Bienvenue - The Mini Exchange" },
+    "header": { "title": "Bienvenue sur The Mini Exchange !", "subtitle": "Configurons votre profil pour commencer" },
+    "avatar": { "label": "Photo de profil", "hint": "Cliquez pour téléverser", "upload": "Téléverser", "selected": "Photo sélectionnée !", "none": "Pas de photo : l'initiale de votre e-mail sera affichée", "constraints": "Max 5 Mo • JPG, PNG ou WebP" },
+    "displayName": { "label": "Nom affiché", "placeholder": "Comment devons-nous vous appeler ?", "hint": "C'est ainsi que les autres verront votre nom", "errors": { "required": "Le nom affiché est obligatoire", "min": "Le nom affiché doit comporter au moins 2 caractères", "max": "Le nom affiché doit comporter moins de 50 caractères" } },
+    "location": { "label": "Localisation", "error": "La localisation est obligatoire", "hint": "Seul votre pays sera affiché publiquement sur votre profil" },
+    "currency": { "label": "Devise préférée", "hint": "Par défaut, la devise de votre pays. Les nouvelles annonces utiliseront cette devise et les prix seront convertis pour les visiteurs qui en utilisent une autre." },
+    "bio": { "label": "Bio", "optional": "Facultatif", "placeholder": "Parlez-nous de vous et de votre passion pour la Classic Mini...", "counter": "{count}/500 caractères" },
+    "submit": "Terminer la configuration",
+    "info": "Vous pourrez toujours mettre à jour votre profil plus tard dans les paramètres de votre compte.",
+    "toast": { "success": { "title": "Bienvenue sur The Mini Exchange !", "body": "Votre profil a été configuré avec succès." }, "fail": { "title": "Échec de la configuration", "body": "Une erreur s'est produite" }, "invalidType": { "title": "Type de fichier non valide", "body": "Veuillez sélectionner un fichier image" }, "tooLarge": { "title": "Fichier trop volumineux", "body": "Veuillez sélectionner une image de moins de 5 Mo" } }
+  },
+  "de": {
+    "seo": { "title": "Willkommen - The Mini Exchange" },
+    "header": { "title": "Willkommen bei The Mini Exchange!", "subtitle": "Richten wir dein Profil ein, um loszulegen" },
+    "avatar": { "label": "Profilbild", "hint": "Zum Hochladen klicken", "upload": "Hochladen", "selected": "Foto ausgewählt!", "none": "Kein Foto – die Initiale deiner E-Mail wird angezeigt", "constraints": "Max. 5 MB • JPG, PNG oder WebP" },
+    "displayName": { "label": "Anzeigename", "placeholder": "Wie sollen wir dich nennen?", "hint": "So sehen andere deinen Namen", "errors": { "required": "Anzeigename ist erforderlich", "min": "Der Anzeigename muss mindestens 2 Zeichen lang sein", "max": "Der Anzeigename muss weniger als 50 Zeichen lang sein" } },
+    "location": { "label": "Standort", "error": "Standort ist erforderlich", "hint": "Nur dein Land wird öffentlich in deinem Profil angezeigt" },
+    "currency": { "label": "Bevorzugte Währung", "hint": "Standardmäßig die Währung deines Landes. Neue Inserate verwenden diese Währung; für Besucher mit anderer Währung werden die Preise umgerechnet angezeigt." },
+    "bio": { "label": "Bio", "optional": "Optional", "placeholder": "Erzähl uns von dir und deiner Leidenschaft für den Classic Mini...", "counter": "{count}/500 Zeichen" },
+    "submit": "Einrichtung abschließen",
+    "info": "Du kannst dein Profil jederzeit später in deinen Kontoeinstellungen aktualisieren.",
+    "toast": { "success": { "title": "Willkommen bei The Mini Exchange!", "body": "Dein Profil wurde erfolgreich eingerichtet." }, "fail": { "title": "Einrichtung fehlgeschlagen", "body": "Ein Fehler ist aufgetreten" }, "invalidType": { "title": "Ungültiger Dateityp", "body": "Bitte wähle eine Bilddatei" }, "tooLarge": { "title": "Datei zu groß", "body": "Bitte wähle ein Bild unter 5 MB" } }
+  },
+  "it": {
+    "seo": { "title": "Benvenuto - The Mini Exchange" },
+    "header": { "title": "Benvenuto su The Mini Exchange!", "subtitle": "Configuriamo il tuo profilo per iniziare" },
+    "avatar": { "label": "Immagine del profilo", "hint": "Clicca per caricare", "upload": "Carica", "selected": "Foto selezionata!", "none": "Nessuna foto: verrà mostrata l'iniziale della tua email", "constraints": "Max 5MB • JPG, PNG o WebP" },
+    "displayName": { "label": "Nome visualizzato", "placeholder": "Come dobbiamo chiamarti?", "hint": "Questo è il nome che gli altri vedranno", "errors": { "required": "Il nome visualizzato è obbligatorio", "min": "Il nome visualizzato deve contenere almeno 2 caratteri", "max": "Il nome visualizzato deve contenere meno di 50 caratteri" } },
+    "location": { "label": "Posizione", "error": "La posizione è obbligatoria", "hint": "Solo il tuo paese sarà mostrato pubblicamente sul tuo profilo" },
+    "currency": { "label": "Valuta preferita", "hint": "Predefinita sulla valuta del tuo paese. I nuovi annunci useranno questa valuta e i prezzi saranno mostrati convertiti per i visitatori che ne usano un'altra." },
+    "bio": { "label": "Biografia", "optional": "Facoltativa", "placeholder": "Raccontaci di te e della tua passione per la Classic Mini...", "counter": "{count}/500 caratteri" },
+    "submit": "Completa la configurazione",
+    "info": "Puoi sempre aggiornare il tuo profilo più tardi nelle impostazioni dell'account.",
+    "toast": { "success": { "title": "Benvenuto su The Mini Exchange!", "body": "Il tuo profilo è stato configurato correttamente." }, "fail": { "title": "Configurazione non riuscita", "body": "Si è verificato un errore" }, "invalidType": { "title": "Tipo di file non valido", "body": "Seleziona un file immagine" }, "tooLarge": { "title": "File troppo grande", "body": "Seleziona un'immagine inferiore a 5MB" } }
+  },
+  "pt": {
+    "seo": { "title": "Bem-vindo - The Mini Exchange" },
+    "header": { "title": "Bem-vindo ao The Mini Exchange!", "subtitle": "Vamos configurar o seu perfil para começar" },
+    "avatar": { "label": "Foto de perfil", "hint": "Clique para enviar", "upload": "Enviar", "selected": "Foto selecionada!", "none": "Sem foto: a inicial do seu e-mail será exibida", "constraints": "Máx. 5MB • JPG, PNG ou WebP" },
+    "displayName": { "label": "Nome de exibição", "placeholder": "Como devemos chamá-lo?", "hint": "É assim que os outros verão o seu nome", "errors": { "required": "O nome de exibição é obrigatório", "min": "O nome de exibição deve ter pelo menos 2 caracteres", "max": "O nome de exibição deve ter menos de 50 caracteres" } },
+    "location": { "label": "Localização", "error": "A localização é obrigatória", "hint": "Apenas o seu país será exibido publicamente no seu perfil" },
+    "currency": { "label": "Moeda preferida", "hint": "Padrão para a moeda do seu país. Os novos anúncios usarão esta moeda e os preços serão exibidos convertidos para visitantes que usam outra." },
+    "bio": { "label": "Bio", "optional": "Opcional", "placeholder": "Conte-nos sobre você e a sua paixão pelo Classic Mini...", "counter": "{count}/500 caracteres" },
+    "submit": "Concluir configuração",
+    "info": "Você sempre pode atualizar o seu perfil depois nas configurações da conta.",
+    "toast": { "success": { "title": "Bem-vindo ao The Mini Exchange!", "body": "O seu perfil foi configurado com sucesso." }, "fail": { "title": "Falha ao concluir a configuração", "body": "Ocorreu um erro" }, "invalidType": { "title": "Tipo de arquivo inválido", "body": "Selecione um arquivo de imagem" }, "tooLarge": { "title": "Arquivo muito grande", "body": "Selecione uma imagem com menos de 5MB" } }
+  },
+  "ru": {
+    "seo": { "title": "Добро пожаловать - The Mini Exchange" },
+    "header": { "title": "Добро пожаловать в The Mini Exchange!", "subtitle": "Давайте настроим ваш профиль, чтобы начать" },
+    "avatar": { "label": "Фото профиля", "hint": "Нажмите, чтобы загрузить", "upload": "Загрузить", "selected": "Фото выбрано!", "none": "Без фото — будет показана первая буква вашего email", "constraints": "Макс. 5 МБ • JPG, PNG или WebP" },
+    "displayName": { "label": "Отображаемое имя", "placeholder": "Как к вам обращаться?", "hint": "Так ваше имя увидят другие", "errors": { "required": "Укажите отображаемое имя", "min": "Имя должно содержать не менее 2 символов", "max": "Имя должно содержать менее 50 символов" } },
+    "location": { "label": "Местоположение", "error": "Укажите местоположение", "hint": "В профиле публично показывается только ваша страна" },
+    "currency": { "label": "Предпочитаемая валюта", "hint": "По умолчанию — валюта вашей страны. Новые объявления будут в этой валюте, а цены покажутся в пересчёте для посетителей с другой валютой." },
+    "bio": { "label": "О себе", "optional": "Необязательно", "placeholder": "Расскажите о себе и о своей любви к Classic Mini...", "counter": "{count}/500 символов" },
+    "submit": "Завершить настройку",
+    "info": "Вы всегда можете обновить профиль позже в настройках аккаунта.",
+    "toast": { "success": { "title": "Добро пожаловать в The Mini Exchange!", "body": "Ваш профиль успешно настроен." }, "fail": { "title": "Не удалось завершить настройку", "body": "Произошла ошибка" }, "invalidType": { "title": "Недопустимый тип файла", "body": "Выберите файл изображения" }, "tooLarge": { "title": "Файл слишком большой", "body": "Выберите изображение размером менее 5 МБ" } }
+  },
+  "ja": {
+    "seo": { "title": "ようこそ - The Mini Exchange" },
+    "header": { "title": "The Mini Exchange へようこそ！", "subtitle": "まずはプロフィールを設定しましょう" },
+    "avatar": { "label": "プロフィール画像", "hint": "クリックしてアップロード", "upload": "アップロード", "selected": "写真を選択しました！", "none": "写真なし — メールアドレスの頭文字が表示されます", "constraints": "最大 5MB・JPG、PNG、WebP" },
+    "displayName": { "label": "表示名", "placeholder": "何とお呼びすればよいですか？", "hint": "他のユーザーにはこの名前が表示されます", "errors": { "required": "表示名は必須です", "min": "表示名は 2 文字以上で入力してください", "max": "表示名は 50 文字未満で入力してください" } },
+    "location": { "label": "所在地", "error": "所在地は必須です", "hint": "プロフィールに公開されるのは国のみです" },
+    "currency": { "label": "希望通貨", "hint": "既定はお住まいの国の通貨です。新しい出品はこの通貨で行われ、異なる通貨の閲覧者には換算した価格が表示されます。" },
+    "bio": { "label": "自己紹介", "optional": "任意", "placeholder": "あなた自身と Classic Mini への情熱について教えてください...", "counter": "{count}/500 文字" },
+    "submit": "設定を完了する",
+    "info": "プロフィールはいつでもアカウント設定から後で更新できます。",
+    "toast": { "success": { "title": "The Mini Exchange へようこそ！", "body": "プロフィールの設定が完了しました。" }, "fail": { "title": "設定を完了できませんでした", "body": "エラーが発生しました" }, "invalidType": { "title": "無効なファイル形式", "body": "画像ファイルを選択してください" }, "tooLarge": { "title": "ファイルが大きすぎます", "body": "5MB 未満の画像を選択してください" } }
+  },
+  "zh": {
+    "seo": { "title": "欢迎 - The Mini Exchange" },
+    "header": { "title": "欢迎来到 The Mini Exchange！", "subtitle": "先来设置你的个人资料吧" },
+    "avatar": { "label": "头像", "hint": "点击上传", "upload": "上传", "selected": "已选择照片！", "none": "没有照片 — 将显示你邮箱的首字母", "constraints": "最大 5MB • JPG、PNG 或 WebP" },
+    "displayName": { "label": "显示名称", "placeholder": "我们该怎么称呼你？", "hint": "其他人会看到这个名称", "errors": { "required": "显示名称为必填项", "min": "显示名称至少需要 2 个字符", "max": "显示名称需少于 50 个字符" } },
+    "location": { "label": "所在地", "error": "所在地为必填项", "hint": "你的个人资料中只会公开显示国家/地区" },
+    "currency": { "label": "首选货币", "hint": "默认使用你所在国家/地区的货币。新发布的商品将使用此货币，并为使用其他货币的访客显示换算后的价格。" },
+    "bio": { "label": "简介", "optional": "可选", "placeholder": "介绍一下你自己以及你对 Classic Mini 的热爱...", "counter": "{count}/500 字" },
+    "submit": "完成设置",
+    "info": "你随时可以稍后在账户设置中更新个人资料。",
+    "toast": { "success": { "title": "欢迎来到 The Mini Exchange！", "body": "你的个人资料已设置成功。" }, "fail": { "title": "无法完成设置", "body": "发生了错误" }, "invalidType": { "title": "文件类型无效", "body": "请选择一个图片文件" }, "tooLarge": { "title": "文件过大", "body": "请选择小于 5MB 的图片" } }
+  },
+  "ko": {
+    "seo": { "title": "환영합니다 - The Mini Exchange" },
+    "header": { "title": "The Mini Exchange에 오신 것을 환영합니다!", "subtitle": "시작하려면 프로필을 설정하세요" },
+    "avatar": { "label": "프로필 사진", "hint": "클릭하여 업로드", "upload": "업로드", "selected": "사진이 선택되었습니다!", "none": "사진 없음 — 이메일 첫 글자가 표시됩니다", "constraints": "최대 5MB • JPG, PNG 또는 WebP" },
+    "displayName": { "label": "표시 이름", "placeholder": "어떻게 불러드릴까요?", "hint": "다른 사용자에게 이 이름이 표시됩니다", "errors": { "required": "표시 이름은 필수입니다", "min": "표시 이름은 2자 이상이어야 합니다", "max": "표시 이름은 50자 미만이어야 합니다" } },
+    "location": { "label": "위치", "error": "위치는 필수입니다", "hint": "프로필에는 국가만 공개로 표시됩니다" },
+    "currency": { "label": "선호 통화", "hint": "기본값은 거주 국가의 통화입니다. 새 매물은 이 통화로 등록되며, 다른 통화를 사용하는 방문자에게는 환산된 가격이 표시됩니다." },
+    "bio": { "label": "소개", "optional": "선택 사항", "placeholder": "자신과 Classic Mini에 대한 애정을 들려주세요...", "counter": "{count}/500자" },
+    "submit": "설정 완료",
+    "info": "프로필은 언제든지 계정 설정에서 나중에 업데이트할 수 있습니다.",
+    "toast": { "success": { "title": "The Mini Exchange에 오신 것을 환영합니다!", "body": "프로필이 성공적으로 설정되었습니다." }, "fail": { "title": "설정을 완료하지 못했습니다", "body": "오류가 발생했습니다" }, "invalidType": { "title": "잘못된 파일 형식", "body": "이미지 파일을 선택하세요" }, "tooLarge": { "title": "파일이 너무 큽니다", "body": "5MB 미만의 이미지를 선택하세요" } }
+  }
+}
+</i18n>

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -7,15 +7,51 @@
   const { getPublicProfile, getPublicProfileVehicles } = useProfile();
   const { track } = useAnalytics();
   const { fetchPublicConfigs } = useGearConfigs();
+  const { getPublicLocation, extractCountry } = useLocation();
+  const supabase = useSupabase();
+
+  // Marketplace seller signals (listings + trust) only surface when the Exchange
+  // section is live. Routes here are NOT flag-gated (this is a kept CMDIY page),
+  // so the marketplace bits are gated inline instead.
+  const exchangeEnabled = useRuntimeConfig().public.exchangeEnabled;
 
   const identifier = route.params.id as string;
 
   const profile = ref<PublicProfile | null>(null);
   const vehicles = ref<Vehicle[]>([]);
   const publicConfigs = ref<any[]>([]);
+  const userListings = ref<any[]>([]);
   const loading = ref(true);
+  const loadingListings = ref(!!exchangeEnabled);
   const notFound = ref(false);
   const isPrivate = ref(false);
+
+  // The user's active marketplace listings (mirrors TME's seller-profile query).
+  const fetchUserListings = async (userId: string) => {
+    loadingListings.value = true;
+    try {
+      const { loadVisibility, activeStatuses } = useExampleListings();
+      await loadVisibility();
+      const { data, error } = await applyPhotoOrdering(
+        supabase
+          .from('listings')
+          .select(
+            `id, title, slug, description, year, model, price, location, condition, tier, created_at,
+             listing_photos ( id, storage_path, is_primary, display_order )`
+          )
+          .eq('user_id', userId)
+          .in('status', activeStatuses.value)
+          .order('created_at', { ascending: false })
+      );
+      if (error) throw error;
+      userListings.value = sortExamplesLast(data || []);
+    } catch (error) {
+      console.error('Failed to load user listings:', error);
+      userListings.value = [];
+    } finally {
+      loadingListings.value = false;
+    }
+  };
 
   onMounted(async () => {
     try {
@@ -33,6 +69,9 @@
 
       profile.value = result.profile;
       track('public_profile_viewed', { target_user_id: result.profile.id });
+
+      // Marketplace listings load independently (flag-gated) — don't block the page.
+      if (exchangeEnabled) fetchUserListings(result.profile.id);
 
       // Fetch gear configs and vehicles in parallel
       const [configs, vehiclesData] = await Promise.all([
@@ -133,7 +172,10 @@
               </div>
 
               <p v-if="profile?.location" class="text-sm opacity-60 mt-1">
-                <i class="fas fa-location-dot mr-1"></i>{{ profile.location }}
+                <template v-if="getCountryFlag(extractCountry(profile.location))">
+                  {{ getCountryFlag(extractCountry(profile.location)) }}
+                </template>
+                <i v-else class="fas fa-location-dot mr-1"></i>{{ getPublicLocation(profile.location) }}
               </p>
 
               <p v-if="profile?.bio" class="mt-2 opacity-80">{{ profile.bio }}</p>
@@ -146,6 +188,9 @@
               <div v-if="hasSocialLinks" class="mt-3">
                 <ProfileSocialLinks :links="profile!.social_links" size="sm" />
               </div>
+
+              <!-- Marketplace seller trust signals (flag-gated) -->
+              <ExchangeProfileSellerTrustSignals v-if="exchangeEnabled && profile?.id" :seller-id="profile.id" class="mt-4" />
             </div>
           </div>
         </div>
@@ -159,6 +204,42 @@
             <h3 class="text-lg font-semibold">{{ t('vehicles.title') }}</h3>
           </div>
           <ProfileVehicleShowcase :vehicles="vehicles" />
+        </div>
+      </div>
+
+      <!-- Marketplace Listings (flag-gated) -->
+      <div v-if="exchangeEnabled" class="card bg-base-100 shadow-sm border border-base-300">
+        <div class="card-body">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center">
+              <i class="fad fa-tag mr-2"></i>
+              <h3 class="text-lg font-semibold">{{ t('listings.title') }}</h3>
+            </div>
+            <span v-if="!loadingListings" class="text-sm opacity-60">
+              {{ t('listings.count', { count: userListings.length }, userListings.length) }}
+            </span>
+          </div>
+
+          <!-- Loading -->
+          <div v-if="loadingListings" class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6 mt-4">
+            <div v-for="i in 3" :key="i" class="skeleton h-80 w-full"></div>
+          </div>
+
+          <!-- Listings grid -->
+          <div v-else-if="userListings.length > 0" class="grid sm:grid-cols-2 xl:grid-cols-3 gap-6 mt-4">
+            <ExchangeListingsListingCard
+              v-for="listing in userListings"
+              :key="listing.id"
+              :listing="listing"
+              :show-seller-info="false"
+            />
+          </div>
+
+          <!-- Empty -->
+          <div v-else class="text-center py-8 opacity-60">
+            <i class="fas fa-inbox text-4xl mb-3 block"></i>
+            <p>{{ t('listings.empty') }}</p>
+          </div>
         </div>
       </div>
 
@@ -212,6 +293,7 @@
     "vehicles": {
       "title": "Their Minis"
     },
+    "listings": {"title": "Active Listings", "count": "{count} listing | {count} listings", "empty": "This member hasn't posted any listings."},
     "gear_configs": {
       "title": "Gear Configurations",
       "empty": "No public configurations shared.",
@@ -237,6 +319,7 @@
     "vehicles": {
       "title": "Sus Minis"
     },
+    "listings": {"title": "Anuncios activos", "count": "{count} anuncio | {count} anuncios", "empty": "Este miembro no ha publicado ningún anuncio."},
     "gear_configs": {
       "title": "Configuraciones de Engranajes",
       "empty": "No hay configuraciones públicas compartidas.",
@@ -262,6 +345,7 @@
     "vehicles": {
       "title": "Ses Minis"
     },
+    "listings": {"title": "Annonces actives", "count": "{count} annonce | {count} annonces", "empty": "Ce membre n'a publié aucune annonce."},
     "gear_configs": {
       "title": "Configurations d'Engrenages",
       "empty": "Aucune configuration publique partagée.",
@@ -287,6 +371,7 @@
     "vehicles": {
       "title": "Ihre Minis"
     },
+    "listings": {"title": "Aktive Inserate", "count": "{count} Inserat | {count} Inserate", "empty": "Dieses Mitglied hat noch keine Inserate veröffentlicht."},
     "gear_configs": {
       "title": "Getriebe-Konfigurationen",
       "empty": "Keine öffentlichen Konfigurationen geteilt.",
@@ -312,6 +397,7 @@
     "vehicles": {
       "title": "Le Sue Mini"
     },
+    "listings": {"title": "Annunci attivi", "count": "{count} annuncio | {count} annunci", "empty": "Questo membro non ha pubblicato alcun annuncio."},
     "gear_configs": {
       "title": "Configurazioni Ingranaggi",
       "empty": "Nessuna configurazione pubblica condivisa.",
@@ -337,6 +423,7 @@
     "vehicles": {
       "title": "Seus Minis"
     },
+    "listings": {"title": "Anúncios ativos", "count": "{count} anúncio | {count} anúncios", "empty": "Este membro não publicou nenhum anúncio."},
     "gear_configs": {
       "title": "Configurações de Engrenagens",
       "empty": "Nenhuma configuração pública compartilhada.",
@@ -362,6 +449,7 @@
     "vehicles": {
       "title": "Автомобили"
     },
+    "listings": {"title": "Активные объявления", "count": "{count} объявление | {count} объявлений", "empty": "Этот участник пока не разместил объявлений."},
     "gear_configs": {
       "title": "Конфигурации Передач",
       "empty": "Нет публичных конфигураций.",
@@ -387,6 +475,7 @@
     "vehicles": {
       "title": "所有車両"
     },
+    "listings": {"title": "出品中", "count": "出品 {count} 件", "empty": "このメンバーはまだ出品していません。"},
     "gear_configs": {
       "title": "ギア設定",
       "empty": "公開設定はありません。",
@@ -412,6 +501,7 @@
     "vehicles": {
       "title": "TA的Mini"
     },
+    "listings": {"title": "在售商品", "count": "{count} 件商品", "empty": "该会员还没有发布任何商品。"},
     "gear_configs": {
       "title": "齿轮配置",
       "empty": "暂无公开配置。",
@@ -437,6 +527,7 @@
     "vehicles": {
       "title": "보유 차량"
     },
+    "listings": {"title": "판매 중인 매물", "count": "매물 {count}개", "empty": "이 회원은 아직 등록한 매물이 없습니다."},
     "gear_configs": {
       "title": "기어 구성",
       "empty": "공개된 구성이 없습니다.",

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -35,8 +35,11 @@
       const { data, error } = await applyPhotoOrdering(
         supabase
           .from('listings')
+          // Select * so ExchangeListingsListingCard gets every field it reads
+          // (status, currency, listing_category, manufacturer, country, previous_price,
+          // final_price, city/state_province, featured_until) and sortExamplesLast has `status`.
           .select(
-            `id, title, slug, description, year, model, price, location, condition, tier, created_at,
+            `*,
              listing_photos ( id, storage_path, is_primary, display_order )`
           )
           .eq('user_id', userId)

--- a/app/utils/countryCurrency.ts
+++ b/app/utils/countryCurrency.ts
@@ -1,0 +1,78 @@
+/**
+ * Map a country name to a default currency code from SUPPORTED_CURRENCIES.
+ * Only currencies supported by the app are returned — others fall back to USD.
+ */
+import type { CurrencyCode } from '~/composables/useCurrency';
+
+// Country name (lowercased) → currency code. Only maps to currencies the app
+// actually supports. Regions whose real currency isn't supported are omitted
+// so callers can apply their own fallback.
+const COUNTRY_CURRENCY: Record<string, CurrencyCode> = {
+  // GBP
+  'united kingdom': 'GBP',
+  uk: 'GBP',
+  'great britain': 'GBP',
+  england: 'GBP',
+  scotland: 'GBP',
+  wales: 'GBP',
+  'northern ireland': 'GBP',
+
+  // USD
+  'united states': 'USD',
+  usa: 'USD',
+  america: 'USD',
+
+  // EUR (eurozone)
+  ireland: 'EUR',
+  germany: 'EUR',
+  france: 'EUR',
+  netherlands: 'EUR',
+  'the netherlands': 'EUR',
+  holland: 'EUR',
+  belgium: 'EUR',
+  italy: 'EUR',
+  spain: 'EUR',
+  portugal: 'EUR',
+  austria: 'EUR',
+  finland: 'EUR',
+  luxembourg: 'EUR',
+  greece: 'EUR',
+  malta: 'EUR',
+  cyprus: 'EUR',
+  estonia: 'EUR',
+  latvia: 'EUR',
+  lithuania: 'EUR',
+  slovakia: 'EUR',
+  slovenia: 'EUR',
+  croatia: 'EUR',
+
+  // AUD / NZD / CAD
+  australia: 'AUD',
+  'new zealand': 'NZD',
+  canada: 'CAD',
+
+  // CHF / SEK / NOK
+  switzerland: 'CHF',
+  sweden: 'SEK',
+  norway: 'NOK',
+
+  // JPY / CNY / HKD / SGD / KRW
+  japan: 'JPY',
+  china: 'CNY',
+  'hong kong': 'HKD',
+  singapore: 'SGD',
+  'south korea': 'KRW',
+  korea: 'KRW',
+
+  // MXN
+  mexico: 'MXN',
+};
+
+/**
+ * Get the default currency for a country name. Returns `undefined` if no match
+ * so callers can decide the fallback (typically USD).
+ */
+export function currencyForCountry(country: string | null | undefined): CurrencyCode | undefined {
+  if (!country) return undefined;
+  return COUNTRY_CURRENCY[country.toLowerCase().trim()];
+}

--- a/app/utils/exchangeRoutes.ts
+++ b/app/utils/exchangeRoutes.ts
@@ -1,0 +1,26 @@
+// Single source of truth for "what counts as the Mini Exchange" at the route
+// level, so the cutover flag-gate and the onboarding gate can't drift apart.
+//
+// EXCHANGE_PREFIXES — the marketplace surfaces a logged-in user must have a
+// completed profile to use: the /exchange section plus the user's own
+// marketplace management tabs under /dashboard. Both the flag-gate (hide
+// pre-cutover) and the onboarding-gate (require a complete account) apply here.
+export const EXCHANGE_PREFIXES = [
+  '/exchange',
+  '/dashboard/listings',
+  '/dashboard/wanted',
+  '/dashboard/notifications',
+  '/dashboard/saved-searches',
+];
+
+// Routes that the cutover flag must ALSO hide pre-launch, but that the
+// onboarding gate must NOT force through onboarding:
+//  - /onboarding is the gate's own target (gating it would loop).
+//  - /admin/exchange is internal moderation tooling reached via is_admin;
+//    admins shouldn't be bounced through buyer/seller onboarding.
+export const EXCHANGE_FLAG_PREFIXES = [...EXCHANGE_PREFIXES, '/onboarding', '/admin/exchange'];
+
+/** True when `path` equals or sits under any of `prefixes`. */
+export function pathInPrefixes(path: string, prefixes: string[]): boolean {
+  return prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}

--- a/docs/plans/2026-06-28-exchange-onboarding-gate.md
+++ b/docs/plans/2026-06-28-exchange-onboarding-gate.md
@@ -76,3 +76,24 @@ toolbox experience a *soft*, dismissible-by-completion nudge instead.
 - **Completion reactivity:** `completeOnboarding` → `fetchUserProfile` refreshes
   `onboarding_completed`, so the nudge vanishes, the chat returns, and the exchange unlocks
   without a reload.
+
+## Post-review adjustments (adversarial review, 2026-06-28)
+
+A 4-lens adversarial review (24 candidate findings → 5 confirmed) drove these:
+
+- **Gate scope (was the real bug):** the hard gate now keys off a shared
+  `~/utils/exchangeRoutes.ts#EXCHANGE_PREFIXES` (= `/exchange` **plus** the user's marketplace
+  dashboard tabs `/dashboard/{listings,wanted,notifications,saved-searches}`), imported by BOTH
+  the flag-gate and the onboarding-gate so the two can't drift. Previously the onboarding gate
+  only matched `/exchange/**`, letting a not-onboarded user reach `/dashboard/listings` (real
+  writes). `/onboarding` and `/admin/exchange` are flag-hidden but intentionally NOT
+  onboarding-gated (admins reach moderation via `is_admin`, not buyer/seller onboarding).
+- **a11y:** the nudge is now an `<aside role="complementary" aria-live="polite">` with a label
+  and `aria-hidden` decorative icons; the avatar picker is keyboard-operable (`role="button"`,
+  `tabindex=0`, Enter/Space handlers, `aria-label`).
+- **Accepted as-is:** nudge shares the bottom-right corner with toasts — but it inherits the
+  exact anchor of the `FloatingChatInput` it replaces, so this is pre-existing corner behavior,
+  not a regression.
+- **Deferred to the profile merge:** `profiles.location` stores the full formatted address
+  (matches TME) while the UI promises "only your country is public" — the public-display
+  contract (country-only rendering on `/users/[id]`) is handled in the seller-signal merge.

--- a/docs/plans/2026-06-28-exchange-onboarding-gate.md
+++ b/docs/plans/2026-06-28-exchange-onboarding-gate.md
@@ -1,0 +1,78 @@
+# Exchange Onboarding Gate
+
+**Date:** 2026-06-28
+**Branch:** `tme-merge`
+**Status:** building
+
+## Goal
+
+Introduce a profile-onboarding concept to CMDIY that gates the **Mini Exchange** behind a
+complete account, without gating the knowledgebase/toolbox. Two tiers:
+
+1. **Soft nudge (toolbox):** for a logged-in user who hasn't completed onboarding, a small
+   fixed bottom-right card **replaces the AI chat overlay** site-wide. It's a CTA that opens
+   the full onboarding experience. Non-blocking — the toolbox stays fully usable. Once
+   onboarding is complete, the nudge disappears and the chat overlay returns.
+2. **Hard gate (exchange):** a logged-in user who hasn't completed onboarding cannot enter any
+   `/exchange/**` route — they are redirected to the full `/onboarding` page (non-skippable),
+   with the intended destination preserved as `?redirect=`.
+
+"Verified account" = `profiles.onboarding_completed = true` (display name + location + currency
+set). Email is already verified by magic-link/OAuth at login, so there is **no separate
+verification step**.
+
+## Locked decisions (from the user)
+
+- Nudge is a **site-wide** corner widget that **outranks the chat** for logged-in,
+  not-onboarded users (shows instead of chat; reverts after completion).
+- Nudge modal = a compact card whose **CTA opens the full onboarding** (one form, DRY).
+- "Verified" = **completed profile** only.
+
+## Assumptions (flag if wrong)
+
+- **The whole concept is flag-gated** (`runtimeConfig.public.exchangeEnabled`). Pre-cutover it
+  is fully invisible: no nudge, no gate, `/onboarding` 404s — consistent with the rest of the
+  consolidation living behind the flag.
+- **Anonymous browsing of the exchange stays public.** The hard gate applies to *logged-in*
+  users only; anonymous visitors keep browsing public, indexable listing pages (the locked SEO
+  plan — 301s, sitemaps, canonicals — depends on this). If you actually want the entire
+  marketplace login-walled, that's a larger change and supersedes this assumption.
+- `profiles.onboarding_completed` already exists in the shared DB (`boolean`, default false), so
+  **no migration**. Existing CMDIY users therefore start as "needs onboarding" once the flag
+  flips — intended (the nudge drives completion). (`onboarding_completed_app` is the separate
+  mobile flag — untouched.)
+
+## Pieces
+
+| File | Role |
+|---|---|
+| `app/composables/useOnboardingGate.ts` | **Linchpin.** `needsOnboarding` computed = `exchangeEnabled && isAuthenticated && userProfile && onboarding_completed === false`. Consumed by the nudge, the homepage swap, and (indirectly) the middleware. |
+| `app/middleware/exchange-onboarding.global.ts` | Hard gate. Client-side; flag-gated; only on `/exchange/**`; `waitForAuth` + active `fetchUserProfile`; redirects incomplete **logged-in** users to `/onboarding?redirect=…`. Anonymous → pass. Session cache by user id. |
+| `app/components/OnboardingNudge.vue` | The soft nudge widget. `fixed bottom-6 right-6 z-50`. Renders only when `needsOnboarding`. CTA → `/onboarding?redirect=<current>`. 10-locale i18n. |
+| `app/pages/onboarding.vue` | The full experience (port of TME's). `layout: false`, `middleware: exchange-auth` (must be logged in). Collects display name (req), location (req), preferred currency, bio, avatar. On complete → `fetchUserProfile` (flips `needsOnboarding`) → redirect to safe `?redirect=` or `/exchange`. 10-locale i18n. |
+| `app/composables/useProfile.ts` | Add `completeOnboarding()` (upsert profile + `onboarding_completed: true`). |
+| `app/utils/countryCurrency.ts` | Ported — currency auto-follows the location country until the user overrides. |
+| `app/composables/useAuth.ts` | Add `onboarding_completed` to the `UserProfile` type **and** the `fetchUserProfile` select (currently omitted — the gate would read `undefined` otherwise). |
+| `app/middleware/exchange-flag.global.ts` | Add `/onboarding` to `GUARDED_PREFIXES` so the page is invisible pre-cutover. |
+| `app/app.vue` | Mount `<OnboardingNudge />` globally (self-gates via `v-if`). |
+| `app/pages/index.vue` | Render `<FloatingChatInput v-if="!needsOnboarding" />` so the homepage chat yields to the nudge. |
+
+## Why not a global onboarding wall (the TME approach)
+
+TME's `onboarding.global.ts` runs on every route for every logged-in user — fine for a
+pure marketplace, but in CMDIY it would wall the entire knowledgebase userbase behind a
+marketplace setup form. This design scopes the *hard* gate to `/exchange/**` and makes the
+toolbox experience a *soft*, dismissible-by-completion nudge instead.
+
+## Edge cases handled
+
+- **Loading race:** the middleware awaits auth + actively fetches the profile before deciding,
+  so a not-onboarded user can't slip into `/exchange` during the auth-load window. The reactive
+  `needsOnboarding` stays false while the profile is null (no premature nudge / no flash beyond
+  the normal post-hydration auth settle).
+- **No trap:** middleware never redirects `/onboarding` or `/auth/callback` to itself.
+- **redirect safety:** the onboarding page only honors `?redirect=` values that start with a
+  single `/` (internal paths); otherwise falls back to `/exchange`.
+- **Completion reactivity:** `completeOnboarding` → `fetchUserProfile` refreshes
+  `onboarding_completed`, so the nudge vanishes, the chat returns, and the exchange unlocks
+  without a reload.


### PR DESCRIPTION
## Section 9 of 10 — TheMiniExchange consolidation

Flag-gated behind `NUXT_PUBLIC_EXCHANGE_ENABLED` (invisible/404 in prod until cutover). 19 files / ~4.3k lines. All translatable surfaces ship `<i18n>` blocks with all 10 locales (verified: valid JSON, no HTML in message values).

### Onboarding gate (design: `docs/plans/2026-06-28-exchange-onboarding-gate.md`)
- `useOnboardingGate.ts` — `needsOnboarding` linchpin (`exchangeEnabled && authed && profile && onboarding_completed === false`)
- `exchange-onboarding.global.ts` — hard gate on `/exchange/**` + marketplace dashboard tabs (shared `exchangeRoutes.ts#EXCHANGE_PREFIXES`); anonymous passes; awaits auth + profile before deciding
- `OnboardingNudge.vue` — soft site-wide corner nudge that replaces the chat for not-onboarded logged-in users (`<aside role=complementary aria-live=polite>`)
- `onboarding.vue` — full onboarding flow (display name + location + currency + bio + avatar); `?redirect=` honored only for internal `/`-prefixed paths
- `useProfile.completeOnboarding()`, `useAuth` adds `onboarding_completed` to type + select, `countryCurrency.ts`, `app.vue` mounts the nudge, `index.vue` yields the homepage chat to the nudge

### Pages ported
- `exchange/{watchlist,safety,feeds,social,how-it-works}` + `exchange/messages/index` (conversation list)
- `users/[id].vue` — **seller signals folded into the public profile** (member-since, listing counts, active listings grid)

### Notes for review
- **Public profile honors the country-only contract:** `/users/[id]` renders `getPublicLocation()` (country + flag only) and exposes **no email** — the full address stays private.
- Onboarding-gate review round already addressed in `1d2dbb21` (gate-scope hole + a11y).
- Folded a daisyUI 5 tab-class fix (`tabs-bordered`→`tabs-border`) into `exchange/messages/index.vue` (pre-empts the PR #646 finding; v4 name is a silent no-op in v5).