### PR TITLE
feat(exchange): feeds + sitemap/robots + legal + 301 redirects (10/10)

### DIFF
--- a/app/pages/legal/marketplace-terms.vue
+++ b/app/pages/legal/marketplace-terms.vue
@@ -1,0 +1,665 @@
+<script setup lang="ts">
+  // The Mini Exchange marketplace Terms of Use, ported into CMDIY as the
+  // authoritative ENGLISH-ONLY legal page for the /exchange marketplace.
+  // Like all /legal/* pages this is intentionally NOT internationalized.
+  import { HERO_TYPES } from '~~/data/models/generic';
+
+  const lastUpdated = 'February 7, 2026';
+
+  useHead({
+    title: 'Terms of Use | Classic Mini DIY',
+    link: [{ rel: 'canonical', href: 'https://www.classicminidiy.com/legal/marketplace-terms' }],
+  });
+  useSeoMeta({
+    description:
+      'Terms of Use for The Mini Exchange marketplace. Read our comprehensive terms governing the use of our Classic Mini marketplace platform, including user responsibilities, dispute resolution, and legal provisions.',
+    ogTitle: 'Terms of Use | Classic Mini DIY',
+    ogType: 'website',
+  });
+</script>
+
+<template>
+  <hero title="Terms of Use" :subtitle="'The Mini Exchange marketplace'" :heroType="HERO_TYPES.ARCHIVE" :navigation="true" />
+
+  <div class="container mx-auto px-4 py-8 max-w-4xl">
+    <breadcrumb class="my-6" page="Terms of Use" />
+
+    <p class="text-base-content/70 mb-8">Last updated: {{ lastUpdated }}</p>
+
+    <div class="prose prose-lg max-w-none">
+      <h2>1. Acceptance of Terms</h2>
+      <p>
+        These Terms of Use ("Terms") govern your access to and use of The Mini Exchange website and services
+        (collectively, the "Platform"). The Platform is operated by The Mini Exchange ("we," "us," or "our").
+      </p>
+      <p>
+        <strong
+          >By accessing or using the Platform, you agree to be bound by these Terms and our Privacy Notice. If you do
+          not agree to these Terms, you may not access or use the Platform.</strong
+        >
+      </p>
+      <p>
+        These Terms constitute a legally binding agreement between you and The Mini Exchange. We may modify these
+        Terms at any time, and your continued use of the Platform after changes are posted constitutes acceptance of
+        the modified Terms.
+      </p>
+
+      <h2>2. Description of Service and Platform Role</h2>
+
+      <h3>2.1 What We Provide</h3>
+      <p>
+        The Mini Exchange is an online marketplace platform exclusively for Classic Mini Cooper vehicles (1959-2000).
+        The Platform allows users to:
+      </p>
+      <ul>
+        <li>Create and publish classified listings for Classic Mini vehicles, parts, and related items</li>
+        <li>Browse, search, and filter available listings</li>
+        <li>Communicate with other users through our messaging system</li>
+        <li>Post questions and comments on listings</li>
+        <li>Save favorite listings to a watchlist</li>
+        <li>Purchase premium listing features (Premium tier, $10)</li>
+      </ul>
+
+      <h3>2.2 What We Are Not</h3>
+      <p>
+        <strong
+          >The Mini Exchange is a marketplace platform only. We are not a vehicle dealer, broker, auction house, or
+          traditional intermediary.</strong
+        >
+        We do not:
+      </p>
+      <ul>
+        <li>Own, possess, sell, or broker any vehicles, parts, or items listed on the Platform</li>
+        <li>Take title to or physical possession of any listed items</li>
+        <li>Process, facilitate, or guarantee payments between buyers and sellers for vehicle transactions</li>
+        <li>Inspect, verify, authenticate, or validate vehicles or listings</li>
+        <li>Arrange transportation, shipping, or delivery of vehicles</li>
+        <li>Provide warranties or guarantees regarding vehicles or sellers</li>
+        <li>Act as an agent for buyers or sellers</li>
+      </ul>
+      <p>
+        All transactions occur directly between buyers and sellers. We provide the platform for users to connect, but
+        we are not a party to any transaction.
+      </p>
+
+      <h2>3. User Accounts and Eligibility</h2>
+
+      <h3>3.1 Account Registration</h3>
+      <p>
+        To access certain features of the Platform (posting listings, messaging, commenting), you must create an
+        account by providing a valid email address. When you create an account, you agree to:
+      </p>
+      <ul>
+        <li>Provide accurate, current, and complete information</li>
+        <li>Maintain and promptly update your account information to keep it accurate and current</li>
+        <li>Maintain the security and confidentiality of your account credentials</li>
+        <li>Notify us immediately of any unauthorized access or security breach</li>
+        <li>Accept responsibility for all activities that occur under your account</li>
+      </ul>
+      <p>
+        You may not share, transfer, or sell your account to another person. You are solely responsible for your
+        account and any activity occurring through it, whether or not you authorized such activity.
+      </p>
+
+      <h3>3.2 Eligibility</h3>
+      <p>
+        You must be at least 18 years old to use the Platform. By using the Platform, you represent and warrant that
+        you are at least 18 years of age and have the legal capacity to enter into these Terms.
+      </p>
+
+      <h3>3.3 Account Suspension and Termination</h3>
+      <p>
+        We reserve the right to suspend, disable, or terminate your account at any time, with or without notice, for
+        any reason, including if we believe you have:
+      </p>
+      <ul>
+        <li>Violated these Terms or our policies</li>
+        <li>Engaged in fraudulent, deceptive, or illegal activity</li>
+        <li>Posed a risk to the Platform, other users, or third parties</li>
+        <li>Created liability for us or exposed us to legal action</li>
+        <li>Engaged in conduct harmful to our business or reputation</li>
+      </ul>
+      <p>
+        If your account is terminated, you may not create a new account or access the Platform using another account
+        without our express written permission. Attempting to circumvent an account suspension or termination is a
+        violation of these Terms.
+      </p>
+      <p>
+        You may terminate your account at any time by contacting us at
+        <a href="mailto:hello@theminiexchange.com" class="link link-primary">hello@theminiexchange.com</a>. Upon
+        termination, your right to access and use the Platform immediately ceases.
+      </p>
+
+      <h2>4. User Conduct and Prohibited Activities</h2>
+
+      <h3>4.1 General Conduct</h3>
+      <p>You agree to use the Platform in a lawful, respectful, and responsible manner. You agree not to:</p>
+      <ul>
+        <li>Violate any applicable local, state, federal, or international law or regulation</li>
+        <li>Engage in any fraudulent, deceptive, misleading, or manipulative activity</li>
+        <li>Infringe upon the intellectual property, privacy, publicity, or other rights of any third party</li>
+        <li>Harass, threaten, intimidate, abuse, defame, or otherwise harm other users</li>
+        <li>Post or transmit content that is unlawful, hateful, discriminatory, or offensive</li>
+        <li>
+          Impersonate any person or entity, or falsely state or misrepresent your affiliation with any person or
+          entity
+        </li>
+        <li>Interfere with or disrupt the Platform, servers, networks, or security measures</li>
+        <li>
+          Collect, harvest, or scrape personal data from other users or use automated systems (bots, scripts,
+          crawlers) to access the Platform without our express written permission
+        </li>
+        <li>Attempt to gain unauthorized access to any portion of the Platform, other accounts, or systems</li>
+        <li>Transmit viruses, malware, or any other malicious code</li>
+        <li>Circumvent any security features or access restrictions</li>
+        <li>Use the Platform for any commercial purpose not expressly permitted by these Terms</li>
+      </ul>
+
+      <h3>4.2 Prohibited Listing Content</h3>
+      <p>When creating listings, you may not:</p>
+      <ul>
+        <li>Post false, inaccurate, misleading, or deceptive information about vehicles</li>
+        <li>Misrepresent the condition, history, title status, or specifications of a vehicle</li>
+        <li>List vehicles you do not own or have authority to sell</li>
+        <li>List stolen vehicles or vehicles with fraudulent documentation</li>
+        <li>
+          List items that are not Classic Mini vehicles, parts, or directly related accessories (1959-2000 only)
+        </li>
+        <li>Use photos you do not own or have permission to use</li>
+        <li>Include external links or contact information intended to circumvent the Platform's messaging system</li>
+        <li>
+          List the same vehicle on multiple accounts or repeatedly post identical listings to manipulate visibility
+        </li>
+      </ul>
+
+      <h3>4.3 Messaging and Communication</h3>
+      <p>When using the Platform's messaging system, you agree not to:</p>
+      <ul>
+        <li>Send spam, unsolicited advertisements, or promotional content</li>
+        <li>Share external payment links or attempt to process payments outside approved methods</li>
+        <li>Harass or abuse other users</li>
+        <li>Share personal information of others without consent</li>
+        <li>Use offensive, abusive, or inappropriate language in messages or public comments</li>
+      </ul>
+      <p>
+        Messages and comments are subject to automated content moderation. Content containing profanity, personal
+        contact information (phone numbers, email addresses), or external URLs may be flagged or filtered.
+      </p>
+      <p>
+        The Contact Seller form allows unauthenticated visitors to send inquiries to sellers. By submitting this form,
+        you consent to your name and email address being shared with the seller so they can respond to your inquiry.
+      </p>
+
+      <h3>4.4 Comments</h3>
+      <p>When posting comments on listings, you agree to the following rules:</p>
+      <ul>
+        <li>Comments are limited to 2,000 characters</li>
+        <li>Threaded replies are supported for organized discussion</li>
+        <li>Comments may be edited within 15 minutes of posting</li>
+        <li>Comments may be deleted at any time by the author</li>
+        <li>All comments are subject to automated content moderation and manual review</li>
+        <li>Comments that violate these Terms or our content guidelines may be removed without notice</li>
+      </ul>
+
+      <h2>5. Listing Guidelines and Seller Obligations</h2>
+
+      <h3>5.1 Listing Requirements</h3>
+      <p>When posting a listing, you represent and warrant that:</p>
+      <ul>
+        <li>All information provided is accurate, complete, and truthful</li>
+        <li>You have the legal right and authority to sell the item</li>
+        <li>The item is a Classic Mini Cooper vehicle or directly related part/accessory from the 1959-2000 era</li>
+        <li>All photos are your own or you have explicit permission to use them</li>
+        <li>You have disclosed all known defects, damage, modifications, and issues</li>
+        <li>The vehicle has a clear title or you have fully disclosed any title issues</li>
+        <li>The listing complies with all applicable laws and regulations</li>
+      </ul>
+
+      <h3>5.2 Disclosure Obligations</h3>
+      <p>Sellers must disclose:</p>
+      <ul>
+        <li>Accurate mileage (or indicate if mileage is unknown/exempt)</li>
+        <li>Known mechanical issues, defects, or damage</li>
+        <li>Previous accidents or collision repairs</li>
+        <li>Title status (clean, salvage, rebuilt, etc.)</li>
+        <li>Any liens or encumbrances on the vehicle</li>
+        <li>Modifications from original factory specifications</li>
+        <li>Whether the vehicle is currently registered and emissions-compliant</li>
+      </ul>
+
+      <h3>5.3 Listing During Publication</h3>
+      <p>
+        While your listing is active on The Mini Exchange, you may not simultaneously list the same vehicle on other
+        classified or dealer platforms without updating or removing your listing if the vehicle sells elsewhere. You
+        must promptly mark listings as sold when a sale is completed.
+      </p>
+
+      <h3>5.4 Listing Moderation</h3>
+      <p>
+        All listings are subject to review and moderation. We reserve the right to reject, remove, or modify any
+        listing that violates these Terms, contains inappropriate content, or does not meet our quality standards. We
+        may also remove listings that appear to be duplicates, spam, or not relevant to Classic Minis (1959-2000).
+      </p>
+      <p>
+        Certain changes to published listings (such as price, year, model, or VIN) require admin review and approval
+        before taking effect. You will be notified when your edit request is approved or rejected.
+      </p>
+      <p>
+        Sold listings may remain publicly visible in our Sold Archive as historical reference for the Classic Mini
+        community. Sold listings are attributed to your account unless you delete your account, in which case they
+        will be anonymized.
+      </p>
+      <p>
+        Active listing data (including title, description, photos, seller display name, and creation date) is included
+        in our public RSS, Atom, and JSON feeds for syndication purposes.
+      </p>
+
+      <h2>6. Buyer and Seller Responsibilities</h2>
+
+      <h3>6.1 Buyer Responsibilities and Due Diligence</h3>
+      <p>As a buyer, you acknowledge and agree that you are solely responsible for:</p>
+      <ul>
+        <li>Conducting thorough due diligence before purchasing any vehicle</li>
+        <li>
+          Inspecting vehicles in person whenever possible before completing a purchase (or arranging professional
+          inspection services)
+        </li>
+        <li>
+          Verifying ownership, title status, vehicle history reports, and all claims made in listings independently
+        </li>
+        <li>Assessing the condition, authenticity, and value of vehicles</li>
+        <li>Negotiating terms directly with sellers</li>
+        <li>Arranging and paying for transportation, shipping, and delivery</li>
+        <li>Ensuring compliance with registration, taxation, and emissions requirements in your jurisdiction</li>
+        <li>
+          Using secure payment methods and taking appropriate precautions to avoid fraud (never wire money to unknown
+          parties)
+        </li>
+      </ul>
+      <p>
+        <strong
+          >We strongly recommend inspecting any vehicle in person before purchase and never sending payment before
+          seeing the vehicle.</strong
+        >
+      </p>
+
+      <h3>6.2 Seller Responsibilities</h3>
+      <p>As a seller, you are solely responsible for:</p>
+      <ul>
+        <li>Accurately representing your vehicle and complying with all disclosure requirements</li>
+        <li>Providing clear and marketable title to any vehicle sold</li>
+        <li>Complying with all applicable local, state, and federal laws regarding vehicle sales</li>
+        <li>Communicating honestly and promptly with potential buyers</li>
+        <li>Removing or marking listings as sold promptly after completing a sale</li>
+        <li>Paying any applicable taxes on proceeds from your sales</li>
+        <li>Honoring commitments made to buyers</li>
+      </ul>
+
+      <h3>6.3 No Platform Involvement in Transactions</h3>
+      <p>
+        <strong
+          >All transactions occur directly between buyers and sellers. The Mini Exchange is not a party to any
+          transaction.</strong
+        >
+        We do not process vehicle payments, hold funds in escrow, or guarantee transactions. Buyers and sellers must
+        arrange payment, delivery, and all transaction terms independently.
+      </p>
+
+      <h2>7. Payment Terms</h2>
+
+      <h3>7.1 Listing Tiers and Fees</h3>
+      <p>The Platform offers two listing tiers:</p>
+      <ul>
+        <li>
+          <strong>Free Tier</strong>: No cost. Up to 5 photos, standard visibility, Q&amp;A comments, and messaging.
+          All listings are subject to admin approval before going live.
+        </li>
+        <li>
+          <strong>Premium Tier</strong>: $10 USD one-time payment. Up to 20 photos, featured placement for 30 days,
+          priority in search results, homepage carousel exposure, and a featured badge on your listing. All listings
+          are subject to admin approval before going live.
+        </li>
+      </ul>
+      <p>
+        Premium listing payments are processed securely through Stripe. All fees are non-refundable once your listing
+        is published, except as required by law or at our sole discretion.
+      </p>
+
+      <h3>7.2 Payment Processing</h3>
+      <p>
+        Premium listing payments are processed by Stripe, a third-party payment processor. By making a payment, you
+        agree to Stripe's Terms of Service and Privacy Policy. We do not store complete payment card information on
+        our servers.
+      </p>
+
+      <h3>7.3 Taxes</h3>
+      <p>
+        You are responsible for paying any applicable taxes on premium listing purchases. Sellers are responsible for
+        paying any applicable taxes on proceeds from vehicle sales. We do not collect or remit taxes on behalf of
+        users.
+      </p>
+
+      <h3>7.4 No Vehicle Transaction Fees</h3>
+      <p>
+        <strong>We do not charge transaction fees or commissions on vehicle sales between buyers and sellers.</strong>
+        The Platform's revenue comes solely from optional premium listing features.
+      </p>
+
+      <h2>8. Disclaimers and Warranties</h2>
+
+      <h3>8.1 "AS IS" Disclaimer</h3>
+      <p>
+        <strong
+          >THE PLATFORM AND ALL CONTENT, MATERIALS, INFORMATION, LISTINGS, AND SERVICES ARE PROVIDED "AS IS" AND "AS
+          AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED.</strong
+        >
+      </p>
+      <p>
+        TO THE FULLEST EXTENT PERMITTED BY LAW, THE MINI EXCHANGE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED,
+        INCLUDING BUT NOT LIMITED TO:
+      </p>
+      <ul>
+        <li>Warranties of merchantability, fitness for a particular purpose, and non-infringement</li>
+        <li>Warranties regarding the accuracy, reliability, completeness, or timeliness of content or listings</li>
+        <li>Warranties that the Platform will be uninterrupted, secure, or error-free</li>
+        <li>Warranties regarding the quality, safety, or legality of vehicles listed</li>
+        <li>Warranties regarding other users or their conduct</li>
+      </ul>
+
+      <h3>8.2 No Verification or Endorsement</h3>
+      <p>
+        <strong
+          >We do not verify, authenticate, inspect, or endorse any listings, vehicles, or users. We make no
+          representations or warranties about the accuracy of listings, the quality of vehicles, or the
+          trustworthiness of users.</strong
+        >
+        Any reliance on listings or user-generated content is at your own risk.
+      </p>
+
+      <h3>8.3 No Guarantee of Results</h3>
+      <p>
+        We do not guarantee that using the Platform will result in any particular outcome, including the sale or
+        purchase of a vehicle. Premium listing features provide enhanced visibility but do not guarantee a sale.
+      </p>
+
+      <h2>9. Limitation of Liability</h2>
+
+      <h3>9.1 Damages Limitation</h3>
+      <p>
+        TO THE FULLEST EXTENT PERMITTED BY LAW, IN NO EVENT SHALL THE MINI EXCHANGE, ITS OFFICERS, DIRECTORS,
+        EMPLOYEES, AGENTS, OR AFFILIATES BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, PUNITIVE, OR
+        EXEMPLARY DAMAGES ARISING FROM OR RELATED TO YOUR USE OF THE PLATFORM, INCLUDING BUT NOT LIMITED TO:
+      </p>
+      <ul>
+        <li>Loss of profits, revenue, business opportunities, or data</li>
+        <li>Loss resulting from fraudulent transactions or misrepresentations by other users</li>
+        <li>Vehicle defects, damage, or condition issues</li>
+        <li>Personal injury or property damage resulting from vehicles</li>
+        <li>Disputes between buyers and sellers</li>
+        <li>Unauthorized access to your account or personal information</li>
+        <li>Errors, bugs, viruses, or interruptions in Platform service</li>
+        <li>Actions or omissions of other users</li>
+      </ul>
+
+      <h3>9.2 Liability Cap</h3>
+      <p>
+        TO THE EXTENT LIABILITY CANNOT BE EXCLUDED BY LAW, OUR TOTAL AGGREGATE LIABILITY TO YOU FOR ALL CLAIMS ARISING
+        FROM OR RELATED TO THE PLATFORM SHALL NOT EXCEED THE GREATER OF (A) FIFTY DOLLARS ($50 USD) OR (B) THE TOTAL
+        AMOUNT YOU PAID TO US IN THE TWELVE (12) MONTHS PRECEDING THE EVENT GIVING RISE TO LIABILITY.
+      </p>
+
+      <h3>9.3 Release from User Disputes</h3>
+      <p>
+        <strong
+          >YOU RELEASE THE MINI EXCHANGE, ITS OFFICERS, DIRECTORS, EMPLOYEES, AGENTS, AND AFFILIATES FROM ALL CLAIMS,
+          DEMANDS, AND DAMAGES ARISING OUT OF OR RELATED TO DISPUTES WITH OTHER USERS OR THIRD PARTIES.</strong
+        >
+      </p>
+      <p>
+        If you are a California resident, you waive California Civil Code Section 1542, which states: "A general
+        release does not extend to claims that the creditor or releasing party does not know or suspect to exist in
+        his or her favor at the time of executing the release and that, if known by him or her, would have materially
+        affected his or her settlement with the debtor or released party."
+      </p>
+
+      <h3>9.4 Force Majeure</h3>
+      <p>
+        We shall not be liable for any failure or delay in performance due to circumstances beyond our reasonable
+        control, including acts of God, natural disasters, war, terrorism, pandemics, labor disputes, or government
+        actions.
+      </p>
+
+      <h2>10. Intellectual Property</h2>
+
+      <h3>10.1 Platform Ownership</h3>
+      <p>
+        The Platform, including its design, features, software, code, graphics, user interface, and all content
+        (excluding user-generated content), is owned by The Mini Exchange and protected by copyright, trademark, and
+        other intellectual property laws. All rights are reserved.
+      </p>
+
+      <h3>10.2 Restrictions on Use</h3>
+      <p>You may not:</p>
+      <ul>
+        <li>Copy, modify, distribute, sell, or lease any part of the Platform or its software</li>
+        <li>Reverse engineer, decompile, or attempt to extract source code from the Platform</li>
+        <li>Remove, alter, or obscure any copyright, trademark, or proprietary notices</li>
+        <li>Use the Platform's name, trademarks, or branding without our express written permission</li>
+        <li>Build a competing business, product, or service using the Platform or its content</li>
+        <li>Frame, mirror, or otherwise incorporate the Platform into another website without permission</li>
+      </ul>
+
+      <h3>10.3 User Content License</h3>
+      <p>
+        By posting content on the Platform (including listings, photos, messages, comments, and descriptions), you
+        grant The Mini Exchange a worldwide, non-exclusive, royalty-free, fully paid, sublicensable, and transferable
+        license to use, reproduce, modify, adapt, publish, display, distribute, and create derivative works from your
+        content for the purpose of operating, promoting, and improving the Platform.
+      </p>
+      <p>This license continues even after you stop using the Platform or delete your account.</p>
+
+      <h3>10.4 User Content Representations</h3>
+      <p>You represent and warrant that:</p>
+      <ul>
+        <li>You own or have the necessary rights to all content you post</li>
+        <li>Your content does not infringe any third-party intellectual property, privacy, or publicity rights</li>
+        <li>Your content complies with these Terms and all applicable laws</li>
+        <li>You have obtained all necessary permissions to use photos, descriptions, or other materials you post</li>
+      </ul>
+
+      <h3>10.5 Copyright Infringement</h3>
+      <p>
+        If you believe content on the Platform infringes your copyright, please contact us at
+        <a href="mailto:hello@theminiexchange.com" class="link link-primary">hello@theminiexchange.com</a>
+        with detailed information about the alleged infringement. We will investigate and take appropriate action,
+        which may include removing the content.
+      </p>
+
+      <h2>11. Indemnification</h2>
+      <p>
+        <strong
+          >You agree to indemnify, defend, and hold harmless The Mini Exchange, its officers, directors, employees,
+          agents, affiliates, and service providers from and against any and all claims, demands, losses, liabilities,
+          damages, costs, and expenses (including reasonable attorneys' fees) arising from or related to:</strong
+        >
+      </p>
+      <ul>
+        <li>Your use or misuse of the Platform</li>
+        <li>Your violation of these Terms</li>
+        <li>Your violation of any law or regulation</li>
+        <li>
+          Your violation of any rights of a third party, including intellectual property, privacy, or publicity rights
+        </li>
+        <li>Your content, including listings, photos, messages, and comments</li>
+        <li>Any transaction or dispute with another user</li>
+        <li>Your sale or purchase of a vehicle through the Platform</li>
+        <li>Any negligence, willful misconduct, or fraud on your part</li>
+      </ul>
+      <p>
+        This indemnification obligation survives termination of your account and your use of the Platform. We reserve
+        the right to assume exclusive defense and control of any matter subject to indemnification, at your expense.
+      </p>
+
+      <h2>12. Dispute Resolution and Arbitration</h2>
+
+      <h3>12.1 Informal Resolution First</h3>
+      <p>
+        If you have a dispute with The Mini Exchange, you agree to first contact us at
+        <a href="mailto:hello@theminiexchange.com" class="link link-primary">hello@theminiexchange.com</a>
+        and attempt to resolve the dispute informally for at least 30 days before initiating arbitration or
+        litigation.
+      </p>
+
+      <h3>12.2 Binding Arbitration</h3>
+      <p>
+        <strong
+          >PLEASE READ THIS SECTION CAREFULLY. IT AFFECTS YOUR LEGAL RIGHTS, INCLUDING YOUR RIGHT TO FILE A LAWSUIT IN
+          COURT.</strong
+        >
+      </p>
+      <p>
+        You and The Mini Exchange agree that any dispute, claim, or controversy arising out of or relating to these
+        Terms or your use of the Platform (except disputes related to intellectual property rights) shall be resolved
+        exclusively through binding individual arbitration rather than in court.
+      </p>
+      <p>
+        Arbitration shall be conducted under the American Arbitration Association (AAA) Consumer Arbitration Rules.
+      </p>
+
+      <h3>12.3 Class Action Waiver</h3>
+      <p>
+        <strong
+          >YOU AND THE MINI EXCHANGE AGREE THAT DISPUTES SHALL BE RESOLVED ON AN INDIVIDUAL BASIS ONLY. YOU WAIVE YOUR
+          RIGHT TO PARTICIPATE IN A CLASS ACTION LAWSUIT OR CLASS-WIDE ARBITRATION.</strong
+        >
+        Any arbitration shall be conducted on an individual basis and not as a class, consolidated, or representative
+        action.
+      </p>
+
+      <h3>12.4 Exceptions to Arbitration</h3>
+      <p>The following disputes are not subject to arbitration:</p>
+      <ul>
+        <li>Disputes related to intellectual property rights (trademarks, copyrights, patents)</li>
+        <li>Claims that can be brought in small claims court</li>
+        <li>
+          Requests for injunctive or equitable relief to prevent infringement or misuse of intellectual property
+        </li>
+      </ul>
+
+      <h3>12.5 User-to-User Disputes</h3>
+      <p>
+        <strong
+          >Disputes between users (buyer-seller disagreements, transaction disputes, etc.) are the sole responsibility
+          of the parties involved.</strong
+        >
+        The Mini Exchange is not obligated to mediate, resolve, or intervene in user-to-user disputes. We encourage
+        users to communicate directly and resolve disputes amicably.
+      </p>
+      <p>
+        If you have a dispute with another user, you release The Mini Exchange from all claims, demands, and damages
+        arising from or related to that dispute.
+      </p>
+
+      <h2>13. Governing Law and Venue</h2>
+      <p>
+        These Terms shall be governed by and construed in accordance with the laws of the State of California, without
+        regard to its conflict of law provisions. Any litigation not subject to arbitration shall be brought
+        exclusively in the state or federal courts located in California, and you consent to the personal jurisdiction
+        of those courts.
+      </p>
+
+      <h2>14. Modifications to Terms</h2>
+      <p>
+        We reserve the right to modify, amend, or update these Terms at any time, at our sole discretion. When we make
+        changes, we will:
+      </p>
+      <ul>
+        <li>Update the "Last Updated" date at the top of this page</li>
+        <li>Post the revised Terms on the Platform</li>
+        <li>For material changes, provide notice via email or a prominent Platform notification</li>
+      </ul>
+      <p>
+        Your continued use of the Platform after changes are posted constitutes your acceptance of the modified Terms.
+        If you do not agree to the modified Terms, you must stop using the Platform immediately.
+      </p>
+
+      <h2>15. Modifications to Platform Services</h2>
+      <p>
+        We reserve the right to modify, suspend, or discontinue any aspect of the Platform (including features,
+        pricing, and availability) at any time, with or without notice, and without liability to you or any third
+        party.
+      </p>
+
+      <h2>16. Privacy</h2>
+      <p>
+        Your use of the Platform is also governed by our
+        <NuxtLink to="/privacy" class="link link-primary">Privacy Notice</NuxtLink>, which describes how we collect,
+        use, and protect your personal information. By using the Platform, you consent to our collection and use of
+        your information as described in the Privacy Notice.
+      </p>
+
+      <h2>17. Third-Party Links and Services</h2>
+      <p>
+        The Platform may contain links to third-party websites, services, or resources (such as Stripe for payment
+        processing). We are not responsible for the content, policies, or practices of third-party websites or
+        services. Your use of third-party services is subject to their own terms and policies.
+      </p>
+
+      <h2>18. Entire Agreement</h2>
+      <p>
+        These Terms, together with our Privacy Notice and any other policies referenced herein, constitute the entire
+        agreement between you and The Mini Exchange regarding your use of the Platform and supersede all prior
+        agreements, understandings, and communications, whether written or oral.
+      </p>
+
+      <h2>19. Severability</h2>
+      <p>
+        If any provision of these Terms is found to be invalid, illegal, or unenforceable by a court of competent
+        jurisdiction, that provision shall be limited or eliminated to the minimum extent necessary, and the remaining
+        provisions shall remain in full force and effect.
+      </p>
+
+      <h2>20. Waiver</h2>
+      <p>
+        Our failure to enforce any provision of these Terms shall not constitute a waiver of that provision or any
+        other provision. No waiver shall be effective unless made in writing and signed by an authorized
+        representative of The Mini Exchange.
+      </p>
+
+      <h2>21. Assignment</h2>
+      <p>
+        You may not assign, transfer, or delegate these Terms or your rights and obligations hereunder without our
+        prior written consent. We may assign these Terms without restriction. Any attempted assignment in violation of
+        this provision is void.
+      </p>
+
+      <h2>22. Survival</h2>
+      <p>
+        Provisions of these Terms that by their nature should survive termination shall survive, including but not
+        limited to: intellectual property provisions, disclaimers, limitations of liability, indemnification, dispute
+        resolution, and governing law.
+      </p>
+
+      <h2>23. Contact Information</h2>
+      <p>For questions, concerns, or notices regarding these Terms of Use, please contact us at:</p>
+      <p>
+        <strong>Email:</strong>
+        <a href="mailto:hello@theminiexchange.com" class="link link-primary">hello@theminiexchange.com</a>
+      </p>
+      <p><strong>Subject Line:</strong> Terms of Use Inquiry</p>
+
+      <div class="alert alert-warning mt-8">
+        <i class="fas fa-triangle-exclamation"></i>
+        <div>
+          <h3 class="font-bold">Important Safety Notice</h3>
+          <p class="text-sm mt-1">
+            <strong>Always inspect vehicles in person before purchasing.</strong> Verify ownership documentation,
+            obtain vehicle history reports, and use secure payment methods. Never wire money to unknown parties or
+            send payment before seeing a vehicle in person. If an offer seems too good to be true, it probably is.
+            Report suspicious activity to us immediately.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -197,6 +197,8 @@ export default defineNuxtConfig({
       '/api/__sitemap__/colors',
       '/api/__sitemap__/wheels',
       '/api/__sitemap__/documents',
+      // Marketplace URLs (flag-gated inside the source — empty pre-cutover).
+      '/api/__sitemap__/exchange',
     ],
     xslColumns: [
       { label: 'URL', width: '50%' },
@@ -226,6 +228,27 @@ export default defineNuxtConfig({
       // module can't see — exclude them here too to avoid mixed signals).
       '/membership/claim',
       '/discord/connect',
+      // All admin sub-pages are private/noindex — keep them out of the sitemap
+      // (the bare `/admin` above only matched the index).
+      '/admin/**',
+      // Private marketplace surfaces are never in the sitemap. Public /exchange
+      // section pages are auto-discovered; dynamic listing/finds/wanted detail
+      // URLs come from /api/__sitemap__/exchange (NOT excluded here, so the broad
+      // glob below would not cancel them post-cutover).
+      '/onboarding',
+      '/exchange/messages',
+      '/exchange/messages/**',
+      '/exchange/watchlist',
+      '/exchange/listings/new',
+      '/exchange/listings/bulk',
+      '/exchange/listings/*/edit',
+      '/exchange/listings/payment/**',
+      '/exchange/finds/submit',
+      '/exchange/wanted/new',
+      // Pre-cutover, hide the ENTIRE marketplace from the sitemap. Build-time flag
+      // (mirrors the runtime gate); at cutover the redeploy drops this so the
+      // public /exchange pages + the dynamic source URLs become discoverable.
+      ...(process.env.NUXT_PUBLIC_EXCHANGE_ENABLED === 'true' ? [] : ['/exchange/**']),
     ],
   },
 

--- a/server/api/__sitemap__/exchange.ts
+++ b/server/api/__sitemap__/exchange.ts
@@ -1,0 +1,65 @@
+/**
+ * Marketplace (Mini Exchange) sitemap source, registered in nuxt.config
+ * `sitemap.sources`. Flag-gated: emits NOTHING until the Exchange is live, so no
+ * /exchange/* URLs leak into the sitemap pre-cutover. (The static /exchange/**
+ * page routes are excluded from auto-discovery in nuxt.config, so this source is
+ * the single place marketplace URLs enter the sitemap.)
+ *
+ * When live: every active listing, approved find, and approved wanted post.
+ * The public section landing pages (/exchange, /exchange/listings, …) are static
+ * routes handled by sitemap auto-discovery (gated build-time in nuxt.config's
+ * `exclude`); this source only adds the dynamic detail URLs. Private surfaces
+ * (messages, watchlist, create/edit forms, onboarding) are excluded there.
+ */
+import { getServiceClient } from '../../utils/supabase';
+
+export default defineSitemapEventHandler(async () => {
+  const config = useRuntimeConfig();
+  if (!config.public.exchangeEnabled) return [];
+
+  const service = getServiceClient();
+
+  const [listingsRes, findsRes, wantedRes] = await Promise.all([
+    service.from('listings').select('slug, updated_at, created_at').eq('status', 'active').limit(5000),
+    service.from('external_listings').select('slug, updated_at, published_at').eq('status', 'approved').limit(5000),
+    service
+      .from('wanted_posts')
+      .select('id, created_at')
+      .eq('status', 'active')
+      .eq('moderation_status', 'approved')
+      .limit(5000),
+  ]);
+
+  if (listingsRes.error) console.error('[sitemap] exchange listings query failed:', listingsRes.error.message);
+  if (findsRes.error) console.error('[sitemap] exchange finds query failed:', findsRes.error.message);
+  if (wantedRes.error) console.error('[sitemap] exchange wanted query failed:', wantedRes.error.message);
+
+  const listingUrls = (listingsRes.data ?? [])
+    .filter((l) => l.slug)
+    .map((l) => ({
+      loc: `/exchange/listings/${l.slug}`,
+      lastmod: l.updated_at || l.created_at,
+      changefreq: 'weekly' as const,
+      priority: 0.8,
+    }));
+
+  const findUrls = (findsRes.data ?? [])
+    .filter((f) => f.slug)
+    .map((f) => ({
+      loc: `/exchange/finds/${f.slug}`,
+      lastmod: f.updated_at || f.published_at,
+      changefreq: 'weekly' as const,
+      priority: 0.7,
+    }));
+
+  const wantedUrls = (wantedRes.data ?? [])
+    .filter((w) => w.id)
+    .map((w) => ({
+      loc: `/exchange/wanted/${w.id}`,
+      lastmod: w.created_at,
+      changefreq: 'weekly' as const,
+      priority: 0.6,
+    }));
+
+  return [...listingUrls, ...findUrls, ...wantedUrls];
+});

--- a/server/routes/exchange/atom.xml.ts
+++ b/server/routes/exchange/atom.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('everything', 'atom');

--- a/server/routes/exchange/feed.json.ts
+++ b/server/routes/exchange/feed.json.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('everything', 'json');

--- a/server/routes/exchange/feed.xml.ts
+++ b/server/routes/exchange/feed.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('everything', 'rss');

--- a/server/routes/exchange/feed/engines.atom.ts
+++ b/server/routes/exchange/feed/engines.atom.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('engines', 'atom');

--- a/server/routes/exchange/feed/engines.json.ts
+++ b/server/routes/exchange/feed/engines.json.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('engines', 'json');

--- a/server/routes/exchange/feed/engines.xml.ts
+++ b/server/routes/exchange/feed/engines.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('engines', 'rss');

--- a/server/routes/exchange/feed/finds.atom.ts
+++ b/server/routes/exchange/feed/finds.atom.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('finds', 'atom');

--- a/server/routes/exchange/feed/finds.json.ts
+++ b/server/routes/exchange/feed/finds.json.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('finds', 'json');

--- a/server/routes/exchange/feed/finds.xml.ts
+++ b/server/routes/exchange/feed/finds.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('finds', 'rss');

--- a/server/routes/exchange/feed/listings.atom.ts
+++ b/server/routes/exchange/feed/listings.atom.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('listings', 'atom');

--- a/server/routes/exchange/feed/listings.json.ts
+++ b/server/routes/exchange/feed/listings.json.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('listings', 'json');

--- a/server/routes/exchange/feed/listings.xml.ts
+++ b/server/routes/exchange/feed/listings.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('listings', 'rss');

--- a/server/routes/exchange/feed/parts.atom.ts
+++ b/server/routes/exchange/feed/parts.atom.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('parts', 'atom');

--- a/server/routes/exchange/feed/parts.json.ts
+++ b/server/routes/exchange/feed/parts.json.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('parts', 'json');

--- a/server/routes/exchange/feed/parts.xml.ts
+++ b/server/routes/exchange/feed/parts.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('parts', 'rss');

--- a/server/routes/exchange/feed/vehicles.atom.ts
+++ b/server/routes/exchange/feed/vehicles.atom.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('vehicles', 'atom');

--- a/server/routes/exchange/feed/vehicles.json.ts
+++ b/server/routes/exchange/feed/vehicles.json.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('vehicles', 'json');

--- a/server/routes/exchange/feed/vehicles.xml.ts
+++ b/server/routes/exchange/feed/vehicles.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('vehicles', 'rss');

--- a/server/routes/exchange/feed/wanted.atom.ts
+++ b/server/routes/exchange/feed/wanted.atom.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('wanted', 'atom');

--- a/server/routes/exchange/feed/wanted.json.ts
+++ b/server/routes/exchange/feed/wanted.json.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('wanted', 'json');

--- a/server/routes/exchange/feed/wanted.xml.ts
+++ b/server/routes/exchange/feed/wanted.xml.ts
@@ -1,0 +1,3 @@
+import { createFeedHandler } from '../../../utils/exchange/feedBuilder';
+
+export default createFeedHandler('wanted', 'rss');

--- a/server/utils/aiBots.ts
+++ b/server/utils/aiBots.ts
@@ -50,6 +50,11 @@ export const PRIVATE_DISALLOW = [
   '/profile',
   '/auth',
   '/login',
+  // Private marketplace surfaces (public /exchange listing/finds/wanted pages
+  // stay crawlable; these are user-specific and noindex'd).
+  '/exchange/messages',
+  '/exchange/watchlist',
+  '/onboarding',
   '/assets/',
   '/data/',
   '/server/',

--- a/server/utils/exchange/feedBuilder.ts
+++ b/server/utils/exchange/feedBuilder.ts
@@ -1,0 +1,371 @@
+import { Feed } from 'feed';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getServiceClient } from '../supabase';
+
+// RSS/Atom/JSON feeds for the Mini Exchange. Ported from TME; rehomed under
+// /exchange/feed/* and gated by the cutover flag. Each route file is a one-liner:
+//   export default createFeedHandler('vehicles', 'rss')
+
+export type FeedType = 'everything' | 'listings' | 'vehicles' | 'engines' | 'parts' | 'finds' | 'wanted';
+export type FeedFormat = 'rss' | 'atom' | 'json';
+
+interface FeedConfig {
+  title: string;
+  description: string;
+  path: string;
+  includeListings: boolean;
+  listingCategory?: 'vehicle' | 'engine' | 'parts';
+  includeFinds: boolean;
+  includeWanted: boolean;
+}
+
+export const FEED_META: Record<FeedType, FeedConfig> = {
+  everything: {
+    title: 'The Mini Exchange - Everything',
+    description: 'All marketplace listings, Mini Finds, and Wanted posts from The Mini Exchange.',
+    path: '/exchange/feed.xml',
+    includeListings: true,
+    includeFinds: true,
+    includeWanted: true,
+  },
+  listings: {
+    title: 'The Mini Exchange - All Marketplace Listings',
+    description: 'All active Classic Mini marketplace listings — vehicles, engines, and parts.',
+    path: '/exchange/feed/listings.xml',
+    includeListings: true,
+    includeFinds: false,
+    includeWanted: false,
+  },
+  vehicles: {
+    title: 'The Mini Exchange - Classic Mini Vehicles',
+    description: 'Classic Mini vehicles for sale on The Mini Exchange.',
+    path: '/exchange/feed/vehicles.xml',
+    includeListings: true,
+    listingCategory: 'vehicle',
+    includeFinds: false,
+    includeWanted: false,
+  },
+  engines: {
+    title: 'The Mini Exchange - Classic Mini Engines',
+    description: 'Classic Mini engines for sale on The Mini Exchange.',
+    path: '/exchange/feed/engines.xml',
+    includeListings: true,
+    listingCategory: 'engine',
+    includeFinds: false,
+    includeWanted: false,
+  },
+  parts: {
+    title: 'The Mini Exchange - Classic Mini Parts',
+    description: 'Classic Mini parts and accessories for sale on The Mini Exchange.',
+    path: '/exchange/feed/parts.xml',
+    includeListings: true,
+    listingCategory: 'parts',
+    includeFinds: false,
+    includeWanted: false,
+  },
+  finds: {
+    title: 'The Mini Exchange - Mini Finds',
+    description: 'Curated Classic Mini listings spotted across the web by the community.',
+    path: '/exchange/feed/finds.xml',
+    includeListings: false,
+    includeFinds: true,
+    includeWanted: false,
+  },
+  wanted: {
+    title: 'The Mini Exchange - Wanted Posts',
+    description: 'Classic Mini vehicles, engines, and parts that community members are seeking.',
+    path: '/exchange/feed/wanted.xml',
+    includeListings: false,
+    includeFinds: false,
+    includeWanted: true,
+  },
+};
+
+/** Escape HTML entities for safe inclusion in feed content. */
+function escapeHtml(unsafe: string): string {
+  return unsafe.replace(
+    /[&<>"']/g,
+    (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[m] || m
+  );
+}
+
+/** Order embedded listing_photos: primary first, then display_order. */
+function applyPhotoOrdering<T extends { order: (...args: any[]) => T }>(query: T): T {
+  return query
+    .order('is_primary', { referencedTable: 'listing_photos', ascending: false })
+    .order('display_order', { referencedTable: 'listing_photos', ascending: true });
+}
+
+function formatServerLocation(listing: any): string {
+  const parts: string[] = [];
+  if (listing.city) parts.push(listing.city);
+  if (listing.state_province) parts.push(listing.state_province);
+  if (listing.country && listing.country !== 'United States') parts.push(listing.country);
+  if (parts.length > 0) return parts.join(', ');
+  return listing.location || '';
+}
+
+interface FeedItem {
+  item: any;
+  date: Date;
+}
+
+function buildListingItems(listings: any[], supabaseUrl: string, siteUrl: string): FeedItem[] {
+  return listings.map((listing: any) => {
+    const listingUrl = `${siteUrl}/exchange/listings/${listing.slug}`;
+
+    const photos = listing.listing_photos || [];
+    const primaryPhoto = photos.find((p: any) => p.is_primary) || photos[0];
+    const imageUrl = primaryPhoto?.storage_path
+      ? `${supabaseUrl}/storage/v1/object/public/listing-photos/${encodeURIComponent(primaryPhoto.storage_path)}`
+      : undefined;
+
+    const sellerName = listing.user?.display_name || 'Anonymous Seller';
+
+    const priceText =
+      listing.price === 0 ? 'Free' : listing.price ? `$${listing.price.toLocaleString()}` : 'Contact for price';
+
+    const safeTitle = escapeHtml(listing.title || '');
+    const safeModel = escapeHtml(String(listing.model || ''));
+    const safeDescription = escapeHtml(listing.description || '');
+    const safeSellerName = escapeHtml(sellerName);
+    const safeLocation = escapeHtml(formatServerLocation(listing));
+
+    const feedItem: any = {
+      title: listing.title,
+      id: listing.id,
+      link: listingUrl,
+      description: `${listing.year} ${safeModel} - ${priceText} - ${safeLocation}\n\n${safeDescription}`,
+      content: `
+        <h2>${safeTitle}</h2>
+        ${imageUrl ? `<img src="${imageUrl}" alt="${safeTitle}" style="max-width: 100%; height: auto;" />` : ''}
+        <p><strong>${listing.year} ${safeModel}</strong></p>
+        <p><strong>Price:</strong> ${priceText}</p>
+        <p><strong>Location:</strong> ${safeLocation}</p>
+        <p><strong>Seller:</strong> ${safeSellerName}</p>
+        <p>${safeDescription}</p>
+        <p><a href="${listingUrl}">View full listing</a></p>
+      `,
+      author: [{ name: sellerName, link: listingUrl }],
+      date: new Date(listing.created_at),
+    };
+
+    if (imageUrl) {
+      feedItem.image = imageUrl;
+      feedItem.enclosure = { url: imageUrl, type: 'image/jpeg' };
+    }
+
+    return { item: feedItem, date: new Date(listing.created_at) };
+  });
+}
+
+function buildFindItems(finds: any[], siteUrl: string): FeedItem[] {
+  return finds.map((find: any) => {
+    const findUrl = `${siteUrl}/exchange/finds/${find.slug}`;
+    const findTitle = `[Mini Find] ${find.title}`;
+    const findContent = find.editor_commentary || find.description || find.og_description || '';
+    const safeTitle = escapeHtml(findTitle);
+    const safeContent = escapeHtml(findContent);
+
+    const feedItem: any = {
+      title: findTitle,
+      id: `external-${find.id}`,
+      link: findUrl,
+      description: safeContent,
+      content: `
+        <h2>${safeTitle}</h2>
+        ${find.og_image_url ? `<img src="${escapeHtml(find.og_image_url)}" alt="${safeTitle}" style="max-width: 100%; height: auto;" />` : ''}
+        <p>${safeContent}</p>
+        <p><a href="${findUrl}">View on The Mini Exchange</a></p>
+      `,
+      author: [{ name: 'The Mini Exchange', link: siteUrl }],
+      date: new Date(find.published_at),
+    };
+
+    if (find.og_image_url) {
+      const safeImageUrl = escapeHtml(find.og_image_url);
+      feedItem.image = safeImageUrl;
+      feedItem.enclosure = { url: safeImageUrl, type: 'image/jpeg' };
+    }
+
+    return { item: feedItem, date: new Date(find.published_at) };
+  });
+}
+
+function formatBudget(minCents: number | null, maxCents: number | null, currency: string): string {
+  const fmt = (cents: number) =>
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(cents / 100);
+
+  if (minCents != null && maxCents != null) return `${fmt(minCents)} – ${fmt(maxCents)}`;
+  if (maxCents != null) return `Up to ${fmt(maxCents)}`;
+  if (minCents != null) return `From ${fmt(minCents)}`;
+  return 'Flexible';
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  vehicle: 'Vehicle',
+  engine: 'Engine',
+  parts: 'Parts',
+};
+
+function buildWantedItems(wantedPosts: any[], siteUrl: string): FeedItem[] {
+  return wantedPosts.map((post: any) => {
+    const postUrl = `${siteUrl}/exchange/wanted/${post.id}`;
+    const postTitle = `[Wanted] ${post.title}`;
+    const budgetText = formatBudget(post.budget_min, post.budget_max, post.currency || 'USD');
+    const categoryLabel = CATEGORY_LABELS[post.category] || post.category;
+    const safeTitle = escapeHtml(postTitle);
+    const safeDescription = escapeHtml(post.description || '');
+    const safeLocation = escapeHtml(formatServerLocation(post));
+
+    const feedItem: any = {
+      title: postTitle,
+      id: `wanted-${post.id}`,
+      link: postUrl,
+      description: `${categoryLabel} — Budget: ${budgetText}${safeLocation ? ` — ${safeLocation}` : ''}\n\n${safeDescription}`,
+      content: `
+        <h2>${safeTitle}</h2>
+        <p><strong>Category:</strong> ${escapeHtml(categoryLabel)}</p>
+        <p><strong>Budget:</strong> ${escapeHtml(budgetText)}</p>
+        ${safeLocation ? `<p><strong>Location:</strong> ${safeLocation}</p>` : ''}
+        <p>${safeDescription}</p>
+        <p><a href="${postUrl}">View wanted post</a></p>
+      `,
+      author: [{ name: 'The Mini Exchange', link: siteUrl }],
+      date: new Date(post.created_at),
+    };
+
+    return { item: feedItem, date: new Date(post.created_at) };
+  });
+}
+
+export async function assembleFeed(
+  feedType: FeedType,
+  supabase: SupabaseClient,
+  config: { public: { supabaseUrl: string; siteUrl?: string } }
+): Promise<Feed> {
+  const meta = FEED_META[feedType];
+  const siteUrl = config.public.siteUrl || 'https://www.classicminidiy.com';
+
+  // Build feed links for all 3 formats.
+  const basePath = meta.path.replace('.xml', '');
+  const feedLinks =
+    feedType === 'everything'
+      ? { rss: `${siteUrl}/exchange/feed.xml`, json: `${siteUrl}/exchange/feed.json`, atom: `${siteUrl}/exchange/atom.xml` }
+      : { rss: `${siteUrl}${basePath}.xml`, json: `${siteUrl}${basePath}.json`, atom: `${siteUrl}${basePath}.atom` };
+
+  const feed = new Feed({
+    title: meta.title,
+    description: meta.description,
+    id: siteUrl,
+    link: siteUrl,
+    language: 'en',
+    image: `${siteUrl}/og-image.jpg`,
+    favicon: `${siteUrl}/favicon.ico`,
+    copyright: `Copyright ${new Date().getFullYear()} The Mini Exchange`,
+    updated: new Date(),
+    generator: 'The Mini Exchange RSS',
+    feedLinks,
+    author: { name: 'The Mini Exchange', link: siteUrl },
+  });
+
+  const allItems: FeedItem[] = [];
+
+  // Marketplace listings.
+  if (meta.includeListings) {
+    let query = supabase
+      .from('listings')
+      .select(
+        `
+        id, title, slug, description, price, year, model,
+        location, city, state_province, country, created_at,
+        user:profiles!listings_user_id_fkey ( display_name ),
+        listing_photos ( storage_path, is_primary )
+      `
+      )
+      .eq('status', 'active');
+
+    if (meta.listingCategory) {
+      query = query.eq('listing_category', meta.listingCategory);
+    }
+
+    query = query.order('created_at', { ascending: false });
+
+    const { data: listings } = await applyPhotoOrdering(query).limit(50);
+    if (listings) {
+      allItems.push(...buildListingItems(listings, config.public.supabaseUrl, siteUrl));
+    }
+  }
+
+  // External listings (finds).
+  if (meta.includeFinds) {
+    const { data: finds } = await supabase
+      .from('external_listings')
+      .select('id, title, slug, description, og_description, og_image_url, editor_commentary, published_at')
+      .eq('status', 'approved')
+      .order('published_at', { ascending: false })
+      .limit(20);
+
+    if (finds) {
+      allItems.push(...buildFindItems(finds, siteUrl));
+    }
+  }
+
+  // Wanted posts.
+  if (meta.includeWanted) {
+    const { data: wantedPosts } = await supabase
+      .from('wanted_posts')
+      .select(
+        'id, title, description, category, budget_min, budget_max, currency, city, state_province, country, created_at'
+      )
+      .eq('status', 'active')
+      .eq('moderation_status', 'approved')
+      .order('created_at', { ascending: false })
+      .limit(20);
+
+    if (wantedPosts) {
+      allItems.push(...buildWantedItems(wantedPosts, siteUrl));
+    }
+  }
+
+  allItems
+    .sort((a, b) => b.date.getTime() - a.date.getTime())
+    .slice(0, 50)
+    .forEach(({ item }) => feed.addItem(item));
+
+  return feed;
+}
+
+const CONTENT_TYPES: Record<FeedFormat, string> = {
+  rss: 'application/xml; charset=utf-8',
+  atom: 'application/atom+xml; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+};
+
+/**
+ * Nitro event handler factory for a given feed type + format. Flag-gated: when
+ * the Exchange is off the feed 404s (invisible/uncrawlable pre-cutover).
+ */
+export function createFeedHandler(type: FeedType, format: FeedFormat) {
+  return defineEventHandler(async (event: any) => {
+    const config = useRuntimeConfig();
+    if (!config.public.exchangeEnabled) {
+      throw createError({ statusCode: 404, statusMessage: 'Not found' });
+    }
+
+    const supabase = getServiceClient();
+    const feed = await assembleFeed(type, supabase as unknown as SupabaseClient, config as any);
+
+    setHeader(event, 'Content-Type', CONTENT_TYPES[format]);
+    setHeader(event, 'Cache-Control', 'public, max-age=3600');
+
+    if (format === 'json') return feed.json1();
+    if (format === 'atom') return feed.atom1();
+    return feed.rss2();
+  });
+}

--- a/server/utils/exchange/feedBuilder.ts
+++ b/server/utils/exchange/feedBuilder.ts
@@ -89,6 +89,34 @@ function escapeHtml(unsafe: string): string {
   );
 }
 
+/**
+ * Build a Supabase Storage public URL from an object key. Encode each path
+ * segment individually so special characters are safe but the `/` separators
+ * are preserved (encodeURIComponent on the whole key would turn `/` into `%2F`
+ * and 404 the object). Mirrors what `storage.getPublicUrl()` does client-side.
+ */
+function storagePublicUrl(supabaseUrl: string, bucket: string, key: string): string {
+  const encoded = key.split('/').map(encodeURIComponent).join('/');
+  return `${supabaseUrl}/storage/v1/object/public/${bucket}/${encoded}`;
+}
+
+/** Infer an image MIME type from a URL's file extension (defaults to JPEG). */
+function imageMimeFromUrl(url: string): string {
+  const ext = url.split(/[?#]/)[0].split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'png':
+      return 'image/png';
+    case 'webp':
+      return 'image/webp';
+    case 'gif':
+      return 'image/gif';
+    case 'avif':
+      return 'image/avif';
+    default:
+      return 'image/jpeg';
+  }
+}
+
 /** Order embedded listing_photos: primary first, then display_order. */
 function applyPhotoOrdering<T extends { order: (...args: any[]) => T }>(query: T): T {
   return query
@@ -117,7 +145,7 @@ function buildListingItems(listings: any[], supabaseUrl: string, siteUrl: string
     const photos = listing.listing_photos || [];
     const primaryPhoto = photos.find((p: any) => p.is_primary) || photos[0];
     const imageUrl = primaryPhoto?.storage_path
-      ? `${supabaseUrl}/storage/v1/object/public/listing-photos/${encodeURIComponent(primaryPhoto.storage_path)}`
+      ? storagePublicUrl(supabaseUrl, 'listing-photos', primaryPhoto.storage_path)
       : undefined;
 
     const sellerName = listing.user?.display_name || 'Anonymous Seller';
@@ -151,8 +179,11 @@ function buildListingItems(listings: any[], supabaseUrl: string, siteUrl: string
     };
 
     if (imageUrl) {
-      feedItem.image = imageUrl;
-      feedItem.enclosure = { url: imageUrl, type: 'image/jpeg' };
+      // Don't set feedItem.image: the `feed` lib re-derives the enclosure MIME
+      // from the URL extension for a string image (e.g. .jpg -> image/jpg) and
+      // overrides our explicit type. The image still renders via the <img> in
+      // `content`/`content_html`; the enclosure carries the canonical MIME.
+      feedItem.enclosure = { url: imageUrl, type: imageMimeFromUrl(imageUrl) };
     }
 
     return { item: feedItem, date: new Date(listing.created_at) };
@@ -183,27 +214,29 @@ function buildFindItems(finds: any[], siteUrl: string): FeedItem[] {
     };
 
     if (find.og_image_url) {
+      // No feedItem.image (see buildListingItems) — keep the canonical enclosure MIME.
       const safeImageUrl = escapeHtml(find.og_image_url);
-      feedItem.image = safeImageUrl;
-      feedItem.enclosure = { url: safeImageUrl, type: 'image/jpeg' };
+      feedItem.enclosure = { url: safeImageUrl, type: imageMimeFromUrl(find.og_image_url) };
     }
 
     return { item: feedItem, date: new Date(find.published_at) };
   });
 }
 
-function formatBudget(minCents: number | null, maxCents: number | null, currency: string): string {
-  const fmt = (cents: number) =>
+function formatBudget(min: number | null, max: number | null, currency: string): string {
+  // Budgets are stored as whole currency units (not cents) — see
+  // app/utils/wantedFormatters.ts#formatBudget, the canonical UI formatter.
+  const fmt = (amount: number) =>
     new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency,
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
-    }).format(cents / 100);
+    }).format(amount);
 
-  if (minCents != null && maxCents != null) return `${fmt(minCents)} – ${fmt(maxCents)}`;
-  if (maxCents != null) return `Up to ${fmt(maxCents)}`;
-  if (minCents != null) return `From ${fmt(minCents)}`;
+  if (min != null && max != null) return `${fmt(min)} – ${fmt(max)}`;
+  if (max != null) return `Up to ${fmt(max)}`;
+  if (min != null) return `From ${fmt(min)}`;
   return 'Flexible';
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -11,5 +11,175 @@
       "source": "/t/:path*",
       "destination": "https://us.i.posthog.com/:path*"
     }
+  ],
+  "redirects": [
+    {
+      "source": "/admin/users",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/admin/users",
+      "permanent": true
+    },
+    {
+      "source": "/admin/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/admin/exchange/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/settings/membership",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/membership",
+      "permanent": true
+    },
+    {
+      "source": "/settings/notifications",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/dashboard/notifications",
+      "permanent": true
+    },
+    {
+      "source": "/settings/saved-searches",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/dashboard/saved-searches",
+      "permanent": true
+    },
+    {
+      "source": "/terms",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/legal/marketplace-terms",
+      "permanent": true
+    },
+    {
+      "source": "/feed.xml",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/feed.xml",
+      "permanent": true
+    },
+    {
+      "source": "/atom.xml",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/atom.xml",
+      "permanent": true
+    },
+    {
+      "source": "/feed.json",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/feed.json",
+      "permanent": true
+    },
+    {
+      "source": "/feed/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/feed/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/feeds",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/feeds",
+      "permanent": true
+    },
+    {
+      "source": "/listings/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/listings/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/wanted/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/wanted/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/finds/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/finds/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/messages/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/messages/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/watchlist",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/watchlist",
+      "permanent": true
+    },
+    {
+      "source": "/sold",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/sold",
+      "permanent": true
+    },
+    {
+      "source": "/social",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/social",
+      "permanent": true
+    },
+    {
+      "source": "/how-it-works",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/how-it-works",
+      "permanent": true
+    },
+    {
+      "source": "/safety",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange/safety",
+      "permanent": true
+    },
+    {
+      "source": "/about",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange",
+      "permanent": true
+    },
+    {
+      "source": "/dashboard/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/dashboard/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/profile/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/profile/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/users/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/users/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/onboarding",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/onboarding",
+      "permanent": true
+    },
+    {
+      "source": "/contact",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/contact",
+      "permanent": true
+    },
+    {
+      "source": "/privacy",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/privacy",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [{ "type": "host", "value": "(www\\.)?theminiexchange\\.com" }],
+      "destination": "https://www.classicminidiy.com/exchange",
+      "permanent": true
+    }
   ]
 }


