### PR TITLE
feat(exchange): build/deploy hardening + social edge fn + open browsing + TME home port

### DIFF
--- a/app/components/exchange/AnnouncementBanner.vue
+++ b/app/components/exchange/AnnouncementBanner.vue
@@ -1,0 +1,37 @@
+<template>
+  <div v-if="announcement" role="alert" class="announcement-banner" :style="bannerStyle">
+    <div class="container flex items-center gap-3">
+      <i :class="[iconClass, 'text-base shrink-0']" :style="iconStyle" />
+      <div class="flex flex-col gap-0.5">
+        <span v-if="announcement.title" class="font-semibold">{{ announcement.title }}</span>
+        <span v-if="announcement.description" :class="{ 'text-sm opacity-80': announcement.title }">
+          {{ announcement.description }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { SiteAnnouncement } from '~/composables/useAnnouncement';
+
+  const { getActiveAnnouncement } = useAnnouncement();
+
+  // Fetch on server to prevent CLS (Cumulative Layout Shift)
+  const { data: announcement } = await useAsyncData<SiteAnnouncement | null>('active-announcement', () =>
+    getActiveAnnouncement()
+  );
+
+  const announcementType = computed(() => announcement.value?.type || 'info');
+  const { bannerStyle, iconStyle } = useAnnouncementStyles(announcementType);
+
+  const iconClass = computed((): string => {
+    const iconMap: Record<string, string> = {
+      error: 'fas fa-circle-xmark',
+      warning: 'fas fa-triangle-exclamation',
+      info: 'fas fa-circle-info',
+      success: 'fas fa-circle-check',
+    };
+    return iconMap[announcement.value?.type || 'info'] || 'fas fa-circle-info';
+  });
+</script>

--- a/app/components/exchange/home/FeaturedGrid.vue
+++ b/app/components/exchange/home/FeaturedGrid.vue
@@ -1,0 +1,203 @@
+<template>
+  <section v-if="listings.length > 0" class="py-12 bg-base-200/50">
+    <div class="container">
+      <div class="flex items-center justify-between mb-8">
+        <h2 class="text-2xl font-bold tracking-tight">{{ t('heading') }}</h2>
+        <NuxtLink to="/exchange/listings" class="btn btn-ghost btn-sm gap-1">
+          {{ t('viewAll') }}
+          <i class="fas fa-arrow-right text-sm" />
+        </NuxtLink>
+      </div>
+
+      <!-- BaT-style grid: image-forward cards -->
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+        <NuxtLink
+          v-for="(listing, index) in listings"
+          :key="listing.id"
+          :to="`/exchange/listings/${listing.slug}`"
+          class="group block rounded-lg overflow-hidden bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+          @click="trackClick(listing.id, index)"
+        >
+          <!-- Image: tall aspect ratio, BaT-style -->
+          <figure class="relative aspect-[4/3] bg-base-300 overflow-hidden">
+            <img
+              v-if="getPrimaryPhoto(listing)"
+              :src="getPrimaryPhoto(listing)"
+              :alt="listing.title"
+              class="w-full h-full object-contain group-hover:scale-[1.02] transition-transform duration-300"
+              style="object-fit: contain"
+              loading="lazy"
+            />
+            <div v-else class="w-full h-full flex items-center justify-center">
+              <i class="fas fa-image text-6xl text-base-content/20" />
+            </div>
+
+            <!-- Compact badge overlay (BaT-style) -->
+            <div class="absolute top-3 left-3 flex gap-1.5">
+              <span
+                v-if="isExampleStatus(listing.status)"
+                class="badge badge-secondary badge-sm font-bold shadow-sm gap-1"
+              >
+                {{ t('exampleListing') }}
+              </span>
+              <span v-else class="badge badge-warning badge-sm font-bold shadow-sm gap-1">
+                <i class="fas fa-star text-xs" />
+                {{ t('featured') }}
+              </span>
+            </div>
+
+            <!-- Price overlay at bottom of image (editorial style) -->
+            <div class="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent pt-8 pb-3 px-4">
+              <div class="text-white text-xl font-bold">
+                {{ formatListingPrice(listing.price, formatCurrency(listing.price, getListingCurrency(listing))) }}
+              </div>
+              <div v-if="getConvertedPrice(listing)" class="text-white/70 text-xs">
+                &approx; {{ formatCurrency(getConvertedPrice(listing)!, userCurrency) }}
+              </div>
+            </div>
+          </figure>
+
+          <!-- Card info below image -->
+          <div class="p-4">
+            <h3 class="font-bold text-base line-clamp-1 mb-1">{{ listing.title }}</h3>
+            <div class="flex items-center gap-1.5 text-sm text-base-content/60">
+              <template v-if="getCountryFlag(listing.country)">{{ getCountryFlag(listing.country) }}</template>
+              <i v-else class="fas fa-location-dot text-sm shrink-0" />
+              <span>{{ displayLocation(listing) }}</span>
+            </div>
+          </div>
+        </NuxtLink>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+  import type { ListingWithPhotos } from '~/composables/useListings';
+  import type { CurrencyCode } from '~/composables/useCurrency';
+  import { isExampleStatus } from '~/composables/useExampleListings';
+  import { getCountryFlag } from '~/utils/countryFlags';
+
+  const props = withDefaults(
+    defineProps<{
+      listings: ListingWithPhotos[];
+      userCurrency?: CurrencyCode;
+    }>(),
+    { userCurrency: undefined }
+  );
+
+  const { t } = useI18n();
+  const { getPrimaryPhoto } = useListings();
+  const {
+    formatCurrency,
+    convertCurrency,
+    fetchExchangeRates,
+    exchangeRates,
+    userCurrency: globalUserCurrency,
+  } = useCurrency();
+
+  // Fall back to the global viewer currency when no override is passed
+  const userCurrency = computed<CurrencyCode>(() => props.userCurrency ?? globalUserCurrency.value);
+  const { formatListingPrice } = useFormatters();
+  const { capture } = usePostHog();
+
+  onMounted(() => {
+    fetchExchangeRates();
+  });
+
+  const getListingCurrency = (listing: ListingWithPhotos): CurrencyCode => {
+    return (listing.currency as CurrencyCode) || 'USD';
+  };
+
+  const getConvertedPrice = (listing: ListingWithPhotos): number | null => {
+    const listingCurrency = getListingCurrency(listing);
+    if (!exchangeRates.value) return null;
+    if (listingCurrency === userCurrency.value) return null;
+    if (!listing.price) return null;
+    return convertCurrency(listing.price, listingCurrency, userCurrency.value);
+  };
+
+  const displayLocation = (listing: ListingWithPhotos): string => {
+    const parts: string[] = [];
+    if (listing.city) parts.push(listing.city);
+    if (listing.country && listing.country !== 'United States') {
+      parts.push(listing.country);
+    } else if (listing.state_province) {
+      parts.push(listing.state_province);
+    }
+    return parts.join(', ') || listing.location || '';
+  };
+
+  const trackClick = (listingId: string, index: number) => {
+    capture('featured_carousel_interaction', {
+      action: 'click',
+      listing_id: listingId,
+      position: index,
+    });
+  };
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "heading": "Featured Listings",
+    "viewAll": "View All",
+    "featured": "Featured",
+    "exampleListing": "Example Listing"
+  },
+  "es": {
+    "heading": "Anuncios Destacados",
+    "viewAll": "Ver Todo",
+    "featured": "Destacado",
+    "exampleListing": "Anuncio de Ejemplo"
+  },
+  "fr": {
+    "heading": "Annonces en Vedette",
+    "viewAll": "Voir Tout",
+    "featured": "En Vedette",
+    "exampleListing": "Annonce Exemple"
+  },
+  "de": {
+    "heading": "Empfohlene Inserate",
+    "viewAll": "Alle Ansehen",
+    "featured": "Empfohlen",
+    "exampleListing": "Beispiel-Inserat"
+  },
+  "it": {
+    "heading": "Annunci in Evidenza",
+    "viewAll": "Vedi Tutti",
+    "featured": "In Evidenza",
+    "exampleListing": "Annuncio di Esempio"
+  },
+  "pt": {
+    "heading": "Anúncios em Destaque",
+    "viewAll": "Ver Todos",
+    "featured": "Destaque",
+    "exampleListing": "Anúncio de Exemplo"
+  },
+  "ru": {
+    "heading": "Рекомендуемые Объявления",
+    "viewAll": "Смотреть Все",
+    "featured": "Рекомендуемое",
+    "exampleListing": "Пример Объявления"
+  },
+  "ja": {
+    "heading": "注目のリスティング",
+    "viewAll": "すべて見る",
+    "featured": "注目",
+    "exampleListing": "サンプルリスティング"
+  },
+  "zh": {
+    "heading": "精选列表",
+    "viewAll": "查看全部",
+    "featured": "精选",
+    "exampleListing": "示例列表"
+  },
+  "ko": {
+    "heading": "추천 매물",
+    "viewAll": "전체 보기",
+    "featured": "추천",
+    "exampleListing": "예시 매물"
+  }
+}
+</i18n>

--- a/app/components/exchange/home/FlagMarquee.vue
+++ b/app/components/exchange/home/FlagMarquee.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+  import { getAllCountriesWithFlags } from '~/utils/countryFlags';
+
+  // Shuffle array (Fisher-Yates)
+  function shuffle<T>(arr: T[]): T[] {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  }
+
+  // All countries, randomized once per page load
+  const items = useState('flag-marquee-items', () => shuffle(getAllCountriesWithFlags()));
+
+  // Dynamic duration so scroll speed stays consistent regardless of item count
+  const animationDuration = computed(() => `${items.value.length * 2}s`);
+</script>
+
+<template>
+  <section class="relative overflow-hidden bg-base-200/50 border-b border-base-300 py-3">
+    <!-- Gradient fades -->
+    <div
+      class="absolute left-0 top-0 bottom-0 w-16 sm:w-24 z-10 bg-linear-to-r from-base-200/50 to-transparent pointer-events-none"
+    />
+    <div
+      class="absolute right-0 top-0 bottom-0 w-16 sm:w-24 z-10 bg-linear-to-l from-base-200/50 to-transparent pointer-events-none"
+    />
+
+    <!-- Scrolling row -->
+    <div class="flex gap-6 animate-marquee">
+      <!-- First set -->
+      <div
+        v-for="(item, index) in items"
+        :key="`a-${index}`"
+        class="flex items-center gap-1.5 shrink-0 text-sm text-base-content/70"
+      >
+        <span class="text-base">{{ item.flag }}</span>
+        <span>{{ item.name }}</span>
+      </div>
+      <!-- Duplicate set for seamless loop -->
+      <div
+        v-for="(item, index) in items"
+        :key="`b-${index}`"
+        class="flex items-center gap-1.5 shrink-0 text-sm text-base-content/70"
+      >
+        <span class="text-base">{{ item.flag }}</span>
+        <span>{{ item.name }}</span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+  @keyframes marquee {
+    0% {
+      transform: translateX(0);
+    }
+    100% {
+      transform: translateX(-50%);
+    }
+  }
+
+  .animate-marquee {
+    animation: marquee v-bind(animationDuration) linear infinite;
+  }
+</style>

