### PR TITLE
fix(exchange): drop module-level rate-limit timer that stalled every Vercel deploy

### DIFF
--- a/server/utils/exchange/rateLimit.ts
+++ b/server/utils/exchange/rateLimit.ts
@@ -19,18 +19,26 @@ const rateLimitStore = new Map<string, RateLimitEntry>();
 // the periodic sweep — a self-inflicted DoS vector. See server/utils/rateLimit.ts.
 const MAX_TRACKED_KEYS = 50_000;
 
-// Cleanup old entries every 5 minutes
-setInterval(
-  () => {
-    const now = Date.now();
-    for (const [key, entry] of rateLimitStore.entries()) {
-      if (entry.resetAt < now) {
-        rateLimitStore.delete(key);
-      }
+// Expired entries are swept lazily on access (throttled below), NOT via a
+// module-level setInterval. This file is bundled into Nitro's core chunk, so a
+// module-level timer also runs inside the prerender process at build time and
+// keeps the Node event loop alive after `nuxi build` finishes — which is
+// exactly what hung every Vercel deploy at "Build complete!" until the 45-min
+// build timeout (2026-06/07 deploy-stall incident). Do not reintroduce a
+// timer here; mirror server/utils/rateLimit.ts (lazy throttled sweep).
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+let lastSweep = 0;
+
+/** Remove expired entries, at most once per SWEEP_INTERVAL_MS. */
+function sweepExpired(now: number): void {
+  if (now - lastSweep < SWEEP_INTERVAL_MS) return;
+  lastSweep = now;
+  for (const [key, entry] of rateLimitStore.entries()) {
+    if (entry.resetAt < now) {
+      rateLimitStore.delete(key);
     }
-  },
-  5 * 60 * 1000
-);
+  }
+}
 
 /** Strictly bound the map before inserting a new key. */
 function makeRoomForNewKey(now: number): void {
@@ -67,6 +75,8 @@ export function checkRateLimit(
   const { maxRequests, windowMs, keyPrefix = 'rl' } = config;
   const key = `${keyPrefix}:${identifier}`;
   const now = Date.now();
+
+  sweepExpired(now);
 
   const entry = rateLimitStore.get(key);
 
@@ -127,6 +137,7 @@ export function createRateLimitMiddleware(config: RateLimitConfig) {
 /** Test/maintenance helper: clear all tracked entries. */
 export function _resetExchangeRateLimitStore(): void {
   rateLimitStore.clear();
+  lastSweep = 0;
 }
 
 /** Test helper: current number of tracked keys. */

--- a/tests/unit/exchange/server/rateLimit.test.ts
+++ b/tests/unit/exchange/server/rateLimit.test.ts
@@ -339,14 +339,14 @@ describe('server/utils/exchange/rateLimit', () => {
     });
   });
 
-  describe('periodic cleanup interval', () => {
-    // The setInterval cleanup callback (lines 25-28 of the source) is registered
-    // at module-load time. The top-level import was evaluated under real timers,
-    // so its interval is not controllable here. Re-import the module *while* fake
-    // timers are installed so the freshly-registered interval can be driven by
-    // vi.advanceTimersByTime, then exercise the sweep over a mix of expired and
-    // still-live entries.
-    it('sweeps expired entries (and spares live ones) when the 5-minute timer fires', async () => {
+  describe('lazy throttled sweep', () => {
+    // Cleanup is a lazy sweep on access (throttled to once per 5 minutes), NOT a
+    // module-level setInterval: a timer here lands in Nitro's core chunk, runs in
+    // the prerender process, and keeps the build alive after "Build complete!" —
+    // the 2026-06/07 Vercel deploy-stall regression. This test pins the lazy
+    // behavior: expired entries are reclaimed by the next checkRateLimit call
+    // once the sweep window has elapsed.
+    it('sweeps expired entries (and spares live ones) on next access after the sweep window', async () => {
       vi.resetModules();
       const mod = await import('~~/server/utils/exchange/rateLimit');
 
@@ -357,13 +357,15 @@ describe('server/utils/exchange/rateLimit', () => {
       expect(mod._rateLimitStoreSize()).toBe(2);
 
       // Advance past the short window (expiring it) and across the 5-minute
-      // cleanup interval so the callback runs.
+      // sweep throttle. Nothing runs in the background — the store is untouched
+      // until the next access.
       vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(mod._rateLimitStoreSize()).toBe(2);
 
-      // Expired entry reclaimed; live entry retained.
-      expect(mod._rateLimitStoreSize()).toBe(1);
-      // The surviving key still holds its window: next hit is the 2nd of 5.
+      // The next call sweeps: expired entry reclaimed, live entry retained and
+      // still holding its window — this hit is the 2nd of 5.
       const res = mod.checkRateLimit('surviving', { maxRequests: 5, windowMs: 10 * 60 * 1000, keyPrefix: 'sweep' });
+      expect(mod._rateLimitStoreSize()).toBe(1);
       expect(res.remaining).toBe(3);
     });
   });


### PR DESCRIPTION
## Root cause of the deploy-stall regression (Phase 1 of the cutover plan)

`server/utils/exchange/rateLimit.ts` registered a **module-level `setInterval`** at import time. Nitro bundles `server/utils` into its core chunk (`nitro.mjs`), which the **prerender process loads during the build** — so the 5-minute timer kept the Node event loop alive after `✨ Build complete!`, `nuxi build` never exited, and Vercel's builder waited until the 45-minute build timeout on every native deploy (git and CLI alike).

Evidence:
- Every stalled deploy's log ends at `✨ Build complete!` with zero lines after — including a fresh CLI deploy today (`dpl_GPn9pS7U44iEKRNE1WaMguXBeziN`).
- Reproduced locally: `vercel build` on `dev` hangs indefinitely after Build complete; the hung node process holds **no sockets** (lsof) — purely timer-held.
- The compiled `setInterval(...,3e5)` sits in `chunks/nitro/nitro.mjs` next to the rate-limit header code.
- `main` deploys fine because its `server/utils/rateLimit.ts` sweeps lazily — no timer.
- `--prebuilt` "worked" because it skips the remote build process entirely.

## Fix

Replace the timer with a lazy sweep on access, throttled to the same 5-minute cadence — mirroring `server/utils/rateLimit.ts`. In serverless the interval was dead weight anyway (instances freeze between requests). Test updated to pin the lazy-sweep behavior instead of the timer (32/32 passing).

Verified: with this change `vercel build` exits code 0 immediately after Build complete.

## Acceptance gate (cutover plan Phase 1)

3 consecutive native git preview deploys READY + 1 clean cached re-deploy, tracked in the cutover session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)