### PR DESCRIPTION
## Section 10 of 10 (final) — TheMiniExchange consolidation

The last slice: syndication feeds, sitemap/robots, the marketplace legal page, and the host-scoped 301 redirects. Flag-gated behind `NUXT_PUBLIC_EXCHANGE_ENABLED`. 27 files / ~1.4k lines.

### Feeds (`server/routes/exchange/feed/*` + top-level)
- RSS (`.xml`), Atom (`.atom`/`atom.xml`), and JSON Feed (`.json`) for listings, wanted, finds, parts, vehicles, engines + combined `feed.xml`/`atom.xml`/`feed.json`
- Shared `server/utils/exchange/feedBuilder.ts#createFeedHandler`:
  - **Flag-gated** — 404s when the Exchange is off, so feeds are invisible/uncrawlable pre-cutover (Nitro routes aren't covered by the app middleware gate, so this guard lives in the handler).
  - **XML-safe** — `escapeHtml()` escapes `& < > " '` on every user-supplied field (title, description, seller name, location, image URL).

### SEO
- `server/api/__sitemap__/exchange.ts` — flag-gated dynamic sitemap source (active listings + approved finds/wanted); the only place `/exchange/*` dynamic URLs enter the sitemap.
- `server/utils/aiBots.ts` — AI-crawler robots policy (private `/exchange/{messages,watchlist}` disallowed; public listing pages stay crawlable).

### Legal + redirects
- `app/pages/legal/marketplace-terms.vue` — TME terms (English-only per the CMDIY legal convention).
- `vercel.json` — 28 host-scoped 301s keyed on `(www\.)?theminiexchange\.com` → CMDIY `/exchange/*` (and `/terms`→`/legal/marketplace-terms`, `/settings/membership`→`/membership`, `/admin/*`→`/admin/exchange/*`, etc.).

### Verified
All feeds return 200 with correct content-types; `feed.xml` parses as well-formed RSS (50 items), `atom.xml` as Atom (50 entries), `feed.json` as JSON Feed v1 (50 items). Legal page 200.

**This closes the section-PR phase.** Next: `dev` → `main` cutover prep (deferred backend work — social/newsletter/SES templates, supabase edge-fn deploy, test port — tracked in `docs/plans/2026-06-28-tme-consolidation-handoff.md`).