--- a/app/components/exchange/home/PromotedListings.vue
+++ b/app/components/exchange/home/PromotedListings.vue
@@ -1,0 +1,174 @@
+<template>
+  <section v-if="listings.length > 0" class="py-12">
+    <div class="container">
+      <div class="flex items-center justify-between mb-8">
+        <h2 class="text-2xl font-bold tracking-tight">{{ t('staffFavorites') }}</h2>
+        <NuxtLink to="/exchange/listings" class="btn btn-ghost btn-sm gap-1">
+          {{ t('viewAll') }}
+          <i class="fas fa-arrow-right text-sm" />
+        </NuxtLink>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+        <NuxtLink
+          v-for="listing in listings"
+          :key="listing.id"
+          :to="`/exchange/listings/${listing.slug}`"
+          class="group block rounded-lg overflow-hidden bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+        >
+          <!-- Image -->
+          <figure class="relative aspect-[4/3] bg-base-300 overflow-hidden">
+            <img
+              v-if="getPrimaryPhoto(listing)"
+              :src="getPrimaryPhoto(listing)"
+              :alt="listing.title"
+              class="w-full h-full object-contain group-hover:scale-[1.02] transition-transform duration-300"
+              style="object-fit: contain"
+              loading="lazy"
+            />
+            <div v-else class="w-full h-full flex items-center justify-center">
+              <i class="fas fa-image text-5xl text-base-content/20" />
+            </div>
+
+            <!-- Compact Promoted badge -->
+            <div class="absolute top-3 left-3">
+              <span class="badge badge-primary badge-sm font-bold shadow-sm gap-1">
+                <i class="fas fa-wand-magic-sparkles text-xs" />
+                {{ t('promoted') }}
+              </span>
+            </div>
+
+            <!-- Price overlay -->
+            <div class="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent pt-6 pb-2 px-3">
+              <div class="text-white text-lg font-bold">
+                {{ formatListingPrice(listing.price, formatCurrency(listing.price, getListingCurrency(listing))) }}
+              </div>
+              <div v-if="getConvertedPrice(listing) && listing.price !== 0" class="text-white/70 text-xs">
+                &approx; {{ formatCurrency(getConvertedPrice(listing)!, userCurrency) }}
+              </div>
+            </div>
+          </figure>
+
+          <!-- Card info -->
+          <div class="p-3">
+            <h3 class="font-semibold text-sm line-clamp-1 mb-1">{{ listing.title }}</h3>
+            <div class="flex items-center gap-1 text-xs text-base-content/60">
+              <template v-if="getCountryFlag(listing.country)">{{ getCountryFlag(listing.country) }}</template>
+              <i v-else class="fas fa-location-dot text-xs shrink-0" />
+              <span class="truncate">{{ displayLocation(listing) }}</span>
+            </div>
+          </div>
+        </NuxtLink>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+  import type { ListingWithPhotos } from '~/composables/useListings';
+  import type { CurrencyCode } from '~/composables/useCurrency';
+  import { getCountryFlag } from '~/utils/countryFlags';
+
+  const { t } = useI18n();
+
+  const props = withDefaults(
+    defineProps<{
+      listings: ListingWithPhotos[];
+      userCurrency?: CurrencyCode;
+    }>(),
+    { userCurrency: undefined }
+  );
+
+  const { getPrimaryPhoto } = useListings();
+  const {
+    formatCurrency,
+    convertCurrency,
+    fetchExchangeRates,
+    exchangeRates,
+    userCurrency: globalUserCurrency,
+  } = useCurrency();
+  const userCurrency = computed<CurrencyCode>(() => props.userCurrency ?? globalUserCurrency.value);
+  const { formatListingPrice } = useFormatters();
+
+  onMounted(() => {
+    fetchExchangeRates();
+  });
+
+  const getListingCurrency = (listing: ListingWithPhotos): CurrencyCode => {
+    return (listing.currency as CurrencyCode) || 'USD';
+  };
+
+  const getConvertedPrice = (listing: ListingWithPhotos): number | null => {
+    const listingCurrency = getListingCurrency(listing);
+    if (!exchangeRates.value) return null;
+    if (listingCurrency === userCurrency.value) return null;
+    if (!listing.price) return null;
+    return convertCurrency(listing.price, listingCurrency, userCurrency.value);
+  };
+
+  const displayLocation = (listing: ListingWithPhotos): string => {
+    const parts: string[] = [];
+    if (listing.city) parts.push(listing.city);
+    if (listing.country && listing.country !== 'United States') {
+      parts.push(listing.country);
+    } else if (listing.state_province) {
+      parts.push(listing.state_province);
+    }
+    return parts.join(', ') || listing.location || 'Unknown';
+  };
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "staffFavorites": "Staff Favorites",
+    "viewAll": "View All",
+    "promoted": "Promoted"
+  },
+  "es": {
+    "staffFavorites": "Favoritos del equipo",
+    "viewAll": "Ver todo",
+    "promoted": "Destacado"
+  },
+  "fr": {
+    "staffFavorites": "Coups de coeur",
+    "viewAll": "Voir tout",
+    "promoted": "Mis en avant"
+  },
+  "de": {
+    "staffFavorites": "Team-Favoriten",
+    "viewAll": "Alle anzeigen",
+    "promoted": "Beworben"
+  },
+  "it": {
+    "staffFavorites": "Preferiti dello staff",
+    "viewAll": "Vedi tutto",
+    "promoted": "In evidenza"
+  },
+  "pt": {
+    "staffFavorites": "Favoritos da equipe",
+    "viewAll": "Ver tudo",
+    "promoted": "Promovido"
+  },
+  "ru": {
+    "staffFavorites": "Избранное редакции",
+    "viewAll": "Смотреть все",
+    "promoted": "Продвигаемое"
+  },
+  "ja": {
+    "staffFavorites": "スタッフのおすすめ",
+    "viewAll": "すべて見る",
+    "promoted": "注目"
+  },
+  "zh": {
+    "staffFavorites": "员工精选",
+    "viewAll": "查看全部",
+    "promoted": "推广"
+  },
+  "ko": {
+    "staffFavorites": "스태프 추천",
+    "viewAll": "전체 보기",
+    "promoted": "프로모션"
+  }
+}
+</i18n>

--- a/app/composables/useMessageAttachments.ts
+++ b/app/composables/useMessageAttachments.ts
@@ -86,6 +86,10 @@ export const useMessageAttachments = () => {
    * be compressed below the limit.
    */
   const prepareAttachment = async (input: File): Promise<PreparedAttachment> => {
+    // Browser-only: dynamically imports heic2any (libheif WASM) +
+    // browser-image-compression. The guard keeps both out of the SSR/server
+    // build so they aren't traced into the Vercel serverless function.
+    if (!import.meta.client) throw new Error('prepareAttachment is browser-only');
     let file: File = input;
 
     // HEIC conversion (iOS Safari) — done BEFORE size check because HEICs

--- a/app/composables/useOnboardingGate.ts
+++ b/app/composables/useOnboardingGate.ts
@@ -19,12 +19,17 @@ export function useOnboardingGate() {
   const { exchangeEnabled } = useRuntimeConfig().public;
   const { isAuthenticated, userProfile } = useAuth();
 
+  // Needs onboarding = a loaded profile that is NOT explicitly completed. This
+  // covers existing users whose `onboarding_completed` is null (the column was
+  // backfilled to null, not false) as well as new users (false) — both get the
+  // nudge that drives them into the flow. Requiring a LOADED profile (`!!`) keeps
+  // it from flashing before auth/profile settle.
   const needsOnboarding = computed(
     () =>
       !!exchangeEnabled &&
       isAuthenticated.value &&
       !!userProfile.value &&
-      userProfile.value.onboarding_completed === false
+      userProfile.value.onboarding_completed !== true
   );
 
   return { needsOnboarding };

--- a/app/middleware/exchange-onboarding.global.ts
+++ b/app/middleware/exchange-onboarding.global.ts
@@ -1,17 +1,19 @@
-// Hard onboarding gate for the Mini Exchange section.
+// Onboarding gate for the Mini Exchange — applied only at the point of ACTION.
 //
-// When the exchange is live (NUXT_PUBLIC_EXCHANGE_ENABLED on), a logged-in user
-// whose profile isn't complete cannot enter any /exchange route — they're
-// redirected to the full /onboarding page (non-skippable), with their intended
-// destination preserved as ?redirect=. Anonymous visitors pass through so public
-// listing pages stay browsable + indexable. The soft, skippable toolbox nudge
-// lives in OnboardingNudge.vue (see useOnboardingGate).
+// When the exchange is live (NUXT_PUBLIC_EXCHANGE_ENABLED on), browsing the
+// marketplace is open to EVERYONE (anonymous or logged-in, onboarded or not) so
+// existing users are never walled out. Onboarding is only required to *act* —
+// create a listing, post a want, submit a find, or message (EXCHANGE_ONBOARDING_
+// PREFIXES). A logged-in user without a completed profile who hits one of those
+// is redirected to the full /onboarding page, intended destination preserved as
+// ?redirect=. The soft nudge that DRIVES onboarding from browse pages lives in
+// OnboardingNudge.vue (see useOnboardingGate).
 //
 // Client-only: the Supabase session is in localStorage, so SSR can't know auth
 // state. We actively wait for auth + fetch the profile before deciding, so a
 // not-onboarded user can't slip in during the auth-load window. Verified state
 // is cached per user id to avoid refetching on every in-section navigation.
-import { EXCHANGE_PREFIXES, pathInPrefixes } from '~/utils/exchangeRoutes';
+import { EXCHANGE_ONBOARDING_PREFIXES, pathInPrefixes } from '~/utils/exchangeRoutes';
 
 let verifiedUserId: string | null = null;
 
@@ -22,9 +24,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const { exchangeEnabled } = useRuntimeConfig().public;
   if (!exchangeEnabled) return;
 
-  // Guard the whole Exchange — the /exchange section AND the user's marketplace
-  // management tabs under /dashboard (shared prefix list with the flag-gate).
-  if (!pathInPrefixes(to.path, EXCHANGE_PREFIXES)) return;
+  // Only gate the action routes (create/list/post/message). Browse + detail +
+  // dashboard tabs are intentionally NOT here — they stay open to everyone.
+  if (!pathInPrefixes(to.path, EXCHANGE_ONBOARDING_PREFIXES)) return;
 
   // Never trap the onboarding page or the auth callback.
   if (to.path === '/onboarding' || to.path === '/auth/callback') return;

--- a/app/pages/exchange/index.vue
+++ b/app/pages/exchange/index.vue
@@ -1,128 +1,981 @@
-<script lang="ts" setup>
-  // Placeholder section landing for The Mini Exchange consolidation (Stage 0).
-  // Gated by app/middleware/exchange-flag.global.ts — only reachable when
-  // NUXT_PUBLIC_EXCHANGE_ENABLED is true. Real browse UI lands in Stage 3.
-  const { t } = useI18n();
-
-  useHead({
-    title: t('seo.title'),
-    meta: [{ key: 'description', name: 'description', content: t('seo.description') }],
-    link: [{ rel: 'canonical', href: 'https://www.classicminidiy.com/exchange' }],
-  });
-</script>
-
 <template>
-  <div class="hero min-h-[60vh] bg-base-200">
-    <div class="hero-content text-center">
-      <div class="max-w-xl">
-        <i class="fas fa-shop text-5xl text-primary mb-4"></i>
-        <h1 class="text-4xl font-bold">{{ t('hero.title') }}</h1>
-        <p class="py-6 text-base-content/70">{{ t('hero.subtitle') }}</p>
+  <div>
+    <h1 class="sr-only">{{ t('seo.srHeading') }}</h1>
+
+    <!-- Site Announcement Banner -->
+    <ExchangeAnnouncementBanner />
+
+    <!-- Search Box -->
+    <section class="bg-base-100 py-6 border-b border-base-300">
+      <div class="container max-w-2xl">
+        <form @submit.prevent="goToSearch">
+          <div class="join w-full">
+            <input
+              v-model="homeSearchQuery"
+              type="text"
+              :placeholder="t('search.placeholder')"
+              class="input join-item flex-1"
+            />
+            <button type="submit" class="btn btn-primary join-item">
+              <i class="fas fa-magnifying-glass text-base"></i>
+              {{ t('search.button') }}
+            </button>
+          </div>
+        </form>
       </div>
-    </div>
+    </section>
+
+    <!-- Country Flag Marquee -->
+    <ExchangeHomeFlagMarquee />
+
+    <!-- Stats Bar (compact, inline) -->
+    <section class="py-6 bg-base-200/50 border-y border-base-300">
+      <div class="container">
+        <div class="flex flex-wrap items-center justify-center gap-x-8 gap-y-3 text-center">
+          <div v-if="statsLoading" class="loading loading-dots loading-sm"></div>
+          <template v-else>
+            <div>
+              <span class="text-2xl font-bold text-primary">{{ stats.totalListings }}</span>
+              <span class="text-sm text-base-content/60 ml-1.5">{{ t('stats.activeListings') }}</span>
+            </div>
+            <div class="text-base-content/20">|</div>
+            <div>
+              <span class="text-2xl font-bold text-primary">{{ stats.countries }}</span>
+              <span class="text-sm text-base-content/60 ml-1.5">{{ t('stats.countries') }}</span>
+            </div>
+            <div class="text-base-content/20">|</div>
+            <div>
+              <span class="text-2xl font-bold text-primary">{{ stats.soldListings }}</span>
+              <span class="text-sm text-base-content/60 ml-1.5">{{ t('stats.soldThisMonth') }}</span>
+            </div>
+            <div class="text-base-content/20">|</div>
+            <div>
+              <span class="text-2xl font-bold text-primary">{{ stats.newThisWeek }}</span>
+              <span class="text-sm text-base-content/60 ml-1.5">{{ t('stats.newThisWeek') }}</span>
+            </div>
+          </template>
+        </div>
+      </div>
+    </section>
+    <!-- Featured Listings Grid (Premium tier - most prominent) -->
+    <ExchangeHomeFeaturedGrid v-if="featuredListings.length > 0" :listings="featuredListings" :user-currency="userCurrency" />
+
+    <!-- Staff Favorites (future feature)
+    <ExchangeHomePromotedListings
+      v-if="promotedListings.length > 0"
+      :listings="promotedListings"
+      :user-currency="userCurrency"
+    />
+    -->
+
+    <!-- CTA Section (two buttons: free vs premium) -->
+    <section class="py-16">
+      <div class="container">
+        <div class="card bg-primary/10">
+          <div class="card-body items-center text-center py-12">
+            <h2 class="card-title text-3xl mb-4">{{ t('cta.title') }}</h2>
+            <p class="text-lg text-base-content/70 mb-6 max-w-2xl">
+              {{ t('cta.body') }}
+            </p>
+            <div class="flex flex-col sm:flex-row gap-3">
+              <NuxtLink to="/exchange/listings/new" class="btn btn-primary btn-lg" @click="trackCta('get_started')">
+                {{ t('cta.listFree') }}
+              </NuxtLink>
+              <NuxtLink to="/exchange/listings/new" class="btn btn-outline btn-lg" @click="trackCta('go_premium')">
+                {{ t('cta.goPremium') }}
+              </NuxtLink>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Recent Listings (card grid, BaT-style) -->
+    <section class="py-12">
+      <div class="container">
+        <div class="flex items-center justify-between mb-8">
+          <h2 class="text-2xl font-bold tracking-tight">{{ t('recent.heading') }}</h2>
+          <NuxtLink to="/exchange/listings" class="btn btn-ghost btn-sm gap-1" @click="trackCta('view_all_recent')">
+            {{ t('recent.viewAll') }}
+            <i class="fas fa-arrow-right text-sm"></i>
+          </NuxtLink>
+        </div>
+
+        <!-- Loading State -->
+        <div v-if="loading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+          <div v-for="i in 8" :key="i" class="skeleton aspect-[4/3] rounded-lg"></div>
+        </div>
+
+        <!-- Card Grid (image-forward like BaT) -->
+        <div
+          v-else-if="recentListings.length > 0"
+          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5"
+        >
+          <ExchangeListingsListingCard
+            v-for="listing in recentListings"
+            :key="listing.id"
+            :listing="listing"
+            variant="card"
+            :show-seller-info="false"
+            :user-currency="userCurrency"
+          />
+        </div>
+
+        <!-- Empty State -->
+        <div v-else class="text-center py-16">
+          <i class="fas fa-inbox text-6xl mx-auto mb-4 text-base-content/30"></i>
+          <h3 class="text-xl font-semibold mb-2">{{ t('recent.emptyTitle') }}</h3>
+          <p class="text-base-content/70 mb-6">{{ t('recent.emptyBody') }}</p>
+          <NuxtLink to="/exchange/listings/new" class="btn btn-primary" @click="trackCta('create_listing_empty_state')">
+            {{ t('recent.emptyAction') }}
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <!-- Features Section (updated with worldwide card) -->
+    <section class="py-16 bg-base-200">
+      <div class="container">
+        <h2 class="text-2xl font-bold text-center mb-10 tracking-tight">{{ t('features.heading') }}</h2>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center">
+              <i class="fas fa-earth-americas text-4xl text-primary mb-3"></i>
+              <h3 class="card-title text-base">{{ t('features.worldwide.title') }}</h3>
+              <p class="text-sm text-base-content/70">
+                {{ t('features.worldwide.body') }}
+              </p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center">
+              <i class="fas fa-screwdriver-wrench text-4xl text-primary mb-3"></i>
+              <h3 class="card-title text-base">{{ t('features.expertise.title') }}</h3>
+              <p class="text-sm text-base-content/70">
+                {{ t('features.expertise.body') }}
+              </p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center">
+              <i class="fas fa-gift text-4xl text-primary mb-3"></i>
+              <h3 class="card-title text-base">{{ t('features.free.title') }}</h3>
+              <p class="text-sm text-base-content/70">
+                {{ t('features.free.body') }}
+              </p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center">
+              <i class="fas fa-camera text-4xl text-primary mb-3"></i>
+              <h3 class="card-title text-base">{{ t('features.photos.title') }}</h3>
+              <p class="text-sm text-base-content/70">
+                {{ t('features.photos.body') }}
+              </p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center">
+              <i class="fas fa-file-lines text-4xl text-primary mb-3"></i>
+              <h3 class="card-title text-base">{{ t('features.heritage.title') }}</h3>
+              <p class="text-sm text-base-content/70">
+                {{ t('features.heritage.body') }}
+              </p>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center">
+              <i class="fas fa-comments text-4xl text-primary mb-3"></i>
+              <h3 class="card-title text-base">{{ t('features.communication.title') }}</h3>
+              <p class="text-sm text-base-content/70">
+                {{ t('features.communication.body') }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
   </div>
 </template>
+
+<script setup lang="ts">
+  import type { ListingWithPhotos } from '~/composables/useListings';
+
+  const { t } = useI18n();
+  const config = useRuntimeConfig();
+  const router = useRouter();
+  const { capture } = usePostHog();
+  const { userCurrency } = useCurrency();
+
+  const homeSearchQuery = ref('');
+
+  const goToSearch = () => {
+    const query = homeSearchQuery.value.trim();
+    if (!query) return;
+    capture('search_performed', { query, source: 'home_page' });
+    router.push({ path: '/exchange/listings', query: { search: query } });
+  };
+
+  const trackCta = (ctaName: string) => {
+    capture('cta_clicked', {
+      cta_name: ctaName,
+      location: 'home_page',
+    });
+  };
+
+  // SEO metadata (updated for worldwide messaging)
+  useSeoMeta({
+    title: () => t('seo.title'),
+    description: () => t('seo.description'),
+    ogTitle: () => t('seo.title'),
+    ogDescription: () => t('seo.shareDescription'),
+    ogType: 'website',
+    ogUrl: `${config.public.siteUrl}/exchange`,
+    ogImage: `${config.public.siteUrl}/og-image.jpg`,
+    twitterCard: 'summary_large_image',
+    twitterTitle: () => t('seo.title'),
+    twitterDescription: () => t('seo.shareDescription'),
+  });
+
+  // Schema.org WebSite markup
+  useSchemaOrg([
+    {
+      '@type': 'WebSite',
+      name: 'The Mini Exchange',
+      url: `${config.public.siteUrl}/exchange`,
+      description:
+        'The premier marketplace for buying and selling Classic Mini Coopers with detailed photo galleries and specifications.',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: {
+          '@type': 'EntryPoint',
+          urlTemplate: `${config.public.siteUrl}/exchange/listings?search={search_term_string}`,
+        },
+        'query-input': 'required name=search_term_string',
+      },
+    },
+  ]);
+
+  const supabase = useSupabase();
+  const { loadVisibility, activeStatuses } = useExampleListings();
+
+  const loading = ref(true);
+  const statsLoading = ref(true);
+  const recentListings = ref<ListingWithPhotos[]>([]);
+  const featuredListings = ref<ListingWithPhotos[]>([]);
+  // const promotedListings = ref<ListingWithPhotos[]>([]); // Staff Favorites (future feature)
+
+  const stats = ref({
+    totalListings: 0,
+    soldListings: 0,
+    newThisWeek: 0,
+    countries: 0,
+  });
+
+  // Fetch statistics (updated with countries count)
+  const loadStatistics = async () => {
+    try {
+      // Total active listings
+      const { count: totalCount } = await supabase
+        .from('listings')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'active');
+
+      stats.value.totalListings = totalCount || 0;
+
+      // Sold this month
+      const firstDayOfMonth = new Date();
+      firstDayOfMonth.setDate(1);
+      firstDayOfMonth.setHours(0, 0, 0, 0);
+
+      const { count: soldCount } = await supabase
+        .from('listings')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'sold')
+        .gte('updated_at', firstDayOfMonth.toISOString());
+
+      stats.value.soldListings = soldCount || 0;
+
+      // New this week
+      const oneWeekAgo = new Date();
+      oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+      const { count: newCount } = await supabase
+        .from('listings')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'active')
+        .gte('created_at', oneWeekAgo.toISOString());
+
+      stats.value.newThisWeek = newCount || 0;
+
+      // Distinct countries (select only country column, cap at 5000 for safety)
+      const { data: countryData } = await supabase
+        .from('listings')
+        .select('country')
+        .eq('status', 'active')
+        .not('country', 'is', null)
+        .limit(5000);
+
+      if (countryData) {
+        const uniqueCountries = new Set(countryData.map((l: { country: string }) => l.country).filter(Boolean));
+        stats.value.countries = uniqueCountries.size;
+      }
+    } catch (error) {
+      console.error('Error loading statistics:', error);
+    } finally {
+      statsLoading.value = false;
+    }
+  };
+
+  // Fetch featured (paid tier) listings
+  const loadFeaturedListings = async () => {
+    try {
+      const now = new Date().toISOString();
+      const { data, error } = await applyPhotoOrdering(
+        supabase
+          .from('listings')
+          .select(
+            `
+          *,
+          listing_photos (id, storage_path, display_order, category, caption, is_primary),
+          profiles:public_profiles!listings_user_id_fkey (id, display_name, username, location, avatar_url)
+        `
+          )
+          .in('status', activeStatuses.value)
+          .eq('tier', 'paid')
+          .gte('featured_until', now)
+          .order('created_at', { ascending: false })
+      ).limit(6);
+
+      if (!error) {
+        featuredListings.value = sortExamplesLast(data || []);
+      }
+    } catch (error) {
+      console.error('Error loading featured listings:', error);
+    }
+  };
+
+  // Staff Favorites (future feature)
+  // const loadPromotedListings = async () => { ... };
+
+  // Fetch recent active listings
+  const loadRecentListings = async () => {
+    try {
+      const { data, error } = await applyPhotoOrdering(
+        supabase
+          .from('listings')
+          .select(
+            `
+          *,
+          listing_photos (id, storage_path, display_order, category, caption, is_primary),
+          profiles:public_profiles!listings_user_id_fkey (id, display_name, username, location, avatar_url)
+        `
+          )
+          .in('status', activeStatuses.value)
+          .order('created_at', { ascending: false })
+      ).limit(12);
+
+      if (!error) {
+        recentListings.value = sortExamplesLast(data || []);
+      }
+    } catch (error) {
+      console.error('Error loading recent listings:', error);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  onMounted(async () => {
+    await loadVisibility();
+    await Promise.all([loadStatistics(), loadFeaturedListings(), loadRecentListings()]);
+  });
+</script>
 
 <i18n lang="json">
 {
   "en": {
     "seo": {
-      "title": "The Mini Exchange — Classic Mini Marketplace | Classic Mini DIY",
-      "description": "Buy and sell Classic Mini Coopers, parts, and project cars in the Classic Mini DIY marketplace."
+      "title": "The Mini Exchange - Classic Mini Classifieds Worldwide",
+      "description": "The marketplace for Classic Minis. Buy and sell vehicles, engines, and parts from the worldwide Mini community.",
+      "shareDescription": "Buy and sell Classic Mini vehicles, engines, and parts from enthusiasts worldwide.",
+      "srHeading": "The Mini Exchange - Classic Mini Cooper Classifieds Worldwide"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "Classic Mini classifieds, now part of Classic Mini DIY."
+    "search": {
+      "placeholder": "Search Classic Mini listings...",
+      "button": "Search"
+    },
+    "stats": {
+      "activeListings": "active listings",
+      "countries": "countries",
+      "soldThisMonth": "sold this month",
+      "newThisWeek": "new this week"
+    },
+    "cta": {
+      "title": "Ready to List Something?",
+      "body": "Reach Classic Mini enthusiasts worldwide. List for free or go Premium for featured placement and priority in search results.",
+      "listFree": "List for Free",
+      "goPremium": "Go Premium — $10"
+    },
+    "recent": {
+      "heading": "Recent Listings",
+      "viewAll": "View All",
+      "emptyTitle": "No listings yet",
+      "emptyBody": "Be the first to post!",
+      "emptyAction": "Create a Listing"
+    },
+    "features": {
+      "heading": "Why The Mini Exchange?",
+      "worldwide": {
+        "title": "Worldwide Marketplace",
+        "body": "Buy and sell across the globe with 15 supported currencies. Prices convert automatically to your preferred currency."
+      },
+      "expertise": {
+        "title": "Classic Mini Expertise",
+        "body": "Built by enthusiasts. 50+ Mini-specific fields for heritage, modifications, and authenticity tracking."
+      },
+      "free": {
+        "title": "Free to List",
+        "body": "No upfront costs. Go Premium for $10 to get featured placement, more photos, and priority search results."
+      },
+      "photos": {
+        "title": "Photo Galleries",
+        "body": "Showcase every detail with organized photo categories: body, engine, interior, and details."
+      },
+      "heritage": {
+        "title": "Heritage Documentation",
+        "body": "Track VIN numbers, BMIHT heritage certificates, original colors, and service history."
+      },
+      "communication": {
+        "title": "Direct Communication",
+        "body": "Built-in messaging plus public Q&A comments for community knowledge sharing."
+      }
     }
   },
   "es": {
     "seo": {
-      "title": "The Mini Exchange — Mercado del Classic Mini | Classic Mini DIY",
-      "description": "Compra y vende Classic Mini Cooper, piezas y coches de proyecto en el mercado de Classic Mini DIY."
+      "title": "The Mini Exchange - Anuncios de Classic Mini en todo el mundo",
+      "description": "El mercado para Classic Minis. Compra y vende vehículos, motores y piezas de la comunidad Mini mundial.",
+      "shareDescription": "Compra y vende vehículos, motores y piezas de Classic Mini de entusiastas de todo el mundo.",
+      "srHeading": "The Mini Exchange - Anuncios de Classic Mini Cooper en todo el mundo"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "Anuncios clasificados del Classic Mini, ahora parte de Classic Mini DIY."
+    "search": {
+      "placeholder": "Buscar anuncios de Classic Mini...",
+      "button": "Buscar"
+    },
+    "stats": {
+      "activeListings": "anuncios activos",
+      "countries": "países",
+      "soldThisMonth": "vendidos este mes",
+      "newThisWeek": "nuevos esta semana"
+    },
+    "cta": {
+      "title": "¿Listo para publicar algo?",
+      "body": "Llega a entusiastas del Classic Mini en todo el mundo. Publica gratis o hazte Premium para obtener posicionamiento destacado y prioridad en los resultados de búsqueda.",
+      "listFree": "Publicar gratis",
+      "goPremium": "Hazte Premium — $10"
+    },
+    "recent": {
+      "heading": "Anuncios recientes",
+      "viewAll": "Ver todo",
+      "emptyTitle": "Aún no hay anuncios",
+      "emptyBody": "¡Sé el primero en publicar!",
+      "emptyAction": "Crear un anuncio"
+    },
+    "features": {
+      "heading": "¿Por qué The Mini Exchange?",
+      "worldwide": {
+        "title": "Mercado mundial",
+        "body": "Compra y vende en todo el mundo con 15 divisas compatibles. Los precios se convierten automáticamente a tu moneda preferida."
+      },
+      "expertise": {
+        "title": "Experiencia en Classic Mini",
+        "body": "Creado por entusiastas. Más de 50 campos específicos del Mini para seguimiento de herencia, modificaciones y autenticidad."
+      },
+      "free": {
+        "title": "Publicación gratuita",
+        "body": "Sin costes iniciales. Hazte Premium por $10 para obtener posicionamiento destacado, más fotos y prioridad en los resultados de búsqueda."
+      },
+      "photos": {
+        "title": "Galerías de fotos",
+        "body": "Muestra cada detalle con categorías de fotos organizadas: carrocería, motor, interior y detalles."
+      },
+      "heritage": {
+        "title": "Documentación de herencia",
+        "body": "Registra números VIN, certificados de herencia BMIHT, colores originales e historial de mantenimiento."
+      },
+      "communication": {
+        "title": "Comunicación directa",
+        "body": "Mensajería integrada más comentarios de preguntas y respuestas públicas para compartir conocimiento en la comunidad."
+      }
     }
   },
   "fr": {
     "seo": {
-      "title": "The Mini Exchange — Place de marché Classic Mini | Classic Mini DIY",
-      "description": "Achetez et vendez des Classic Mini Cooper, des pièces et des voitures à restaurer sur la place de marché Classic Mini DIY."
+      "title": "The Mini Exchange - Petites annonces Classic Mini dans le monde entier",
+      "description": "Le marché pour les Classic Minis. Achetez et vendez des véhicules, moteurs et pièces au sein de la communauté Mini mondiale.",
+      "shareDescription": "Achetez et vendez des véhicules, moteurs et pièces Classic Mini auprès d'enthousiastes du monde entier.",
+      "srHeading": "The Mini Exchange - Petites annonces Classic Mini Cooper dans le monde entier"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "Petites annonces Classic Mini, désormais intégrées à Classic Mini DIY."
+    "search": {
+      "placeholder": "Rechercher des annonces Classic Mini...",
+      "button": "Rechercher"
+    },
+    "stats": {
+      "activeListings": "annonces actives",
+      "countries": "pays",
+      "soldThisMonth": "vendus ce mois-ci",
+      "newThisWeek": "nouveaux cette semaine"
+    },
+    "cta": {
+      "title": "Prêt à publier quelque chose ?",
+      "body": "Atteignez des passionnés de Classic Mini du monde entier. Publiez gratuitement ou passez Premium pour un placement en vedette et une priorité dans les résultats de recherche.",
+      "listFree": "Publier gratuitement",
+      "goPremium": "Passer Premium — 10 $"
+    },
+    "recent": {
+      "heading": "Annonces récentes",
+      "viewAll": "Tout voir",
+      "emptyTitle": "Aucune annonce pour l'instant",
+      "emptyBody": "Soyez le premier à publier !",
+      "emptyAction": "Créer une annonce"
+    },
+    "features": {
+      "heading": "Pourquoi The Mini Exchange ?",
+      "worldwide": {
+        "title": "Marché mondial",
+        "body": "Achetez et vendez dans le monde entier avec 15 devises prises en charge. Les prix sont automatiquement convertis dans votre devise préférée."
+      },
+      "expertise": {
+        "title": "Expertise Classic Mini",
+        "body": "Créé par des passionnés. Plus de 50 champs spécifiques au Mini pour le suivi du patrimoine, des modifications et de l'authenticité."
+      },
+      "free": {
+        "title": "Publication gratuite",
+        "body": "Sans frais initiaux. Passez Premium pour 10 $ afin d'obtenir un placement en vedette, plus de photos et une priorité dans les résultats de recherche."
+      },
+      "photos": {
+        "title": "Galeries de photos",
+        "body": "Mettez en valeur chaque détail avec des catégories de photos organisées : carrosserie, moteur, intérieur et détails."
+      },
+      "heritage": {
+        "title": "Documentation patrimoniale",
+        "body": "Suivez les numéros VIN, les certificats patrimoniaux BMIHT, les couleurs d'origine et l'historique d'entretien."
+      },
+      "communication": {
+        "title": "Communication directe",
+        "body": "Messagerie intégrée et commentaires de questions-réponses publics pour le partage des connaissances communautaires."
+      }
     }
   },
   "de": {
     "seo": {
-      "title": "The Mini Exchange — Classic-Mini-Marktplatz | Classic Mini DIY",
-      "description": "Kaufen und verkaufen Sie Classic Mini Cooper, Teile und Projektfahrzeuge auf dem Classic-Mini-DIY-Marktplatz."
+      "title": "The Mini Exchange - Classic-Mini-Kleinanzeigen weltweit",
+      "description": "Der Marktplatz für Classic Minis. Kaufe und verkaufe Fahrzeuge, Motoren und Teile aus der weltweiten Mini-Community.",
+      "shareDescription": "Kaufe und verkaufe Classic-Mini-Fahrzeuge, Motoren und Teile von Enthusiasten weltweit.",
+      "srHeading": "The Mini Exchange - Classic-Mini-Cooper-Kleinanzeigen weltweit"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "Classic-Mini-Kleinanzeigen, jetzt Teil von Classic Mini DIY."
+    "search": {
+      "placeholder": "Classic-Mini-Anzeigen durchsuchen...",
+      "button": "Suchen"
+    },
+    "stats": {
+      "activeListings": "aktive Anzeigen",
+      "countries": "Länder",
+      "soldThisMonth": "diesen Monat verkauft",
+      "newThisWeek": "neu diese Woche"
+    },
+    "cta": {
+      "title": "Bereit, etwas zu inserieren?",
+      "body": "Erreiche Classic-Mini-Enthusiasten weltweit. Inseriere kostenlos oder wechsle zu Premium für hervorgehobene Platzierung und Priorität in den Suchergebnissen.",
+      "listFree": "Kostenlos inserieren",
+      "goPremium": "Premium werden — 10 $"
+    },
+    "recent": {
+      "heading": "Neueste Anzeigen",
+      "viewAll": "Alle ansehen",
+      "emptyTitle": "Noch keine Anzeigen",
+      "emptyBody": "Sei der Erste, der etwas postet!",
+      "emptyAction": "Anzeige erstellen"
+    },
+    "features": {
+      "heading": "Warum The Mini Exchange?",
+      "worldwide": {
+        "title": "Weltweiter Marktplatz",
+        "body": "Kaufe und verkaufe weltweit mit 15 unterstützten Währungen. Preise werden automatisch in deine bevorzugte Währung umgerechnet."
+      },
+      "expertise": {
+        "title": "Classic-Mini-Expertise",
+        "body": "Von Enthusiasten entwickelt. Über 50 Mini-spezifische Felder für Heritage-, Modifikations- und Authentizitätsverfolgung."
+      },
+      "free": {
+        "title": "Kostenlos inserieren",
+        "body": "Keine Vorabkosten. Wechsle für 10 $ zu Premium für hervorgehobene Platzierung, mehr Fotos und Priorität in den Suchergebnissen."
+      },
+      "photos": {
+        "title": "Fotogalerien",
+        "body": "Zeige jedes Detail mit organisierten Fotokategorien: Karosserie, Motor, Innenraum und Details."
+      },
+      "heritage": {
+        "title": "Heritage-Dokumentation",
+        "body": "Verfolge VIN-Nummern, BMIHT-Heritage-Zertifikate, Originalfarben und Wartungshistorie."
+      },
+      "communication": {
+        "title": "Direkte Kommunikation",
+        "body": "Integriertes Messaging plus öffentliche Q&A-Kommentare für den Wissensaustausch in der Community."
+      }
     }
   },
   "it": {
     "seo": {
-      "title": "The Mini Exchange — Mercato Classic Mini | Classic Mini DIY",
-      "description": "Compra e vendi Classic Mini Cooper, ricambi e auto da restauro nel mercato di Classic Mini DIY."
+      "title": "The Mini Exchange - Annunci Classic Mini in tutto il mondo",
+      "description": "Il mercato per le Classic Mini. Compra e vendi veicoli, motori e ricambi dalla comunità Mini mondiale.",
+      "shareDescription": "Compra e vendi veicoli, motori e ricambi Classic Mini da appassionati di tutto il mondo.",
+      "srHeading": "The Mini Exchange - Annunci Classic Mini Cooper in tutto il mondo"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "Annunci Classic Mini, ora parte di Classic Mini DIY."
+    "search": {
+      "placeholder": "Cerca annunci Classic Mini...",
+      "button": "Cerca"
+    },
+    "stats": {
+      "activeListings": "annunci attivi",
+      "countries": "paesi",
+      "soldThisMonth": "venduti questo mese",
+      "newThisWeek": "nuovi questa settimana"
+    },
+    "cta": {
+      "title": "Pronto a pubblicare qualcosa?",
+      "body": "Raggiungi gli appassionati di Classic Mini in tutto il mondo. Pubblica gratuitamente o passa a Premium per un posizionamento in evidenza e priorità nei risultati di ricerca.",
+      "listFree": "Pubblica gratis",
+      "goPremium": "Vai Premium — $10"
+    },
+    "recent": {
+      "heading": "Annunci recenti",
+      "viewAll": "Vedi tutto",
+      "emptyTitle": "Ancora nessun annuncio",
+      "emptyBody": "Sii il primo a pubblicare!",
+      "emptyAction": "Crea un annuncio"
+    },
+    "features": {
+      "heading": "Perché The Mini Exchange?",
+      "worldwide": {
+        "title": "Mercato mondiale",
+        "body": "Compra e vendi in tutto il mondo con 15 valute supportate. I prezzi vengono convertiti automaticamente nella tua valuta preferita."
+      },
+      "expertise": {
+        "title": "Competenza Classic Mini",
+        "body": "Creato da appassionati. Oltre 50 campi specifici per il Mini per il tracciamento di heritage, modifiche e autenticità."
+      },
+      "free": {
+        "title": "Pubblicazione gratuita",
+        "body": "Nessun costo iniziale. Passa a Premium per $10 per ottenere posizionamento in evidenza, più foto e priorità nei risultati di ricerca."
+      },
+      "photos": {
+        "title": "Gallerie fotografiche",
+        "body": "Metti in risalto ogni dettaglio con categorie fotografiche organizzate: carrozzeria, motore, interni e dettagli."
+      },
+      "heritage": {
+        "title": "Documentazione heritage",
+        "body": "Traccia numeri VIN, certificati heritage BMIHT, colori originali e cronologia di manutenzione."
+      },
+      "communication": {
+        "title": "Comunicazione diretta",
+        "body": "Messaggistica integrata più commenti Q&A pubblici per la condivisione delle conoscenze della community."
+      }
     }
   },
   "pt": {
     "seo": {
-      "title": "The Mini Exchange — Mercado Classic Mini | Classic Mini DIY",
-      "description": "Compre e venda Classic Mini Cooper, peças e carros para restauro no mercado da Classic Mini DIY."
+      "title": "The Mini Exchange - Anúncios de Classic Mini em todo o mundo",
+      "description": "O mercado para Classic Minis. Compre e venda veículos, motores e peças da comunidade Mini mundial.",
+      "shareDescription": "Compre e venda veículos, motores e peças Classic Mini de entusiastas de todo o mundo.",
+      "srHeading": "The Mini Exchange - Anúncios de Classic Mini Cooper em todo o mundo"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "Classificados Classic Mini, agora parte da Classic Mini DIY."
+    "search": {
+      "placeholder": "Pesquisar anúncios Classic Mini...",
+      "button": "Pesquisar"
+    },
+    "stats": {
+      "activeListings": "anúncios ativos",
+      "countries": "países",
+      "soldThisMonth": "vendidos este mês",
+      "newThisWeek": "novos esta semana"
+    },
+    "cta": {
+      "title": "Pronto para publicar algo?",
+      "body": "Alcance entusiastas do Classic Mini em todo o mundo. Publique gratuitamente ou passe para o Premium para destaque e prioridade nos resultados de pesquisa.",
+      "listFree": "Publicar gratuitamente",
+      "goPremium": "Ir para Premium — $10"
+    },
+    "recent": {
+      "heading": "Anúncios recentes",
+      "viewAll": "Ver tudo",
+      "emptyTitle": "Ainda não há anúncios",
+      "emptyBody": "Seja o primeiro a publicar!",
+      "emptyAction": "Criar um anúncio"
+    },
+    "features": {
+      "heading": "Por que The Mini Exchange?",
+      "worldwide": {
+        "title": "Mercado mundial",
+        "body": "Compre e venda em todo o mundo com 15 moedas suportadas. Os preços são convertidos automaticamente para a sua moeda preferida."
+      },
+      "expertise": {
+        "title": "Experiência em Classic Mini",
+        "body": "Criado por entusiastas. Mais de 50 campos específicos do Mini para rastreamento de herança, modificações e autenticidade."
+      },
+      "free": {
+        "title": "Publicação gratuita",
+        "body": "Sem custos iniciais. Vá para o Premium por $10 para obter posicionamento em destaque, mais fotos e prioridade nos resultados de pesquisa."
+      },
+      "photos": {
+        "title": "Galerias de fotos",
+        "body": "Mostre cada detalhe com categorias de fotos organizadas: carroceria, motor, interior e detalhes."
+      },
+      "heritage": {
+        "title": "Documentação de herança",
+        "body": "Rastreie números VIN, certificados de herança BMIHT, cores originais e histórico de manutenção."
+      },
+      "communication": {
+        "title": "Comunicação direta",
+        "body": "Mensagens integradas mais comentários públicos de perguntas e respostas para compartilhamento de conhecimento da comunidade."
+      }
     }
   },
   "ru": {
     "seo": {
-      "title": "The Mini Exchange — площадка Classic Mini | Classic Mini DIY",
-      "description": "Покупайте и продавайте Classic Mini Cooper, запчасти и проектные автомобили на площадке Classic Mini DIY."
+      "title": "The Mini Exchange - Объявления Classic Mini по всему миру",
+      "description": "Торговая площадка для Classic Mini. Покупайте и продавайте автомобили, двигатели и запчасти от мирового сообщества Mini.",
+      "shareDescription": "Покупайте и продавайте автомобили, двигатели и запчасти Classic Mini у энтузиастов со всего мира.",
+      "srHeading": "The Mini Exchange - Объявления Classic Mini Cooper по всему миру"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "Объявления Classic Mini теперь часть Classic Mini DIY."
+    "search": {
+      "placeholder": "Поиск объявлений Classic Mini...",
+      "button": "Поиск"
+    },
+    "stats": {
+      "activeListings": "активных объявлений",
+      "countries": "стран",
+      "soldThisMonth": "продано в этом месяце",
+      "newThisWeek": "новых на этой неделе"
+    },
+    "cta": {
+      "title": "Готовы разместить объявление?",
+      "body": "Достигайте энтузиастов Classic Mini по всему миру. Размещайте бесплатно или переходите на Premium для выделенного размещения и приоритета в результатах поиска.",
+      "listFree": "Разместить бесплатно",
+      "goPremium": "Перейти на Premium — $10"
+    },
+    "recent": {
+      "heading": "Последние объявления",
+      "viewAll": "Смотреть все",
+      "emptyTitle": "Объявлений пока нет",
+      "emptyBody": "Будьте первым, кто разместит!",
+      "emptyAction": "Создать объявление"
+    },
+    "features": {
+      "heading": "Почему The Mini Exchange?",
+      "worldwide": {
+        "title": "Мировой рынок",
+        "body": "Покупайте и продавайте по всему миру с поддержкой 15 валют. Цены автоматически конвертируются в предпочитаемую валюту."
+      },
+      "expertise": {
+        "title": "Экспертиза Classic Mini",
+        "body": "Создано энтузиастами. Более 50 полей, специфичных для Mini, для отслеживания наследия, модификаций и аутентичности."
+      },
+      "free": {
+        "title": "Бесплатное размещение",
+        "body": "Без предварительных затрат. Перейдите на Premium за $10 для выделенного размещения, большего количества фото и приоритета в результатах поиска."
+      },
+      "photos": {
+        "title": "Фотогалереи",
+        "body": "Демонстрируйте каждую деталь с организованными категориями фото: кузов, двигатель, салон и детали."
+      },
+      "heritage": {
+        "title": "Документация по наследию",
+        "body": "Отслеживайте VIN-номера, сертификаты наследия BMIHT, оригинальные цвета и историю обслуживания."
+      },
+      "communication": {
+        "title": "Прямая коммуникация",
+        "body": "Встроенный мессенджер плюс публичные комментарии в формате вопрос-ответ для обмена знаниями в сообществе."
+      }
     }
   },
   "ja": {
     "seo": {
-      "title": "The Mini Exchange — クラシックミニ マーケットプレイス | Classic Mini DIY",
-      "description": "Classic Mini DIY のマーケットプレイスで、クラシックミニ クーパーや部品、プロジェクト車を売買できます。"
+      "title": "The Mini Exchange - 世界のクラシックミニ売買情報",
+      "description": "クラシックミニのマーケットプレイス。世界中のMiniコミュニティから車両、エンジン、パーツを売買できます。",
+      "shareDescription": "世界中の愛好家からクラシックミニの車両、エンジン、パーツを売買できます。",
+      "srHeading": "The Mini Exchange - 世界のクラシックミニクーパー売買情報"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "クラシックミニの売買が Classic Mini DIY の一部になりました。"
+    "search": {
+      "placeholder": "クラシックミニの出品を検索...",
+      "button": "検索"
+    },
+    "stats": {
+      "activeListings": "件の出品中",
+      "countries": "か国",
+      "soldThisMonth": "件が今月売れた",
+      "newThisWeek": "件が今週追加"
+    },
+    "cta": {
+      "title": "出品しませんか？",
+      "body": "世界中のクラシックミニ愛好家にリーチできます。無料で出品するか、プレミアムにアップグレードして注目の掲載枠と検索優先表示を手に入れましょう。",
+      "listFree": "無料で出品",
+      "goPremium": "プレミアムにする — $10"
+    },
+    "recent": {
+      "heading": "最近の出品",
+      "viewAll": "すべて見る",
+      "emptyTitle": "まだ出品がありません",
+      "emptyBody": "最初の出品者になりましょう！",
+      "emptyAction": "出品を作成"
+    },
+    "features": {
+      "heading": "なぜ The Mini Exchange？",
+      "worldwide": {
+        "title": "世界規模のマーケットプレイス",
+        "body": "15の通貨をサポートし、世界中で売買できます。価格は自動的に希望の通貨に換算されます。"
+      },
+      "expertise": {
+        "title": "クラシックミニの専門知識",
+        "body": "愛好家が作成。ヘリテージ、改造、真正性追跡のためのMini固有フィールドが50以上。"
+      },
+      "free": {
+        "title": "無料で出品",
+        "body": "初期費用なし。$10でプレミアムにアップグレードすると、注目の掲載枠、より多くの写真、検索優先表示が得られます。"
+      },
+      "photos": {
+        "title": "フォトギャラリー",
+        "body": "ボディ、エンジン、インテリア、ディテールなど整理されたカテゴリで細部まで紹介できます。"
+      },
+      "heritage": {
+        "title": "ヘリテージドキュメント",
+        "body": "VIN番号、BMIHTヘリテージ証明書、オリジナルカラー、整備履歴を記録できます。"
+      },
+      "communication": {
+        "title": "直接コミュニケーション",
+        "body": "組み込みメッセージングとコミュニティの知識共有のための公開Q&Aコメント。"
+      }
     }
   },
   "zh": {
     "seo": {
-      "title": "The Mini Exchange — 经典 Mini 交易市场 | Classic Mini DIY",
-      "description": "在 Classic Mini DIY 交易市场买卖经典 Mini Cooper、零件和项目车。"
+      "title": "The Mini Exchange - 全球经典 Mini 分类广告",
+      "description": "经典 Mini 的交易市场。来自全球 Mini 社区的车辆、发动机和零件买卖平台。",
+      "shareDescription": "与全球各地的爱好者买卖经典 Mini 车辆、发动机和零件。",
+      "srHeading": "The Mini Exchange - 全球经典 Mini Cooper 分类广告"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "经典 Mini 分类信息，现已并入 Classic Mini DIY。"
+    "search": {
+      "placeholder": "搜索经典 Mini 刊登...",
+      "button": "搜索"
+    },
+    "stats": {
+      "activeListings": "条活跃刊登",
+      "countries": "个国家",
+      "soldThisMonth": "本月已售",
+      "newThisWeek": "本周新增"
+    },
+    "cta": {
+      "title": "准备好发布了吗？",
+      "body": "触达全球经典 Mini 爱好者。免费发布，或升级 Premium 以获得特色展示位和搜索结果优先排名。",
+      "listFree": "免费发布",
+      "goPremium": "升级 Premium — $10"
+    },
+    "recent": {
+      "heading": "最新刊登",
+      "viewAll": "查看全部",
+      "emptyTitle": "暂无刊登",
+      "emptyBody": "来发布第一个吧！",
+      "emptyAction": "创建刊登"
+    },
+    "features": {
+      "heading": "为什么选择 The Mini Exchange？",
+      "worldwide": {
+        "title": "全球市场",
+        "body": "支持 15 种货币，在全球范围内买卖。价格自动换算为您的首选货币。"
+      },
+      "expertise": {
+        "title": "经典 Mini 专业知识",
+        "body": "由爱好者打造。超过 50 个 Mini 专属字段，用于跟踪传承、改装和真实性。"
+      },
+      "free": {
+        "title": "免费发布",
+        "body": "无需预付费用。升级 Premium 仅需 $10，即可获得特色展示位、更多图片和搜索优先排名。"
+      },
+      "photos": {
+        "title": "照片库",
+        "body": "通过有序分类（车身、发动机、内饰、细节）展示每个细节。"
+      },
+      "heritage": {
+        "title": "传承文件",
+        "body": "追踪 VIN 编号、BMIHT 传承证书、原厂颜色和维修历史。"
+      },
+      "communication": {
+        "title": "直接沟通",
+        "body": "内置消息功能加上公开问答评论，促进社区知识共享。"
+      }
     }
   },
   "ko": {
     "seo": {
-      "title": "The Mini Exchange — 클래식 미니 마켓플레이스 | Classic Mini DIY",
-      "description": "Classic Mini DIY 마켓플레이스에서 클래식 미니 쿠퍼, 부품, 프로젝트 차량을 사고팔 수 있습니다."
+      "title": "The Mini Exchange - 전 세계 클래식 미니 분류 광고",
+      "description": "클래식 미니를 위한 마켓플레이스. 전 세계 미니 커뮤니티에서 차량, 엔진, 부품을 사고파세요.",
+      "shareDescription": "전 세계 애호가들과 함께 클래식 미니 차량, 엔진, 부품을 사고파세요.",
+      "srHeading": "The Mini Exchange - 전 세계 클래식 미니 쿠퍼 분류 광고"
     },
-    "hero": {
-      "title": "The Mini Exchange",
-      "subtitle": "클래식 미니 중고 거래가 이제 Classic Mini DIY의 일부입니다."
+    "search": {
+      "placeholder": "클래식 미니 매물 검색...",
+      "button": "검색"
+    },
+    "stats": {
+      "activeListings": "개 활성 매물",
+      "countries": "개국",
+      "soldThisMonth": "건 이번 달 판매됨",
+      "newThisWeek": "건 이번 주 신규"
+    },
+    "cta": {
+      "title": "무언가 등록할 준비가 되셨나요?",
+      "body": "전 세계 클래식 미니 애호가에게 다가가세요. 무료로 등록하거나 Premium으로 업그레이드하여 추천 배치와 검색 결과 우선 노출 혜택을 받으세요.",
+      "listFree": "무료로 등록",
+      "goPremium": "Premium 이용하기 — $10"
+    },
+    "recent": {
+      "heading": "최근 매물",
+      "viewAll": "전체 보기",
+      "emptyTitle": "아직 매물이 없습니다",
+      "emptyBody": "첫 번째로 등록해 보세요!",
+      "emptyAction": "매물 등록하기"
+    },
+    "features": {
+      "heading": "왜 The Mini Exchange인가요?",
+      "worldwide": {
+        "title": "전 세계 마켓플레이스",
+        "body": "15개 통화를 지원하여 전 세계에서 사고팔 수 있습니다. 가격은 선호하는 통화로 자동 변환됩니다."
+      },
+      "expertise": {
+        "title": "클래식 미니 전문성",
+        "body": "애호가가 만들었습니다. 헤리티지, 개조, 정통성 추적을 위한 Mini 전용 필드 50개 이상."
+      },
+      "free": {
+        "title": "무료 등록",
+        "body": "선불 비용 없음. $10에 Premium으로 업그레이드하면 추천 배치, 더 많은 사진, 검색 결과 우선 노출을 받습니다."
+      },
+      "photos": {
+        "title": "사진 갤러리",
+        "body": "차체, 엔진, 인테리어, 세부 사항 등 정리된 사진 카테고리로 모든 세부 사항을 보여주세요."
+      },
+      "heritage": {
+        "title": "헤리티지 문서화",
+        "body": "VIN 번호, BMIHT 헤리티지 인증서, 원래 색상 및 정비 이력을 추적하세요."
+      },
+      "communication": {
+        "title": "직접 소통",
+        "body": "내장 메시지 기능과 커뮤니티 지식 공유를 위한 공개 Q&A 댓글."
+      }
     }
   }
 }

--- a/app/utils/exchangeRoutes.ts
+++ b/app/utils/exchangeRoutes.ts
@@ -1,10 +1,11 @@
 // Single source of truth for "what counts as the Mini Exchange" at the route
 // level, so the cutover flag-gate and the onboarding gate can't drift apart.
 //
-// EXCHANGE_PREFIXES — the marketplace surfaces a logged-in user must have a
-// completed profile to use: the /exchange section plus the user's own
-// marketplace management tabs under /dashboard. Both the flag-gate (hide
-// pre-cutover) and the onboarding-gate (require a complete account) apply here.
+// EXCHANGE_PREFIXES — the marketplace surfaces the cutover flag hides pre-launch:
+// the /exchange section plus the user's own marketplace management tabs under
+// /dashboard. These are open to BROWSE for everyone once live; onboarding is NOT
+// required to view them (see EXCHANGE_ONBOARDING_PREFIXES for what actually needs
+// a completed profile).
 export const EXCHANGE_PREFIXES = [
   '/exchange',
   '/dashboard/listings',
@@ -19,6 +20,20 @@ export const EXCHANGE_PREFIXES = [
 //  - /admin/exchange is internal moderation tooling reached via is_admin;
 //    admins shouldn't be bounced through buyer/seller onboarding.
 export const EXCHANGE_FLAG_PREFIXES = [...EXCHANGE_PREFIXES, '/onboarding', '/admin/exchange'];
+
+// Routes that REQUIRE a completed profile to *act* — list, post a want, submit a
+// find, message. Everything else in the Exchange (landing, browse + detail pages,
+// feeds, dashboard tabs) stays open to everyone — anonymous OR logged-in,
+// onboarded or not — so the marketplace is fully viewable and existing users are
+// never walled out of browsing. Onboarding is DRIVEN by the soft nudge
+// (OnboardingNudge) and enforced here only at the point of action.
+export const EXCHANGE_ONBOARDING_PREFIXES = [
+  '/exchange/listings/new',
+  '/exchange/listings/bulk',
+  '/exchange/wanted/new',
+  '/exchange/finds/submit',
+  '/exchange/messages',
+];
 
 /** True when `path` equals or sits under any of `prefixes`. */
 export function pathInPrefixes(path: string, prefixes: string[]): boolean {

--- a/app/utils/imageOptimizer.ts
+++ b/app/utils/imageOptimizer.ts
@@ -47,6 +47,10 @@ export const isHeicFile = (file: File): boolean => {
  * Convert HEIC file to JPEG using heic2any (dynamically imported)
  */
 const convertHeicToJpeg = async (file: File): Promise<File> => {
+  // Browser-only: heic2any bundles a multi-MB libheif WASM blob. The
+  // import.meta.client guard lets the SSR/server build dead-code-eliminate this
+  // path so heic2any is never traced into the Vercel serverless function.
+  if (!import.meta.client) throw new Error('convertHeicToJpeg is browser-only');
   try {
     const heic2any = await import('heic2any');
     const blob = await heic2any.default({
@@ -85,6 +89,10 @@ const createPreview = (file: File): Promise<string> => {
  * - Outputs WebP (or JPEG fallback)
  */
 export const optimizeImage = async (file: File, opts: OptimizeOptions = {}): Promise<OptimizeResult> => {
+  // Browser-only: uses canvas/FileReader/web-workers + dynamically imports
+  // browser-image-compression (and heic2any via convertHeicToJpeg). The guard
+  // keeps both out of the SSR/server build + the Vercel serverless function.
+  if (!import.meta.client) throw new Error('optimizeImage is browser-only');
   const originalSize = file.size;
   let fileToProcess = file;
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -668,7 +668,26 @@ export default defineNuxtConfig({
         'highlight.js',
         '@vue/devtools-core',
         '@vue/devtools-kit',
+        '@vueuse/core',
         'fuse.js',
+        // schema-org (via @nuxtjs/seo, imported from app.vue) — pre-bundle so dev
+        // doesn't trigger a mid-session re-optimize + full page reload.
+        '@unhead/schema-org/vue',
+        // Exchange client-only deps discovered on the listing/message pages.
+        // (They're client-only — guarded out of the server bundle — so this is
+        // purely a dev pre-bundle to stop the mid-session re-optimize/reload.)
+        'mapbox-gl',
+        'heic2any',
+        'browser-image-compression',
+        // Other client-only libs across exchange/model components (charts,
+        // drag-reorder, 3D viewer, HTML sanitizer, zip). Pre-bundled up front so
+        // dev doesn't re-optimize + reload the first time each page is visited.
+        'chart.js',
+        'vue-chartjs',
+        'vuedraggable',
+        'three',
+        'dompurify',
+        'client-zip',
       ],
       exclude: [],
     },

--- a/server/utils/exchange/rateLimit.ts
+++ b/server/utils/exchange/rateLimit.ts
@@ -125,7 +125,7 @@ export function createRateLimitMiddleware(config: RateLimitConfig) {
 }
 
 /** Test/maintenance helper: clear all tracked entries. */
-export function _resetRateLimitStore(): void {
+export function _resetExchangeRateLimitStore(): void {
   rateLimitStore.clear();
 }
 

--- a/tests/unit/exchange/composables/useOnboardingGate.test.ts
+++ b/tests/unit/exchange/composables/useOnboardingGate.test.ts
@@ -11,11 +11,13 @@ import { cleanupGlobalMocks } from '../../../setup/testHelpers';
  *     - exchangeEnabled is truthy            (flag gate)
  *     - isAuthenticated.value is true        (logged in)
  *     - userProfile.value is truthy          (profile loaded, not null)
- *     - userProfile.value.onboarding_completed === false  (explicit false)
+ *     - userProfile.value.onboarding_completed !== true  (not explicitly completed)
  *
- * It is intentionally conservative: a still-loading (null) profile, or a
- * profile whose onboarding_completed is undefined/true, yields false. So does
- * the flag being off or the user being anonymous.
+ * The check is `!== true`, meaning null/undefined/false all satisfy the
+ * condition (all these users are driven to onboard). Only an explicit true
+ * yields false. A still-loading (null) profile returns false because the
+ * profile-loaded gate (`!!userProfile.value`) fails first.
+ * Flag off, not authed, or no profile loaded also yield false.
  */
 
 // Fine-grained auth stub. Unlike testHelpers' createMockAuth (which couples
@@ -130,9 +132,9 @@ describe('useOnboardingGate', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // onboarding_completed branch: must be EXPLICIT === false
+  // onboarding_completed branch: !== true means false/null/undefined all need onboarding
   // ---------------------------------------------------------------------------
-  describe('onboarding_completed branch (strict === false)', () => {
+  describe('onboarding_completed branch (!== true)', () => {
     it('is true when onboarding_completed === false', async () => {
       stubExchangeFlag(true);
       stubAuth({ authed: true, profile: { onboarding_completed: false } });
@@ -151,29 +153,31 @@ describe('useOnboardingGate', () => {
       expect(needsOnboarding.value).toBe(false);
     });
 
-    it('is false when onboarding_completed is undefined (column absent on profile)', async () => {
+    it('is true when onboarding_completed is undefined (column absent on profile — needs onboarding)', async () => {
       stubExchangeFlag(true);
       stubAuth({ authed: true, profile: {} });
 
       const { needsOnboarding } = await loadComposable();
 
-      expect(needsOnboarding.value).toBe(false);
+      // undefined !== true → user has a loaded profile but hasn't completed onboarding.
+      expect(needsOnboarding.value).toBe(true);
     });
 
-    it('is false when onboarding_completed is null (strict equality, not loose falsy)', async () => {
+    it('is true when onboarding_completed is null (backfilled null also needs onboarding)', async () => {
       stubExchangeFlag(true);
       stubAuth({ authed: true, profile: { onboarding_completed: null } });
 
       const { needsOnboarding } = await loadComposable();
 
-      // null !== false — the === false check must NOT treat null as "needs onboarding".
-      expect(needsOnboarding.value).toBe(false);
+      // null !== true → existing users whose column was backfilled to null get the nudge.
+      expect(needsOnboarding.value).toBe(true);
     });
   });
 
   // ---------------------------------------------------------------------------
   // Truth table — every combination of (flag, authed, profile-present,
-  // onboarding_completed). The single true case is the conjunction of all gates.
+  // onboarding_completed). The single false-for-complete case is when
+  // onboarding_completed === true; all other loaded-profile states need onboarding.
   // ---------------------------------------------------------------------------
   describe('full truth table', () => {
     type Row = {
@@ -210,15 +214,15 @@ describe('useOnboardingGate', () => {
         expected: false,
         label: 'flag on / anon / pending profile present',
       },
-      // flag ON, authed, profile null — false (loading)
+      // flag ON, authed, profile null — false (loading, profile-loaded gate fails)
       { flag: true, authed: true, profile: null, expected: false, label: 'flag on / authed / profile loading (null)' },
-      // flag ON, authed, profile present — depends on onboarding_completed
+      // flag ON, authed, profile present — depends on onboarding_completed !== true
       {
         flag: true,
         authed: true,
         profile: { onboarding_completed: false },
         expected: true,
-        label: 'flag on / authed / pending (=== false) ⇒ THE one true case',
+        label: 'flag on / authed / pending (=== false) ⇒ needs onboarding',
       },
       {
         flag: true,
@@ -231,15 +235,15 @@ describe('useOnboardingGate', () => {
         flag: true,
         authed: true,
         profile: {},
-        expected: false,
-        label: 'flag on / authed / onboarding_completed undefined',
+        expected: true,
+        label: 'flag on / authed / onboarding_completed undefined ⇒ needs onboarding',
       },
       {
         flag: true,
         authed: true,
         profile: { onboarding_completed: null },
-        expected: false,
-        label: 'flag on / authed / onboarding_completed null',
+        expected: true,
+        label: 'flag on / authed / onboarding_completed null ⇒ needs onboarding',
       },
     ];
 
@@ -252,8 +256,11 @@ describe('useOnboardingGate', () => {
       expect(needsOnboarding.value).toBe(expected);
     });
 
-    it('has exactly one true row in the truth table (only the full conjunction)', () => {
-      expect(rows.filter((r) => r.expected).length).toBe(1);
+    it('has exactly one false row for the completed case (only explicit true skips onboarding)', () => {
+      // Among authenticated, flag-on, profile-loaded rows, only onboarding_completed === true is false.
+      const authedFlagOnLoaded = rows.filter((r) => r.flag && r.authed && r.profile !== null);
+      expect(authedFlagOnLoaded.filter((r) => !r.expected).length).toBe(1);
+      expect(authedFlagOnLoaded.find((r) => !r.expected)?.profile).toEqual({ onboarding_completed: true });
     });
   });
 
@@ -272,6 +279,18 @@ describe('useOnboardingGate', () => {
 
       // Profile finishes loading, onboarding not yet done.
       auth.userProfile.value = { onboarding_completed: false };
+      expect(needsOnboarding.value).toBe(true);
+    });
+
+    it('flips false → true when a null profile resolves to one with undefined onboarding_completed', async () => {
+      stubExchangeFlag(true);
+      const auth = stubAuth({ authed: true, profile: null });
+
+      const { needsOnboarding } = await loadComposable();
+      expect(needsOnboarding.value).toBe(false);
+
+      // Profile loaded but column absent (existing user, column backfilled null in DB).
+      auth.userProfile.value = { onboarding_completed: null };
       expect(needsOnboarding.value).toBe(true);
     });
 

--- a/tests/unit/exchange/middleware/exchange-onboarding.test.ts
+++ b/tests/unit/exchange/middleware/exchange-onboarding.test.ts
@@ -4,11 +4,20 @@ import { ref } from 'vue';
 // Tests for the hard onboarding gate that guards the Mini Exchange section.
 // Source: app/middleware/exchange-onboarding.global.ts
 //
-// The middleware imports EXCHANGE_PREFIXES + pathInPrefixes from
+// The middleware imports EXCHANGE_ONBOARDING_PREFIXES + pathInPrefixes from
 // ~/utils/exchangeRoutes — those resolve for real via the vitest alias, so the
 // prefix-matching is exercised end-to-end (not mocked). Everything else
 // (defineNuxtRouteMiddleware, navigateTo, useRuntimeConfig, useAuth) is a Nuxt
 // auto-import stubbed as a global per case.
+//
+// Key contract (open-browsing model):
+//   - GATED action routes: EXCHANGE_ONBOARDING_PREFIXES =
+//       ['/exchange/listings/new', '/exchange/listings/bulk',
+//        '/exchange/wanted/new', '/exchange/finds/submit', '/exchange/messages']
+//   - OPEN to everyone: browse/detail ('/exchange/listings', '/exchange/listings/123'),
+//     landing, dashboard tabs ('/dashboard/listings', '/dashboard/wanted', etc.)
+//   - For gated routes: anonymous → pass; authed+complete → pass;
+//     authed+incomplete → redirect to /onboarding?redirect=<encoded-fullPath>
 //
 // NOTE on the `import.meta.server` early-return: vitest.config.ts rewrites
 // `import.meta.server` to the literal `(false)` at transform time, so on the
@@ -18,7 +27,8 @@ import { ref } from 'vue';
 
 type Route = { path: string; fullPath: string };
 
-const EXCHANGE_ROUTE: Route = { path: '/exchange/listings', fullPath: '/exchange/listings' };
+// A real action route — sits inside EXCHANGE_ONBOARDING_PREFIXES.
+const ACTION_ROUTE: Route = { path: '/exchange/listings/new', fullPath: '/exchange/listings/new' };
 
 describe('exchange-onboarding global middleware', () => {
   // Mutable auth state the stubbed useAuth() closes over.
@@ -61,7 +71,7 @@ describe('exchange-onboarding global middleware', () => {
 
   it('passes through when the exchange flag is OFF (never touches auth)', async () => {
     const middleware = await loadMiddleware(false);
-    const result = await middleware(EXCHANGE_ROUTE);
+    const result = await middleware(ACTION_ROUTE);
 
     expect(result).toBeUndefined();
     expect(navigateTo).not.toHaveBeenCalled();
@@ -69,7 +79,7 @@ describe('exchange-onboarding global middleware', () => {
     expect(waitForAuth).not.toHaveBeenCalled();
   });
 
-  it('passes through for a route NOT in EXCHANGE_PREFIXES (flag on)', async () => {
+  it('passes through for a route NOT in EXCHANGE_ONBOARDING_PREFIXES (flag on)', async () => {
     const middleware = await loadMiddleware(true);
     const result = await middleware({ path: '/technical/needles', fullPath: '/technical/needles' });
 
@@ -79,9 +89,8 @@ describe('exchange-onboarding global middleware', () => {
     expect(waitForAuth).not.toHaveBeenCalled();
   });
 
-  it('passes through for /dashboard tabs NOT owned by the exchange', async () => {
+  it('passes through for /dashboard/settings (not an exchange action route)', async () => {
     const middleware = await loadMiddleware(true);
-    // /dashboard/settings is under /dashboard but not in EXCHANGE_PREFIXES.
     const result = await middleware({ path: '/dashboard/settings', fullPath: '/dashboard/settings' });
 
     expect(result).toBeUndefined();
@@ -89,12 +98,56 @@ describe('exchange-onboarding global middleware', () => {
     expect(waitForAuth).not.toHaveBeenCalled();
   });
 
+  // Open-browsing model: dashboard exchange tabs are NOT gated — pass through
+  // even for an authed user with an incomplete profile.
   it.each([
     ['/dashboard/listings'],
     ['/dashboard/wanted'],
     ['/dashboard/notifications'],
     ['/dashboard/saved-searches'],
-  ])('guards exchange-owned dashboard prefix %s', async (path) => {
+  ])('passes through exchange-owned dashboard tab %s (open to all, no onboarding required)', async (path) => {
+    user = ref({ id: 'u1' });
+    userProfile = ref({ onboarding_completed: false });
+    const middleware = await loadMiddleware(true);
+
+    const result = await middleware({ path, fullPath: path });
+
+    expect(result).toBeUndefined();
+    expect(navigateTo).not.toHaveBeenCalled();
+    // Dashboard tabs are open — middleware returns before ever reaching auth.
+    expect(waitForAuth).not.toHaveBeenCalled();
+  });
+
+  // Open-browsing model: browse/detail routes pass through for incomplete users.
+  it.each([
+    ['/exchange/listings'],
+    ['/exchange/listings/123'],
+    ['/exchange/wanted'],
+    ['/exchange/finds'],
+    ['/dashboard/listings'],
+  ])(
+    'passes through open browse/detail route %s for an authed incomplete user',
+    async (path) => {
+      user = ref({ id: 'u1' });
+      userProfile = ref({ onboarding_completed: false });
+      const middleware = await loadMiddleware(true);
+
+      const result = await middleware({ path, fullPath: path });
+
+      expect(result).toBeUndefined();
+      expect(navigateTo).not.toHaveBeenCalled();
+    }
+  );
+
+  // The five real action routes in EXCHANGE_ONBOARDING_PREFIXES must redirect
+  // an authed user with an incomplete profile.
+  it.each([
+    ['/exchange/listings/new'],
+    ['/exchange/listings/bulk'],
+    ['/exchange/wanted/new'],
+    ['/exchange/finds/submit'],
+    ['/exchange/messages'],
+  ])('redirects an incomplete authed user on gated action route %s', async (path) => {
     user = ref({ id: 'u1' });
     userProfile = ref({ onboarding_completed: false });
     const middleware = await loadMiddleware(true);
@@ -109,7 +162,7 @@ describe('exchange-onboarding global middleware', () => {
     userProfile = ref({ onboarding_completed: false });
     const middleware = await loadMiddleware(true);
 
-    // /onboarding is not in EXCHANGE_PREFIXES, so it short-circuits at the
+    // /onboarding is not in EXCHANGE_ONBOARDING_PREFIXES, so it short-circuits at the
     // prefix check; assert it is never redirected regardless.
     const result = await middleware({ path: '/onboarding', fullPath: '/onboarding' });
 
@@ -132,7 +185,7 @@ describe('exchange-onboarding global middleware', () => {
     user = ref(null);
     const middleware = await loadMiddleware(true);
 
-    const result = await middleware(EXCHANGE_ROUTE);
+    const result = await middleware(ACTION_ROUTE);
 
     expect(result).toBeUndefined();
     expect(navigateTo).not.toHaveBeenCalled();
@@ -146,7 +199,7 @@ describe('exchange-onboarding global middleware', () => {
     userProfile = ref({ onboarding_completed: true });
     const middleware = await loadMiddleware(true);
 
-    const result = await middleware(EXCHANGE_ROUTE);
+    const result = await middleware(ACTION_ROUTE);
 
     expect(result).toBeUndefined();
     expect(navigateTo).not.toHaveBeenCalled();
@@ -163,7 +216,7 @@ describe('exchange-onboarding global middleware', () => {
     });
     const middleware = await loadMiddleware(true);
 
-    const result = await middleware(EXCHANGE_ROUTE);
+    const result = await middleware(ACTION_ROUTE);
 
     expect(fetchUserProfile).toHaveBeenCalledWith('u1');
     expect(navigateTo).not.toHaveBeenCalled();
@@ -173,7 +226,10 @@ describe('exchange-onboarding global middleware', () => {
   it('redirects an authed user with an INCOMPLETE profile to /onboarding with redirect', async () => {
     user = ref({ id: 'u1' });
     userProfile = ref({ onboarding_completed: false });
-    const to: Route = { path: '/exchange/listings/create', fullPath: '/exchange/listings/create?foo=bar' };
+    const to: Route = {
+      path: '/exchange/listings/new',
+      fullPath: '/exchange/listings/new?foo=bar',
+    };
     const middleware = await loadMiddleware(true);
 
     await middleware(to);
@@ -189,29 +245,32 @@ describe('exchange-onboarding global middleware', () => {
     fetchUserProfile = vi.fn(async () => {});
     const middleware = await loadMiddleware(true);
 
-    await middleware(EXCHANGE_ROUTE);
+    await middleware(ACTION_ROUTE);
 
     expect(fetchUserProfile).toHaveBeenCalledWith('u1');
     expect(navigateTo).toHaveBeenCalledWith(
-      `/onboarding?redirect=${encodeURIComponent(EXCHANGE_ROUTE.fullPath)}`
+      `/onboarding?redirect=${encodeURIComponent(ACTION_ROUTE.fullPath)}`
     );
   });
 
-  it('properly URL-encodes the redirect target', async () => {
+  it('properly URL-encodes the redirect target (spaces and ampersands)', async () => {
     user = ref({ id: 'u1' });
     userProfile = ref({ onboarding_completed: false });
+    // Use a real action route so the gate is reached.
     const to: Route = {
-      path: '/exchange/search',
-      fullPath: '/exchange/search?q=mini cooper&sort=price',
+      path: '/exchange/listings/new',
+      fullPath: '/exchange/listings/new?title=mini cooper&year=1979',
     };
     const middleware = await loadMiddleware(true);
 
     await middleware(to);
 
-    const expected = `/onboarding?redirect=${encodeURIComponent('/exchange/search?q=mini cooper&sort=price')}`;
+    const expected = `/onboarding?redirect=${encodeURIComponent('/exchange/listings/new?title=mini cooper&year=1979')}`;
     expect(navigateTo).toHaveBeenCalledWith(expected);
     // Spaces/ampersands must be encoded, not raw.
-    expect(navigateTo).not.toHaveBeenCalledWith('/onboarding?redirect=/exchange/search?q=mini cooper&sort=price');
+    expect(navigateTo).not.toHaveBeenCalledWith(
+      '/onboarding?redirect=/exchange/listings/new?title=mini cooper&year=1979'
+    );
   });
 
   it('caches a verified user — second navigation skips the profile fetch', async () => {
@@ -220,7 +279,7 @@ describe('exchange-onboarding global middleware', () => {
     const middleware = await loadMiddleware(true);
 
     // First pass verifies + caches the id.
-    await middleware(EXCHANGE_ROUTE);
+    await middleware(ACTION_ROUTE);
     expect(navigateTo).not.toHaveBeenCalled();
 
     // Now blank the profile to prove the cache short-circuits before any
@@ -239,17 +298,17 @@ describe('exchange-onboarding global middleware', () => {
     user = ref({ id: 'u1' });
     userProfile = ref({ onboarding_completed: true });
     const middleware = await loadMiddleware(true);
-    await middleware(EXCHANGE_ROUTE);
+    await middleware(ACTION_ROUTE);
     expect(navigateTo).not.toHaveBeenCalled();
 
     // A different incomplete user on the same (non-reset) module must NOT be
     // treated as verified.
     user = ref({ id: 'u2' });
     userProfile = ref({ onboarding_completed: false });
-    await middleware(EXCHANGE_ROUTE);
+    await middleware(ACTION_ROUTE);
 
     expect(navigateTo).toHaveBeenCalledWith(
-      `/onboarding?redirect=${encodeURIComponent(EXCHANGE_ROUTE.fullPath)}`
+      `/onboarding?redirect=${encodeURIComponent(ACTION_ROUTE.fullPath)}`
     );
   });
 
@@ -260,7 +319,7 @@ describe('exchange-onboarding global middleware', () => {
     waitForAuth = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const middleware = await loadMiddleware(true);
 
-    const result = await middleware(EXCHANGE_ROUTE);
+    const result = await middleware(ACTION_ROUTE);
 
     expect(waitForAuth).toHaveBeenCalledTimes(2);
     expect(waitForAuth).toHaveBeenNthCalledWith(1, 1500);
@@ -275,7 +334,7 @@ describe('exchange-onboarding global middleware', () => {
     waitForAuth = vi.fn().mockResolvedValue(true);
     const middleware = await loadMiddleware(true);
 
-    await middleware(EXCHANGE_ROUTE);
+    await middleware(ACTION_ROUTE);
 
     expect(waitForAuth).toHaveBeenCalledTimes(1);
     expect(waitForAuth).toHaveBeenCalledWith(1500);
@@ -288,11 +347,11 @@ describe('exchange-onboarding global middleware', () => {
     waitForAuth = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const middleware = await loadMiddleware(true);
 
-    await middleware(EXCHANGE_ROUTE);
+    await middleware(ACTION_ROUTE);
 
     expect(waitForAuth).toHaveBeenCalledTimes(2);
     expect(navigateTo).toHaveBeenCalledWith(
-      `/onboarding?redirect=${encodeURIComponent(EXCHANGE_ROUTE.fullPath)}`
+      `/onboarding?redirect=${encodeURIComponent(ACTION_ROUTE.fullPath)}`
     );
   });
 });

--- a/tests/unit/exchange/server/rateLimit.test.ts
+++ b/tests/unit/exchange/server/rateLimit.test.ts
@@ -4,14 +4,14 @@ import {
   checkRateLimit,
   createRateLimitMiddleware,
   RateLimitPresets,
-  _resetRateLimitStore,
+  _resetExchangeRateLimitStore,
   _rateLimitStoreSize,
   _MAX_TRACKED_KEYS,
 } from '~~/server/utils/exchange/rateLimit';
 
 describe('server/utils/exchange/rateLimit', () => {
   beforeEach(() => {
-    _resetRateLimitStore();
+    _resetExchangeRateLimitStore();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
   });
@@ -137,7 +137,7 @@ describe('server/utils/exchange/rateLimit', () => {
     });
 
     it('defaults keyPrefix to "rl"', () => {
-      _resetRateLimitStore();
+      _resetExchangeRateLimitStore();
       checkRateLimit('px', { maxRequests: 5, windowMs: 1000 });
       expect(_rateLimitStoreSize()).toBe(1);
       // Re-keying with explicit "rl" prefix collides with the default bucket.
@@ -245,7 +245,7 @@ describe('server/utils/exchange/rateLimit', () => {
       expect(getHeader).toHaveBeenCalledWith(expect.anything(), 'x-real-ip');
       // The bucket must be keyed off x-real-ip, not the forwarded IP. Exhaust
       // the real-ip bucket and confirm the forwarded IP would still be fresh.
-      _resetRateLimitStore();
+      _resetExchangeRateLimitStore();
       const realIp = checkRateLimit('203.0.113.9', config);
       expect(realIp.remaining).toBe(4);
       // getRequestIP is only consulted as a fallback; with x-real-ip present it

--- a/tests/unit/exchange/server/routes/admin-social-retry.post.test.ts
+++ b/tests/unit/exchange/server/routes/admin-social-retry.post.test.ts
@@ -1,0 +1,301 @@
+/** @vitest-environment node */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+// social-retry is a thin proxy: requireAdminAuth -> validate body -> forward to
+// the `post-listing-social` Supabase edge function with the service-role bearer,
+// returning its body verbatim (errors mapped in the catch). The route imports
+// requireAdminAuth via a relative specifier that resolves to the same module as
+// `~~/server/utils/adminAuth`. Everything else it touches (useRuntimeConfig,
+// readBody, createError, defineEventHandler, $fetch) is a Nuxt/h3 GLOBAL from
+// tests/setup/vitest.setup.ts, driven per-test.
+// ---------------------------------------------------------------------------
+vi.mock('~~/server/utils/adminAuth', () => ({
+  requireAdminAuth: vi.fn(),
+}));
+
+import { requireAdminAuth } from '~~/server/utils/adminAuth';
+
+const handler = (await import('~~/server/api/admin/exchange/social-retry.post')).default;
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+const ADMIN_ID = 'admin-1';
+const ADMIN_EMAIL = 'admin@classicminidiy.com';
+const LISTING_ID = 'listing-123';
+const PLATFORMS = ['facebook', 'bluesky'];
+const EDGE_SUCCESS = {
+  success: true,
+  results: [
+    { platform: 'facebook', success: true },
+    { platform: 'bluesky', success: true },
+  ],
+  allSucceeded: true,
+};
+
+function evt(): any {
+  return { context: {} };
+}
+
+/** Capture the args $fetch was invoked with (url, options). */
+function fetchCall(): [string, any] | undefined {
+  return ($fetch as any).mock.calls[0];
+}
+
+/** Restore the default runtimeConfig the setup file provides. */
+function defaultRuntimeConfig() {
+  (useRuntimeConfig as any).mockReturnValue({
+    public: {
+      supabaseUrl: 'https://test.supabase.co',
+      supabaseKey: 'test-anon-key',
+    },
+    SUPABASE_SERVICE_KEY: 'test-service-key',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // adminAuth passes by default, yielding an admin user.
+  (requireAdminAuth as any).mockResolvedValue({ user: { id: ADMIN_ID, email: ADMIN_EMAIL }, profile: { is_admin: true } });
+  // valid body by default: a listing id + a non-empty platforms array.
+  (readBody as any).mockResolvedValue({ listingId: LISTING_ID, platforms: PLATFORMS });
+  // edge function succeeds by default; the route returns its body verbatim.
+  ($fetch as any).mockResolvedValue(EDGE_SUCCESS);
+  defaultRuntimeConfig();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('server/api/admin/exchange/social-retry.post', () => {
+  // =========================================================================
+  //  Auth (401 / 403) — propagated from requireAdminAuth before any work
+  // =========================================================================
+  it('propagates 401 from requireAdminAuth before reading the body or calling the edge fn', async () => {
+    (requireAdminAuth as any).mockRejectedValue(
+      Object.assign(new Error('Authentication required'), { statusCode: 401 })
+    );
+
+    await expect(handler(evt())).rejects.toMatchObject({ statusCode: 401 });
+    expect(readBody).not.toHaveBeenCalled();
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  it('propagates 403 from requireAdminAuth (authenticated but not admin)', async () => {
+    (requireAdminAuth as any).mockRejectedValue(
+      Object.assign(new Error('Admin access required'), { statusCode: 403 })
+    );
+
+    await expect(handler(evt())).rejects.toMatchObject({ statusCode: 403 });
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  it('passes the event through to requireAdminAuth', async () => {
+    const e = evt();
+    await handler(e);
+    expect(requireAdminAuth).toHaveBeenCalledWith(e);
+  });
+
+  // =========================================================================
+  //  Body validation (400) — before the config guard + edge call
+  // =========================================================================
+  it('throws 400 when listingId is missing', async () => {
+    (readBody as any).mockResolvedValue({ platforms: PLATFORMS });
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: 'Missing listingId',
+    });
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws 400 when platforms is missing', async () => {
+    (readBody as any).mockResolvedValue({ listingId: LISTING_ID });
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: 'Missing or invalid platforms array',
+    });
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws 400 when platforms is an empty array', async () => {
+    (readBody as any).mockResolvedValue({ listingId: LISTING_ID, platforms: [] });
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: 'Missing or invalid platforms array',
+    });
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws 400 when platforms is not an array', async () => {
+    (readBody as any).mockResolvedValue({ listingId: LISTING_ID, platforms: 'facebook' as any });
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: 'Missing or invalid platforms array',
+    });
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  //  Config guard (500) — supabaseUrl / serviceKey must both be present
+  // =========================================================================
+  it('throws 500 when supabaseUrl is empty', async () => {
+    (useRuntimeConfig as any).mockReturnValue({
+      public: { supabaseUrl: '', supabaseKey: 'test-anon-key' },
+      SUPABASE_SERVICE_KEY: 'test-service-key',
+    });
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 500,
+      statusMessage: 'Supabase not configured',
+    });
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws 500 when SUPABASE_SERVICE_KEY is empty', async () => {
+    (useRuntimeConfig as any).mockReturnValue({
+      public: { supabaseUrl: 'https://test.supabase.co', supabaseKey: 'test-anon-key' },
+      SUPABASE_SERVICE_KEY: '',
+    });
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 500,
+      statusMessage: 'Supabase not configured',
+    });
+    expect($fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws 500 when supabaseUrl is undefined (optional-chained .replace)', async () => {
+    (useRuntimeConfig as any).mockReturnValue({
+      public: { supabaseKey: 'test-anon-key' },
+      SUPABASE_SERVICE_KEY: 'test-service-key',
+    });
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 500,
+      statusMessage: 'Supabase not configured',
+    });
+  });
+
+  it('runs requireAdminAuth before the supabase-config guard', async () => {
+    (useRuntimeConfig as any).mockReturnValue({
+      public: { supabaseUrl: '', supabaseKey: '' },
+      SUPABASE_SERVICE_KEY: '',
+    });
+    (requireAdminAuth as any).mockRejectedValue(
+      Object.assign(new Error('Authentication required'), { statusCode: 401 })
+    );
+
+    // Auth failure (401) wins over the would-be config 500.
+    await expect(handler(evt())).rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  // =========================================================================
+  //  Happy path — proxy to the post-listing-social edge function
+  // =========================================================================
+  it('returns the edge function body verbatim on success', async () => {
+    const result = await handler(evt());
+    expect(result).toBe(EDGE_SUCCESS);
+  });
+
+  it('targets the post-listing-social endpoint with a trimmed trailing slash on the base url', async () => {
+    (useRuntimeConfig as any).mockReturnValue({
+      public: { supabaseUrl: 'https://test.supabase.co/', supabaseKey: 'test-anon-key' },
+      SUPABASE_SERVICE_KEY: 'test-service-key',
+    });
+
+    await handler(evt());
+
+    const [url] = fetchCall()!;
+    // The route does `.replace(/\/$/, '')` so there is no double slash.
+    expect(url).toBe('https://test.supabase.co/functions/v1/post-listing-social');
+  });
+
+  it('POSTs with the service key as Bearer, the anon key as apikey, and json content-type', async () => {
+    await handler(evt());
+
+    const [url, opts] = fetchCall()!;
+    expect(url).toBe('https://test.supabase.co/functions/v1/post-listing-social');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers).toMatchObject({
+      Authorization: 'Bearer test-service-key',
+      apikey: 'test-anon-key',
+      'content-type': 'application/json',
+    });
+  });
+
+  it('forwards the listingId and platforms in the request body', async () => {
+    await handler(evt());
+
+    const [, opts] = fetchCall()!;
+    expect(opts.body).toEqual({ listingId: LISTING_ID, platforms: PLATFORMS });
+  });
+
+  it('calls the edge function exactly once', async () => {
+    await handler(evt());
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // =========================================================================
+  //  Edge-function thrown-error mapping (network/HTTP failures)
+  // =========================================================================
+  it('maps an edge error with statusCode + data.error to that status/message', async () => {
+    ($fetch as any).mockRejectedValue(
+      Object.assign(new Error('upstream'), { statusCode: 422, data: { error: 'Listing not found' } })
+    );
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 422,
+      statusMessage: 'Listing not found',
+    });
+  });
+
+  it('maps an edge error using response.status when statusCode is absent', async () => {
+    ($fetch as any).mockRejectedValue(
+      Object.assign(new Error('upstream'), { response: { status: 503 }, data: { error: 'Service down' } })
+    );
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'Service down',
+    });
+  });
+
+  it('falls back to 502 + a generic message when the edge error carries no status or message', async () => {
+    ($fetch as any).mockRejectedValue(new Error('network blip'));
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 502,
+      statusMessage: 'Failed to retry social posting',
+    });
+  });
+
+  it('uses statusMessage from the error when data.error is absent', async () => {
+    ($fetch as any).mockRejectedValue(
+      Object.assign(new Error('boom'), { statusCode: 418, statusMessage: 'Teapot' })
+    );
+
+    await expect(handler(evt())).rejects.toMatchObject({
+      statusCode: 418,
+      statusMessage: 'Teapot',
+    });
+  });
+
+  it('logs the edge function error to console.error', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    ($fetch as any).mockRejectedValue(
+      Object.assign(new Error('boom'), { statusCode: 500, data: { error: 'kaboom' } })
+    );
+
+    await expect(handler(evt())).rejects.toMatchObject({ statusCode: 500 });
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/tests/unit/exchange/server/routes/camino-distance.post.test.ts
+++ b/tests/unit/exchange/server/routes/camino-distance.post.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { _resetRateLimitStore, RateLimitPresets } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore, RateLimitPresets } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -76,7 +76,7 @@ describe('server/api/exchange/camino/distance.post', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cacheStore.clear();
-    _resetRateLimitStore();
+    _resetExchangeRateLimitStore();
 
     // Defaults: valid body, fixed IP, no x-forwarded-for fallback, happy Camino.
     setBody({ ...VALID_BODY });

--- a/tests/unit/exchange/server/routes/camino-meeting-spots.post.test.ts
+++ b/tests/unit/exchange/server/routes/camino-meeting-spots.post.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { _resetRateLimitStore, RateLimitPresets } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore, RateLimitPresets } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -80,7 +80,7 @@ function setRealIp(ip: string | undefined) {
 describe('server/api/exchange/camino/meeting-spots.post', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    _resetRateLimitStore();
+    _resetExchangeRateLimitStore();
 
     // Defaults: valid body, fixed IP, no x-forwarded-for fallback, happy upstream.
     setBody({ ...VALID_BODY });

--- a/tests/unit/exchange/server/routes/comments-create.post.test.ts
+++ b/tests/unit/exchange/server/routes/comments-create.post.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -103,7 +103,7 @@ function wireSingles(...results: Array<{ data: any; error: any }>) {
 }
 
 beforeEach(() => {
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
   vi.clearAllMocks();
 
   (requireUserClient as any).mockResolvedValue({ user: { ...USER } });
@@ -126,7 +126,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
 });
 
 // ===========================================================================

--- a/tests/unit/exchange/server/routes/contact-seller.post.test.ts
+++ b/tests/unit/exchange/server/routes/contact-seller.post.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -83,7 +83,7 @@ describe('server/api/exchange/contact-seller.post', () => {
     mockQueueNotification.mockResolvedValue(undefined);
 
     // Reset the shared in-memory rate-limit store so per-IP counts don't leak.
-    _resetRateLimitStore();
+    _resetExchangeRateLimitStore();
 
     setBody({ ...VALID_BODY });
     setRealIp('9.9.9.9');
@@ -94,7 +94,7 @@ describe('server/api/exchange/contact-seller.post', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    _resetRateLimitStore();
+    _resetExchangeRateLimitStore();
   });
 
   // -------------------------------------------------------------------------

--- a/tests/unit/exchange/server/routes/external-listings--id-.delete.test.ts
+++ b/tests/unit/exchange/server/routes/external-listings--id-.delete.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -74,7 +74,7 @@ function wire(find: { data: any; error: any }, profile: { data: any; error: any 
 
 beforeEach(() => {
   vi.clearAllMocks();
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
   (requireUserClient as any).mockResolvedValue({ user: { ...USER } });
   setFindId(FIND_ID);
   // Default happy path: non-admin owner deletes their own pending find.
@@ -83,7 +83,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
 });
 
 describe('server/api/exchange/external-listings/[id].delete', () => {

--- a/tests/unit/exchange/server/routes/external-listings-notify-submit.post.test.ts
+++ b/tests/unit/exchange/server/routes/external-listings-notify-submit.post.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mock the auth + service deps the route imports. The route imports them via
@@ -81,7 +81,7 @@ function wireSupabase(
 }
 
 beforeEach(() => {
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
   vi.clearAllMocks();
 
   // Default: authenticated user owns a clean find that resolves successfully.

--- a/tests/unit/exchange/server/routes/external-listings-parse.post.test.ts
+++ b/tests/unit/exchange/server/routes/external-listings-parse.post.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // The route under test:
@@ -129,7 +129,7 @@ function wireImageFetch(contentType = 'image/jpeg', ok = true) {
 }
 
 beforeEach(() => {
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
   vi.clearAllMocks();
 
   // Default happy-ish setup: a fetched page with NO OG (so the easy branches

--- a/tests/unit/exchange/server/routes/wanted--id-.delete.test.ts
+++ b/tests/unit/exchange/server/routes/wanted--id-.delete.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -71,7 +71,7 @@ function wire(post: { data: any; error: any }, profile: { data: any; error: any 
 }
 
 beforeEach(() => {
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
   vi.clearAllMocks();
   (requireUserClient as any).mockResolvedValue({ user: { ...USER } });
   setPostId('wp-1');

--- a/tests/unit/exchange/server/routes/wanted--id-.put.test.ts
+++ b/tests/unit/exchange/server/routes/wanted--id-.put.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mock the auth + service deps the route imports. The route imports them via
@@ -101,7 +101,7 @@ function lastUpdateArg() {
 }
 
 beforeEach(() => {
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
   vi.clearAllMocks();
 
   // Default: authenticated owner, existing post, clean partial update.

--- a/tests/unit/exchange/server/routes/wanted-create.post.test.ts
+++ b/tests/unit/exchange/server/routes/wanted-create.post.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMockSupabaseClient } from '../../../../setup/mockSupabase';
-import { _resetRateLimitStore } from '~~/server/utils/exchange/rateLimit';
+import { _resetExchangeRateLimitStore } from '~~/server/utils/exchange/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Mock the auth + service deps the route imports. The route imports them via
@@ -92,7 +92,7 @@ function wireSupabase(opts: {
 }
 
 beforeEach(() => {
-  _resetRateLimitStore();
+  _resetExchangeRateLimitStore();
   vi.clearAllMocks();
 
   // Default: authenticated, non-banned, clean post that inserts successfully.


### PR DESCRIPTION
This batch sits on top of what already landed in `dev` from the earlier consolidation section PRs. It covers the Vercel build/deploy investigation, moving social posting server-side, the exchange browse/onboarding UX, and a faithful port of the TME home page.

## Build / deploy hardening
- Raise Node heap to 8GB for the Vercel build (server-bundle OOM)
- Externalize `sharp` + `@atproto/api` from the Nitro bundle; drop server source maps
- **Note:** the native Vercel build-runner *finalize* stall is infra-side, not code (a `--prebuilt` deploy of identical output goes READY in ~13s). Still the open blocker for native git deploys — see "what's left".

## Social auto-posting → Supabase edge function
- `post-listing-social` edge fn replaces the in-app `@atproto`/`sharp` social path; the web admin retry route is now a thin Bearer proxy. (Edge fn + `*/15` cron live in supabase PR #48, **not yet deployed**.)

## Exchange UX
- **Open browsing:** onboarding only gates *action* routes (new/bulk/post/submit/messages); landing/browse/detail/dashboard are public. Nudge fires on `onboarding_completed !== true` so existing/null profiles get driven into the flow instead of walled out.
- **Real `/exchange` home:** faithful port of TME's `pages/index.vue` — search box, country-flag marquee scroller, stats bar, Featured Listings grid, free/premium CTA, BaT-style recent grid, "Why The Mini Exchange?". New `exchange/AnnouncementBanner` + `exchange/home/{FlagMarquee,FeaturedGrid,PromotedListings}`. Markup verbatim (auto-themes to CMDIY), only icons→FA6, routes→`/exchange/*`, `usePostHog`, + 10-locale i18n.

## Dev DX
- Pre-bundle the exchange/model client deps (`mapbox-gl`, `heic2any`, `browser-image-compression`, `@vueuse/core`, `chart.js`, `vue-chartjs`, `vuedraggable`, `three`, `dompurify`, `client-zip`, schema-org) to stop the per-page re-optimize/reload
- Guard `heic2any`/`browser-image-compression` with `import.meta.client` so they stay out of the server bundle
- Rename exchange `_resetRateLimitStore` → `_resetExchangeRateLimitStore` (Nitro auto-import collision warning)

## Supabase coordination
- Listing-detail RPC fix (`get_seller_stats`, `get_related_listings` schema drift) is **already applied to prod** + tracked in supabase PR #48.
- supabase PR #48 also carries the notification event types, watcher triggers, social cron, and the listing-checkout edge fns — **deploy is staged for cutover** (watcher triggers/social cron deferred so TME prod behavior is untouched while it's still live).

## Verify
- `/exchange` renders correctly on a flagged preview (screenshot in the session); flag-gated off by default so this is invisible in prod until cutover.
