### PR TITLE
feat(exchange): port TME anti-scam messaging controls (TME PR #101)

### DIFF
--- a/app/components/exchange/messages/MessageList.vue
+++ b/app/components/exchange/messages/MessageList.vue
@@ -13,7 +13,7 @@
 
     <!-- Messages -->
     <div v-else ref="messagesContainer" class="space-y-4">
-      <div v-for="message in messages" :key="message.id">
+      <div v-for="message in visibleMessages" :key="message.id">
         <!-- System message (admin injected) -->
         <div v-if="message.is_system_message" class="flex justify-center my-4">
           <div class="alert alert-info max-w-md py-2 px-4">
@@ -34,8 +34,13 @@
               }"
             >
               <!-- Sender name (only for other person's messages) -->
-              <div v-if="!isOwnMessage(message.sender_id)" class="chat-header mb-1">
+              <div v-if="!isOwnMessage(message.sender_id)" class="chat-header mb-1 flex items-center gap-2">
                 <span class="text-sm font-medium">{{ getSenderName(message) }}</span>
+                <!-- New-account signal: helps recipients spot cold outreach from a fresh account -->
+                <span v-if="isNewAccountSender(message)" class="badge badge-warning badge-xs gap-1" :title="t('newAccountTitle')">
+                  <i class="fas fa-wand-magic-sparkles"></i>
+                  {{ t('newAccount') }}
+                </span>
               </div>
 
               <!-- Message content -->
@@ -68,6 +73,18 @@
                   <div class="flex items-center gap-2 text-xs opacity-75">
                     <i class="fas fa-triangle-exclamation"></i>
                     <span>{{ t('flagged') }}</span>
+                  </div>
+                </div>
+
+                <!-- Pending (held) indicator — only shown to the sender of their
+                     own held message. The recipient never sees a pending message. -->
+                <div
+                  v-if="message.moderation_status === 'pending' && isOwnMessage(message.sender_id)"
+                  class="mt-2 pt-2 border-t border-current/20"
+                >
+                  <div class="flex items-center gap-2 text-xs opacity-75">
+                    <i class="fas fa-clock"></i>
+                    <span>{{ t('pendingNotice') }}</span>
                   </div>
                 </div>
               </div>
@@ -122,9 +139,15 @@
     messages: Message[];
     loading?: boolean;
     conversationId: string;
+    /** The other participant's id — used to tag their messages with a "new account" badge. */
+    counterpartyId?: string;
+    /** When true, the counterparty is a recently-created account (cold-outreach signal). */
+    counterpartyIsNew?: boolean;
   }
 
   const props = defineProps<Props>();
+
+  const { isBlocked } = useBlockedUsers();
 
   // Memoize rendered markdown per message id to avoid re-parsing on every
   // re-render (scroll, unread-count updates, etc.).
@@ -160,6 +183,26 @@
   const isOwnMessage = (senderId: string) => {
     return user.value?.id === senderId;
   };
+
+  // Messages actually rendered to the current user.
+  // - A 'pending' (held) message is only visible to its own sender; the
+  //   recipient never sees it. RLS already enforces this server-side, but we
+  //   filter client-side too as defense-in-depth (realtime/cache could surface
+  //   a row that slips past).
+  // - Messages from blocked/muted users are hidden from the current user's view.
+  const visibleMessages = computed(() =>
+    props.messages.filter((message) => {
+      const own = isOwnMessage(message.sender_id);
+      if (message.moderation_status === 'pending' && !own) return false;
+      if (!own && isBlocked(message.sender_id)) return false;
+      return true;
+    })
+  );
+
+  // Tag a counterparty's messages with a "new account" badge so recipients can
+  // spot cold outreach from a freshly-created account.
+  const isNewAccountSender = (message: Message) =>
+    !!props.counterpartyIsNew && !isOwnMessage(message.sender_id) && message.sender_id === props.counterpartyId;
 
   // Get sender display name
   const getSenderName = (message: Message) => {
@@ -197,16 +240,16 @@
 
 <i18n lang="json">
 {
-  "en": { "empty": "No messages yet. Start the conversation!", "flagged": "Message flagged for review", "report": "Report message", "sent": "Sent", "read": "Read", "anonymous": "Anonymous", "unknownUser": "Unknown User" },
-  "es": { "empty": "Aún no hay mensajes. ¡Inicia la conversación!", "flagged": "Mensaje marcado para revisión", "report": "Reportar mensaje", "sent": "Enviado", "read": "Leído", "anonymous": "Anónimo", "unknownUser": "Usuario desconocido" },
-  "fr": { "empty": "Aucun message pour le moment. Lancez la conversation !", "flagged": "Message signalé pour examen", "report": "Signaler le message", "sent": "Envoyé", "read": "Lu", "anonymous": "Anonyme", "unknownUser": "Utilisateur inconnu" },
-  "de": { "empty": "Noch keine Nachrichten. Starte die Unterhaltung!", "flagged": "Nachricht zur Überprüfung gemeldet", "report": "Nachricht melden", "sent": "Gesendet", "read": "Gelesen", "anonymous": "Anonym", "unknownUser": "Unbekannter Benutzer" },
-  "it": { "empty": "Ancora nessun messaggio. Inizia la conversazione!", "flagged": "Messaggio segnalato per revisione", "report": "Segnala messaggio", "sent": "Inviato", "read": "Letto", "anonymous": "Anonimo", "unknownUser": "Utente sconosciuto" },
-  "pt": { "empty": "Ainda não há mensagens. Inicie a conversa!", "flagged": "Mensagem sinalizada para revisão", "report": "Denunciar mensagem", "sent": "Enviado", "read": "Lido", "anonymous": "Anônimo", "unknownUser": "Usuário desconhecido" },
-  "ru": { "empty": "Сообщений пока нет. Начните разговор!", "flagged": "Сообщение отмечено для проверки", "report": "Пожаловаться на сообщение", "sent": "Отправлено", "read": "Прочитано", "anonymous": "Аноним", "unknownUser": "Неизвестный пользователь" },
-  "ja": { "empty": "まだメッセージはありません。会話を始めましょう！", "flagged": "メッセージが確認のため報告されました", "report": "メッセージを報告", "sent": "送信済み", "read": "既読", "anonymous": "匿名", "unknownUser": "不明なユーザー" },
-  "zh": { "empty": "还没有消息。开始对话吧！", "flagged": "消息已被举报待审核", "report": "举报消息", "sent": "已发送", "read": "已读", "anonymous": "匿名", "unknownUser": "未知用户" },
-  "ko": { "empty": "아직 메시지가 없습니다. 대화를 시작하세요!", "flagged": "메시지가 검토를 위해 신고되었습니다", "report": "메시지 신고", "sent": "전송됨", "read": "읽음", "anonymous": "익명", "unknownUser": "알 수 없는 사용자" }
+  "en": {"empty": "No messages yet. Start the conversation!", "flagged": "Message flagged for review", "report": "Report message", "sent": "Sent", "read": "Read", "anonymous": "Anonymous", "unknownUser": "Unknown User", "newAccount": "New account", "newAccountTitle": "This account was created recently. Be cautious with unexpected requests, links, or payment asks.", "pendingNotice": "Pending review — the other person won't see this until it's approved"},
+  "es": {"empty": "Aún no hay mensajes. ¡Inicia la conversación!", "flagged": "Mensaje marcado para revisión", "report": "Reportar mensaje", "sent": "Enviado", "read": "Leído", "anonymous": "Anónimo", "unknownUser": "Usuario desconocido", "newAccount": "Cuenta nueva", "newAccountTitle": "Esta cuenta se creó recientemente. Ten cuidado con solicitudes, enlaces o peticiones de pago inesperadas.", "pendingNotice": "Pendiente de revisión: la otra persona no lo verá hasta que se apruebe"},
+  "fr": {"empty": "Aucun message pour le moment. Lancez la conversation !", "flagged": "Message signalé pour examen", "report": "Signaler le message", "sent": "Envoyé", "read": "Lu", "anonymous": "Anonyme", "unknownUser": "Utilisateur inconnu", "newAccount": "Nouveau compte", "newAccountTitle": "Ce compte a été créé récemment. Méfiez-vous des demandes, liens ou demandes de paiement inattendus.", "pendingNotice": "En attente de vérification — l'autre personne ne le verra pas avant son approbation"},
+  "de": {"empty": "Noch keine Nachrichten. Starte die Unterhaltung!", "flagged": "Nachricht zur Überprüfung gemeldet", "report": "Nachricht melden", "sent": "Gesendet", "read": "Gelesen", "anonymous": "Anonym", "unknownUser": "Unbekannter Benutzer", "newAccount": "Neues Konto", "newAccountTitle": "Dieses Konto wurde kürzlich erstellt. Sei vorsichtig bei unerwarteten Anfragen, Links oder Zahlungsaufforderungen.", "pendingNotice": "Wartet auf Überprüfung — die andere Person sieht dies erst nach der Freigabe"},
+  "it": {"empty": "Ancora nessun messaggio. Inizia la conversazione!", "flagged": "Messaggio segnalato per revisione", "report": "Segnala messaggio", "sent": "Inviato", "read": "Letto", "anonymous": "Anonimo", "unknownUser": "Utente sconosciuto", "newAccount": "Account nuovo", "newAccountTitle": "Questo account è stato creato di recente. Fai attenzione a richieste, link o richieste di pagamento inaspettate.", "pendingNotice": "In attesa di revisione: l'altra persona non lo vedrà finché non sarà approvato"},
+  "pt": {"empty": "Ainda não há mensagens. Inicie a conversa!", "flagged": "Mensagem sinalizada para revisão", "report": "Denunciar mensagem", "sent": "Enviado", "read": "Lido", "anonymous": "Anônimo", "unknownUser": "Usuário desconhecido", "newAccount": "Conta nova", "newAccountTitle": "Esta conta foi criada recentemente. Tenha cuidado com solicitações, links ou pedidos de pagamento inesperados.", "pendingNotice": "Aguardando revisão — a outra pessoa só verá após a aprovação"},
+  "ru": {"empty": "Сообщений пока нет. Начните разговор!", "flagged": "Сообщение отмечено для проверки", "report": "Пожаловаться на сообщение", "sent": "Отправлено", "read": "Прочитано", "anonymous": "Аноним", "unknownUser": "Неизвестный пользователь", "newAccount": "Новый аккаунт", "newAccountTitle": "Этот аккаунт создан недавно. Будьте осторожны с неожиданными просьбами, ссылками или запросами оплаты.", "pendingNotice": "Ожидает проверки — собеседник не увидит это до одобрения"},
+  "ja": {"empty": "まだメッセージはありません。会話を始めましょう！", "flagged": "メッセージが確認のため報告されました", "report": "メッセージを報告", "sent": "送信済み", "read": "既読", "anonymous": "匿名", "unknownUser": "不明なユーザー", "newAccount": "新規アカウント", "newAccountTitle": "このアカウントは最近作成されました。予期しない依頼、リンク、支払い要求にはご注意ください。", "pendingNotice": "審査待ち — 承認されるまで相手には表示されません"},
+  "zh": {"empty": "还没有消息。开始对话吧！", "flagged": "消息已被举报待审核", "report": "举报消息", "sent": "已发送", "read": "已读", "anonymous": "匿名", "unknownUser": "未知用户", "newAccount": "新账户", "newAccountTitle": "该账户是最近创建的。请警惕意外的请求、链接或付款要求。", "pendingNotice": "等待审核——在批准之前对方不会看到此消息"},
+  "ko": {"empty": "아직 메시지가 없습니다. 대화를 시작하세요!", "flagged": "메시지가 검토를 위해 신고되었습니다", "report": "메시지 신고", "sent": "전송됨", "read": "읽음", "anonymous": "익명", "unknownUser": "알 수 없는 사용자", "newAccount": "신규 계정", "newAccountTitle": "이 계정은 최근에 생성되었습니다. 예상치 못한 요청, 링크 또는 결제 요구에 주의하세요.", "pendingNotice": "검토 대기 중 — 승인될 때까지 상대방에게 표시되지 않습니다"}
 }
 </i18n>
 

--- a/app/components/exchange/messages/MessageList.vue
+++ b/app/components/exchange/messages/MessageList.vue
@@ -5,8 +5,9 @@
       <span class="loading loading-spinner loading-lg"></span>
     </div>
 
-    <!-- Empty state -->
-    <div v-else-if="messages.length === 0" class="text-center py-12">
+    <!-- Empty state (based on what's actually visible — blocked/held messages
+         don't count, so an all-hidden thread still explains itself) -->
+    <div v-else-if="visibleMessages.length === 0" class="text-center py-12">
       <i class="fas fa-comments text-6xl mx-auto text-base-content/30 mb-4 block"></i>
       <p class="text-base-content/60">{{ t('empty') }}</p>
     </div>
@@ -223,9 +224,10 @@
     });
   };
 
-  // Watch for new messages and scroll
+  // Watch for new VISIBLE messages and scroll — hidden (blocked/held) rows
+  // changing the raw prop length must not cause a scroll jump.
   watch(
-    () => props.messages.length,
+    () => visibleMessages.value.length,
     () => {
       scrollToBottom();
     },

--- a/app/components/exchange/messages/ReportMessageModal.vue
+++ b/app/components/exchange/messages/ReportMessageModal.vue
@@ -12,6 +12,7 @@
           type="button"
           class="btn btn-xs"
           :class="reason === preset.label ? 'btn-error' : 'btn-outline'"
+          :aria-pressed="reason === preset.label"
           @click="reason = preset.label"
         >
           {{ preset.label }}

--- a/app/components/exchange/messages/ReportMessageModal.vue
+++ b/app/components/exchange/messages/ReportMessageModal.vue
@@ -4,7 +4,21 @@
       <h3 class="font-bold text-lg">{{ t('title') }}</h3>
       <p class="text-base-content/70 mt-2">{{ t('prompt') }}</p>
 
-      <div class="mt-4">
+      <!-- Quick-reason presets — speeds up reporting the common scam patterns -->
+      <div class="flex flex-wrap gap-2 mt-4">
+        <button
+          v-for="preset in reasonPresets"
+          :key="preset.key"
+          type="button"
+          class="btn btn-xs"
+          :class="reason === preset.label ? 'btn-error' : 'btn-outline'"
+          @click="reason = preset.label"
+        >
+          {{ preset.label }}
+        </button>
+      </div>
+
+      <div class="mt-3">
         <textarea
           v-model="reason"
           class="textarea textarea-bordered w-full"
@@ -47,6 +61,15 @@
   const reason = ref('');
   const submitting = ref(false);
 
+  // Localized quick-reason chips. The submitted reason is the localized label —
+  // admins review free text anyway, and presets mostly save the reporter typing.
+  const reasonPresets = computed(() =>
+    (['scam', 'offPlatform', 'spam', 'harassment', 'payment'] as const).map((key) => ({
+      key,
+      label: t(`presets.${key}`),
+    }))
+  );
+
   const open = () => {
     reason.value = '';
     modalEl.value?.showModal();
@@ -77,15 +100,15 @@
 
 <i18n lang="json">
 {
-  "en": { "title": "Report Message", "prompt": "Why are you reporting this message?", "placeholder": "Describe the issue (harassment, spam, scam, etc.)...", "charCount": "{count}/500", "cancel": "Cancel", "submit": "Report Message", "close": "close" },
-  "es": { "title": "Reportar mensaje", "prompt": "¿Por qué reportas este mensaje?", "placeholder": "Describe el problema (acoso, spam, estafa, etc.)...", "charCount": "{count}/500", "cancel": "Cancelar", "submit": "Reportar mensaje", "close": "cerrar" },
-  "fr": { "title": "Signaler le message", "prompt": "Pourquoi signalez-vous ce message ?", "placeholder": "Décrivez le problème (harcèlement, spam, arnaque, etc.)...", "charCount": "{count}/500", "cancel": "Annuler", "submit": "Signaler le message", "close": "fermer" },
-  "de": { "title": "Nachricht melden", "prompt": "Warum meldest du diese Nachricht?", "placeholder": "Beschreibe das Problem (Belästigung, Spam, Betrug usw.)...", "charCount": "{count}/500", "cancel": "Abbrechen", "submit": "Nachricht melden", "close": "schließen" },
-  "it": { "title": "Segnala messaggio", "prompt": "Perché segnali questo messaggio?", "placeholder": "Descrivi il problema (molestie, spam, truffa, ecc.)...", "charCount": "{count}/500", "cancel": "Annulla", "submit": "Segnala messaggio", "close": "chiudi" },
-  "pt": { "title": "Denunciar mensagem", "prompt": "Por que você está denunciando esta mensagem?", "placeholder": "Descreva o problema (assédio, spam, golpe, etc.)...", "charCount": "{count}/500", "cancel": "Cancelar", "submit": "Denunciar mensagem", "close": "fechar" },
-  "ru": { "title": "Пожаловаться на сообщение", "prompt": "Почему вы жалуетесь на это сообщение?", "placeholder": "Опишите проблему (домогательство, спам, мошенничество и т. д.)...", "charCount": "{count}/500", "cancel": "Отмена", "submit": "Пожаловаться", "close": "закрыть" },
-  "ja": { "title": "メッセージを報告", "prompt": "このメッセージを報告する理由は何ですか？", "placeholder": "問題を説明してください（嫌がらせ、スパム、詐欺など）...", "charCount": "{count}/500", "cancel": "キャンセル", "submit": "メッセージを報告", "close": "閉じる" },
-  "zh": { "title": "举报消息", "prompt": "您为什么要举报这条消息？", "placeholder": "描述问题（骚扰、垃圾信息、诈骗等）...", "charCount": "{count}/500", "cancel": "取消", "submit": "举报消息", "close": "关闭" },
-  "ko": { "title": "메시지 신고", "prompt": "이 메시지를 신고하는 이유는 무엇인가요?", "placeholder": "문제를 설명해 주세요 (괴롭힘, 스팸, 사기 등)...", "charCount": "{count}/500", "cancel": "취소", "submit": "메시지 신고", "close": "닫기" }
+  "en": {"title": "Report Message", "prompt": "Why are you reporting this message?", "placeholder": "Describe the issue (harassment, spam, scam, etc.)...", "charCount": "{count}/500", "cancel": "Cancel", "submit": "Report Message", "close": "close", "presets": {"scam": "Scam or phishing", "offPlatform": "Asking to move off-platform", "spam": "Spam", "harassment": "Harassment", "payment": "Suspicious payment request"}},
+  "es": {"title": "Reportar mensaje", "prompt": "¿Por qué reportas este mensaje?", "placeholder": "Describe el problema (acoso, spam, estafa, etc.)...", "charCount": "{count}/500", "cancel": "Cancelar", "submit": "Reportar mensaje", "close": "cerrar", "presets": {"scam": "Estafa o phishing", "offPlatform": "Pide salir de la plataforma", "spam": "Spam", "harassment": "Acoso", "payment": "Solicitud de pago sospechosa"}},
+  "fr": {"title": "Signaler le message", "prompt": "Pourquoi signalez-vous ce message ?", "placeholder": "Décrivez le problème (harcèlement, spam, arnaque, etc.)...", "charCount": "{count}/500", "cancel": "Annuler", "submit": "Signaler le message", "close": "fermer", "presets": {"scam": "Arnaque ou hameçonnage", "offPlatform": "Demande de quitter la plateforme", "spam": "Spam", "harassment": "Harcèlement", "payment": "Demande de paiement suspecte"}},
+  "de": {"title": "Nachricht melden", "prompt": "Warum meldest du diese Nachricht?", "placeholder": "Beschreibe das Problem (Belästigung, Spam, Betrug usw.)...", "charCount": "{count}/500", "cancel": "Abbrechen", "submit": "Nachricht melden", "close": "schließen", "presets": {"scam": "Betrug oder Phishing", "offPlatform": "Will die Plattform verlassen", "spam": "Spam", "harassment": "Belästigung", "payment": "Verdächtige Zahlungsaufforderung"}},
+  "it": {"title": "Segnala messaggio", "prompt": "Perché segnali questo messaggio?", "placeholder": "Descrivi il problema (molestie, spam, truffa, ecc.)...", "charCount": "{count}/500", "cancel": "Annulla", "submit": "Segnala messaggio", "close": "chiudi", "presets": {"scam": "Truffa o phishing", "offPlatform": "Chiede di uscire dalla piattaforma", "spam": "Spam", "harassment": "Molestie", "payment": "Richiesta di pagamento sospetta"}},
+  "pt": {"title": "Denunciar mensagem", "prompt": "Por que você está denunciando esta mensagem?", "placeholder": "Descreva o problema (assédio, spam, golpe, etc.)...", "charCount": "{count}/500", "cancel": "Cancelar", "submit": "Denunciar mensagem", "close": "fechar", "presets": {"scam": "Golpe ou phishing", "offPlatform": "Pede para sair da plataforma", "spam": "Spam", "harassment": "Assédio", "payment": "Pedido de pagamento suspeito"}},
+  "ru": {"title": "Пожаловаться на сообщение", "prompt": "Почему вы жалуетесь на это сообщение?", "placeholder": "Опишите проблему (домогательство, спам, мошенничество и т. д.)...", "charCount": "{count}/500", "cancel": "Отмена", "submit": "Пожаловаться", "close": "закрыть", "presets": {"scam": "Мошенничество или фишинг", "offPlatform": "Просит уйти с платформы", "spam": "Спам", "harassment": "Домогательство", "payment": "Подозрительный запрос оплаты"}},
+  "ja": {"title": "メッセージを報告", "prompt": "このメッセージを報告する理由は何ですか？", "placeholder": "問題を説明してください（嫌がらせ、スパム、詐欺など）...", "charCount": "{count}/500", "cancel": "キャンセル", "submit": "メッセージを報告", "close": "閉じる", "presets": {"scam": "詐欺・フィッシング", "offPlatform": "プラットフォーム外への誘導", "spam": "スパム", "harassment": "嫌がらせ", "payment": "不審な支払い要求"}},
+  "zh": {"title": "举报消息", "prompt": "您为什么要举报这条消息？", "placeholder": "描述问题（骚扰、垃圾信息、诈骗等）...", "charCount": "{count}/500", "cancel": "取消", "submit": "举报消息", "close": "关闭", "presets": {"scam": "诈骗或钓鱼", "offPlatform": "要求转到平台外交易", "spam": "垃圾信息", "harassment": "骚扰", "payment": "可疑的付款请求"}},
+  "ko": {"title": "메시지 신고", "prompt": "이 메시지를 신고하는 이유는 무엇인가요?", "placeholder": "문제를 설명해 주세요 (괴롭힘, 스팸, 사기 등)...", "charCount": "{count}/500", "cancel": "취소", "submit": "메시지 신고", "close": "닫기", "presets": {"scam": "사기 또는 피싱", "offPlatform": "플랫폼 밖 거래 요구", "spam": "스팸", "harassment": "괴롭힘", "payment": "의심스러운 결제 요청"}}
 }
 </i18n>

--- a/app/composables/useBlockedUsers.ts
+++ b/app/composables/useBlockedUsers.ts
@@ -34,7 +34,10 @@ export const useBlockedUsers = () => {
     if (!import.meta.client) return;
     try {
       const raw = localStorage.getItem(storageKey());
-      blockedIds.value = raw ? (JSON.parse(raw) as string[]) : [];
+      const parsed = raw ? JSON.parse(raw) : [];
+      // Corrupted storage (non-array, or non-string members) must not poison
+      // the reactive list — includes()/spread assume string[].
+      blockedIds.value = Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
     } catch {
       blockedIds.value = [];
     }

--- a/app/composables/useBlockedUsers.ts
+++ b/app/composables/useBlockedUsers.ts
@@ -1,0 +1,87 @@
+/**
+ * Blocked Users (client-side mute)
+ *
+ * The shared Supabase backend does not (yet) expose a server-side block table —
+ * the platform's anti-abuse enforcement lives in messaging probation, the
+ * fan-out cap, link-holding, and admin "ban-at-source" driven by message
+ * Reports. This composable provides a complementary, user-controlled *mute*:
+ * a blocked user's messages are hidden from the current user's threads and the
+ * composer is disabled for that conversation.
+ *
+ * Scope and honesty: a client-side mute hides the other person from *your*
+ * view on this device; it does not stop them sending or reach other devices.
+ * To have the platform act on a bad actor, users should also Report the message
+ * (which feeds admin moderation / ban-at-source). The block list is namespaced
+ * per signed-in user so it never leaks between accounts on a shared device.
+ *
+ * If a server-side `blocked_users` table + `block_user()`/`unblock_user()` RPCs
+ * are added later, swap the persistence here for those calls — the public API
+ * (isBlocked / blockUser / unblockUser / blockedIds) is designed to stay stable.
+ */
+
+const STORAGE_PREFIX = 'cmdiy_blocked_users';
+
+export const useBlockedUsers = () => {
+  const { user } = useAuth();
+  const { capture } = usePostHog();
+
+  // Shared reactive state so every component (thread, composer) stays in sync.
+  const blockedIds = useState<string[]>('blocked-users', () => []);
+
+  const storageKey = () => `${STORAGE_PREFIX}:${user.value?.id ?? 'anon'}`;
+
+  const load = () => {
+    if (!import.meta.client) return;
+    try {
+      const raw = localStorage.getItem(storageKey());
+      blockedIds.value = raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+      blockedIds.value = [];
+    }
+  };
+
+  // `blockedIds` is a client-side useState singleton, so without this it would
+  // retain the previous user's list across a logout→login that doesn't trigger a
+  // full page reload (state leakage between accounts on a shared device). Re-load
+  // from the per-user storage key whenever the signed-in user changes so the
+  // shared state always reflects the current account.
+  if (import.meta.client) {
+    watch(() => user.value?.id, load, { immediate: true });
+  }
+
+  const persist = () => {
+    if (!import.meta.client) return;
+    try {
+      localStorage.setItem(storageKey(), JSON.stringify(blockedIds.value));
+    } catch {
+      // Ignore quota / serialization errors — muting is best-effort.
+    }
+  };
+
+  const isBlocked = (userId: string | null | undefined): boolean => {
+    if (!userId) return false;
+    return blockedIds.value.includes(userId);
+  };
+
+  const blockUser = (userId: string) => {
+    if (!userId || isBlocked(userId)) return;
+    blockedIds.value = [...blockedIds.value, userId];
+    persist();
+    capture('user_blocked', { blocked_user_id: userId });
+  };
+
+  const unblockUser = (userId: string) => {
+    if (!isBlocked(userId)) return;
+    blockedIds.value = blockedIds.value.filter((id) => id !== userId);
+    persist();
+    capture('user_unblocked', { blocked_user_id: userId });
+  };
+
+  return {
+    blockedIds: readonly(blockedIds),
+    load,
+    isBlocked,
+    blockUser,
+    unblockUser,
+  };
+};

--- a/app/composables/useMessages.ts
+++ b/app/composables/useMessages.ts
@@ -39,11 +39,13 @@ export interface Conversation {
     id: string;
     display_name: string | null;
     username: string | null;
+    created_at?: string | null;
   };
   seller?: {
     id: string;
     display_name: string | null;
     username: string | null;
+    created_at?: string | null;
   };
   latest_message?: Message;
 }
@@ -130,12 +132,14 @@ export const useMessages = () => {
           buyer:public_profiles!conversations_buyer_id_fkey (
             id,
             display_name,
-            username
+            username,
+            created_at
           ),
           seller:public_profiles!conversations_seller_id_fkey (
             id,
             display_name,
-            username
+            username,
+            created_at
           )
         `
         )
@@ -194,12 +198,14 @@ export const useMessages = () => {
           buyer:public_profiles!conversations_buyer_id_fkey (
             id,
             display_name,
-            username
+            username,
+            created_at
           ),
           seller:public_profiles!conversations_seller_id_fkey (
             id,
             display_name,
-            username
+            username,
+            created_at
           )
         `
         )
@@ -426,10 +432,19 @@ export const useMessages = () => {
           sender_id: user.value.id,
           content: content.trim(),
         })
-        .select('id')
+        .select('id, moderation_status, moderation_issues')
         .single();
 
       if (error) throw error;
+
+      // The shared Supabase backend may "hold" a message from a new/probationary
+      // account when it contains an external link: the row is saved with
+      // moderation_status='pending' (and 'external_url' in moderation_issues),
+      // and RLS hides it from the recipient until an admin approves it. The
+      // sender still sees their own pending message, so this is NOT a failure —
+      // we just let them know it's awaiting review and skip notifying the
+      // recipient (who can't see it yet).
+      const isPending = (inserted as any)?.moderation_status === 'pending';
 
       // Upload and link any attachments. If this fails we keep the text
       // message and surface a toast; orphaned storage objects (if any)
@@ -463,7 +478,20 @@ export const useMessages = () => {
         listing_id: context?.conversation?.listing_id || undefined,
         message_length: content.length,
         is_first_message: (context?.existingMessageCount ?? 0) === 0,
+        moderation_status: isPending ? 'pending' : 'approved',
       });
+
+      if (isPending) {
+        toast.add({
+          title: 'Message Pending Review',
+          description:
+            "Because your account is new, messages containing links are checked before the other person sees them. This lifts as your account ages — your message will appear once it's approved.",
+          color: 'info',
+          duration: 9000,
+        });
+        // Don't notify the recipient about a message they can't see yet.
+        return true;
+      }
 
       // Fire-and-forget: queue notification for the recipient
       // Server derives recipient and sender name from the conversation + auth token
@@ -487,19 +515,71 @@ export const useMessages = () => {
 
       // Track message failure
       capture('message_failed', {
-        error_type: error.message || 'unknown',
+        error_type: error?.code || error?.message || 'unknown',
         conversation_id: conversationId,
       });
 
+      // The shared Supabase backend enforces anti-abuse limits at the DB layer.
+      // A blocked insert surfaces as a Postgres error (SQLSTATE 42501) carrying
+      // a specific message. Translate the known cases into friendly copy
+      // instead of a generic failure.
+      const { title, description } = friendlySendError(error);
       toast.add({
-        title: 'Error',
-        description: 'Failed to send message',
+        title,
+        description,
         color: 'error',
+        duration: 9000,
       });
       return false;
     } finally {
       sending.value = false;
     }
+  };
+
+  /**
+   * Translate a failed message insert into user-friendly copy.
+   *
+   * The shared Supabase backend (classicminidiy-supabase messaging probation)
+   * rejects sends at the DB layer with SQLSTATE 42501 and a recognizable
+   * message for two cases:
+   *   - Banned sender: "Account is banned from sending messages"
+   *   - Fan-out cap:   "New accounts are limited to N new conversations per 24 hours…"
+   * Anything else falls back to a generic-but-clear message.
+   */
+  const friendlySendError = (error: any): { title: string; description: string } => {
+    const message: string = error?.message || '';
+    const lower = message.toLowerCase();
+
+    if (lower.includes('banned')) {
+      return {
+        title: 'Account Restricted',
+        description:
+          "Your account can't send messages right now. If you believe this is a mistake, please contact support.",
+      };
+    }
+
+    if (lower.includes('new accounts are limited') || lower.includes('conversations per') || lower.includes('24 hours')) {
+      return {
+        title: 'New-Account Message Limit',
+        description:
+          // Surface the server's own message when present — it states the exact cap.
+          message ||
+          'New accounts can only start a few new conversations per day. This lifts as your account ages, or after 24 hours.',
+      };
+    }
+
+    if (error?.code === '42501') {
+      return {
+        title: "Message Couldn't Be Sent",
+        description:
+          "You don't have permission to send this message, or a sending limit applies. New accounts have lighter limits that lift as the account ages.",
+      };
+    }
+
+    return {
+      title: 'Error',
+      description: 'Failed to send message. Please try again.',
+    };
   };
 
   /**
@@ -558,18 +638,22 @@ export const useMessages = () => {
   /**
    * Get display name for other participant in conversation
    */
-  const getOtherParticipant = (conversation: Conversation): { name: string; id: string } | null => {
+  const getOtherParticipant = (
+    conversation: Conversation
+  ): { name: string; id: string; created_at?: string | null } | null => {
     if (!user.value) return null;
 
     if (conversation.buyer_id === user.value.id && conversation.seller) {
       return {
         name: conversation.seller.display_name || conversation.seller.username || 'Anonymous',
         id: conversation.seller.id,
+        created_at: conversation.seller.created_at ?? null,
       };
     } else if (conversation.seller_id === user.value.id && conversation.buyer) {
       return {
         name: conversation.buyer.display_name || conversation.buyer.username || 'Anonymous',
         id: conversation.buyer.id,
+        created_at: conversation.buyer.created_at ?? null,
       };
     }
 

--- a/app/pages/exchange/messages/[conversationId].vue
+++ b/app/pages/exchange/messages/[conversationId].vue
@@ -43,7 +43,7 @@
               </NuxtLink>
 
               <!-- Listing details -->
-              <div class="flex-1">
+              <div class="flex-1 min-w-0">
                 <NuxtLink
                   :to="`/exchange/listings/${conversation.listing.slug}`"
                   class="link link-hover text-lg font-semibold mb-1 block"
@@ -51,12 +51,33 @@
                   {{ conversation.listing.title }}
                 </NuxtLink>
 
-                <div class="flex items-center gap-4 text-sm">
+                <div class="flex items-center flex-wrap gap-x-4 gap-y-1 text-sm">
                   <span class="font-bold text-primary text-lg">
                     ${{ conversation.listing.price?.toLocaleString() }}
                   </span>
                   <span class="text-base-content/60">{{ t('chattingWith', { name: otherParticipantName }) }}</span>
+                  <span v-if="counterpartyIsNew" class="badge badge-warning badge-sm gap-1" :title="t('newAccountTitle')">
+                    <i class="fas fa-wand-magic-sparkles"></i>
+                    {{ t('newAccount') }}
+                  </span>
                 </div>
+              </div>
+
+              <!-- Per-user controls -->
+              <div v-if="otherParticipantId" class="flex-shrink-0">
+                <button
+                  v-if="!isCounterpartyBlocked"
+                  class="btn btn-ghost btn-sm text-base-content/60"
+                  :title="t('blockTitle')"
+                  @click="handleBlock"
+                >
+                  <i class="fas fa-ban"></i>
+                  {{ t('block') }}
+                </button>
+                <button v-else class="btn btn-ghost btn-sm text-error" :title="t('unblockTitle')" @click="handleUnblock">
+                  <i class="fas fa-ban"></i>
+                  {{ t('unblock') }}
+                </button>
               </div>
             </div>
 
@@ -105,11 +126,28 @@
                   {{ t('loadOlder') }}
                 </button>
               </div>
-              <ExchangeMessagesMessageList :messages="messages" :loading="messagesLoading" :conversation-id="conversationId" />
+              <ExchangeMessagesMessageList
+                :messages="messages"
+                :loading="messagesLoading"
+                :conversation-id="conversationId"
+                :counterparty-id="otherParticipantId"
+                :counterparty-is-new="counterpartyIsNew"
+              />
+            </div>
+
+            <!-- Blocked notice (replaces the composer) -->
+            <div v-if="isCounterpartyBlocked" class="alert alert-warning">
+              <i class="fas fa-ban text-xl"></i>
+              <div class="text-sm">
+                <p class="font-medium">{{ t('blockedNotice.title', { name: otherParticipantName }) }}</p>
+                <p class="opacity-80">{{ t('blockedNotice.body') }}</p>
+              </div>
+              <button class="btn btn-sm btn-ghost" @click="handleUnblock">{{ t('unblock') }}</button>
             </div>
 
             <!-- Message Composer -->
             <ExchangeMessagesMessageComposer
+              v-else
               :conversation-id="conversationId"
               :listing-id="conversation.listing?.id"
               :message-count="messages.length"
@@ -147,6 +185,12 @@
   const { getPhotoUrl } = useListings();
   const { capture } = usePostHog();
   const { user } = useAuth();
+  const toast = useToast();
+  const { isBlocked, blockUser, unblockUser, load: loadBlockedUsers } = useBlockedUsers();
+
+  // Accounts younger than this are surfaced as "new" so recipients can spot
+  // cold outreach from a freshly-created account.
+  const NEW_ACCOUNT_AGE_DAYS = 7;
 
   const conversation = ref<any>(null);
   const messages = ref<any[]>([]);
@@ -155,11 +199,46 @@
   const loadingOlder = ref(false);
   const initialLoadComplete = ref(false);
 
-  const otherParticipantName = computed(() => {
-    if (!conversation.value) return '';
-    const participant = getOtherParticipant(conversation.value);
-    return participant?.name || t('unknownUser');
+  const otherParticipant = computed(() => {
+    if (!conversation.value) return null;
+    return getOtherParticipant(conversation.value);
   });
+
+  const otherParticipantName = computed(() => otherParticipant.value?.name || t('unknownUser'));
+  const otherParticipantId = computed(() => otherParticipant.value?.id);
+
+  // Age-based "new account" signal (cold-outreach hint). Derived from the
+  // public profile's created_at — no extra round-trip.
+  const counterpartyIsNew = computed(() => {
+    const createdAt = otherParticipant.value?.created_at;
+    if (!createdAt) return false;
+    const ageMs = Date.now() - new Date(createdAt).getTime();
+    return ageMs >= 0 && ageMs < NEW_ACCOUNT_AGE_DAYS * 24 * 60 * 60 * 1000;
+  });
+
+  const isCounterpartyBlocked = computed(() => isBlocked(otherParticipantId.value));
+
+  const handleBlock = () => {
+    const id = otherParticipantId.value;
+    if (!id) return;
+    blockUser(id);
+    toast.add({
+      title: t('blockToast.title'),
+      description: t('blockToast.description', { name: otherParticipantName.value }),
+      color: 'success',
+    });
+  };
+
+  const handleUnblock = () => {
+    const id = otherParticipantId.value;
+    if (!id) return;
+    unblockUser(id);
+    toast.add({
+      title: t('unblockToast.title'),
+      description: t('unblockToast.description', { name: otherParticipantName.value }),
+      color: 'info',
+    });
+  };
 
   const listingImage = computed(() => {
     const photos = conversation.value?.listing?.listing_photos;
@@ -225,6 +304,7 @@
 
   // Load on mount
   onMounted(async () => {
+    loadBlockedUsers();
     await loadConversation();
   });
 
@@ -271,104 +351,304 @@
 <i18n lang="json">
 {
   "en": {
-    "seo": { "title": "Conversation - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "Conversation - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "Back to Messages",
     "notFound": "Conversation not found",
     "chattingWith": "Chatting with {name}",
     "conversation": "Conversation",
     "loadOlder": "Load Older Messages",
     "unknownUser": "Unknown User",
-    "noListing": "No associated listing"
+    "noListing": "No associated listing",
+    "newAccount": "New account",
+    "newAccountTitle": "This account was created recently. Be cautious with unexpected requests, off-platform links, or payment asks.",
+    "block": "Block",
+    "blockTitle": "Block this person — you won't see their messages here",
+    "unblock": "Unblock",
+    "unblockTitle": "Unblock this person",
+    "blockedNotice": {
+      "title": "You've blocked {name}.",
+      "body": "Their messages are hidden and you can't reply. If they're breaking the rules, please report a message so our team can act. You can unblock them at any time."
+    },
+    "blockToast": {
+      "title": "Blocked",
+      "description": "You won't see messages from {name}. Report a message if they're breaking the rules."
+    },
+    "unblockToast": {
+      "title": "Unblocked",
+      "description": "You'll see messages from {name} again."
+    }
   },
   "es": {
-    "seo": { "title": "Conversación - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "Conversación - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "Volver a Mensajes",
     "notFound": "Conversación no encontrada",
     "chattingWith": "Chateando con {name}",
     "conversation": "Conversación",
     "loadOlder": "Cargar mensajes anteriores",
     "unknownUser": "Usuario desconocido",
-    "noListing": "Sin anuncio asociado"
+    "noListing": "Sin anuncio asociado",
+    "newAccount": "Cuenta nueva",
+    "newAccountTitle": "Esta cuenta se creó recientemente. Ten cuidado con solicitudes inesperadas, enlaces externos o peticiones de pago.",
+    "block": "Bloquear",
+    "blockTitle": "Bloquear a esta persona: no verás sus mensajes aquí",
+    "unblock": "Desbloquear",
+    "unblockTitle": "Desbloquear a esta persona",
+    "blockedNotice": {
+      "title": "Has bloqueado a {name}.",
+      "body": "Sus mensajes están ocultos y no puedes responder. Si incumple las normas, reporta un mensaje para que nuestro equipo actúe. Puedes desbloquear en cualquier momento."
+    },
+    "blockToast": {
+      "title": "Bloqueado",
+      "description": "No verás mensajes de {name}. Reporta un mensaje si incumple las normas."
+    },
+    "unblockToast": {
+      "title": "Desbloqueado",
+      "description": "Volverás a ver los mensajes de {name}."
+    }
   },
   "fr": {
-    "seo": { "title": "Conversation - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "Conversation - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "Retour aux messages",
     "notFound": "Conversation introuvable",
     "chattingWith": "Discussion avec {name}",
     "conversation": "Conversation",
     "loadOlder": "Charger les messages plus anciens",
     "unknownUser": "Utilisateur inconnu",
-    "noListing": "Aucune annonce associée"
+    "noListing": "Aucune annonce associée",
+    "newAccount": "Nouveau compte",
+    "newAccountTitle": "Ce compte a été créé récemment. Méfiez-vous des demandes inattendues, des liens externes ou des demandes de paiement.",
+    "block": "Bloquer",
+    "blockTitle": "Bloquer cette personne — vous ne verrez plus ses messages ici",
+    "unblock": "Débloquer",
+    "unblockTitle": "Débloquer cette personne",
+    "blockedNotice": {
+      "title": "Vous avez bloqué {name}.",
+      "body": "Ses messages sont masqués et vous ne pouvez pas répondre. En cas d'infraction aux règles, signalez un message pour que notre équipe agisse. Vous pouvez débloquer à tout moment."
+    },
+    "blockToast": {
+      "title": "Bloqué",
+      "description": "Vous ne verrez plus les messages de {name}. Signalez un message en cas d'infraction."
+    },
+    "unblockToast": {
+      "title": "Débloqué",
+      "description": "Vous verrez à nouveau les messages de {name}."
+    }
   },
   "de": {
-    "seo": { "title": "Konversation - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "Konversation - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "Zurück zu Nachrichten",
     "notFound": "Konversation nicht gefunden",
     "chattingWith": "Chat mit {name}",
     "conversation": "Konversation",
     "loadOlder": "Ältere Nachrichten laden",
     "unknownUser": "Unbekannter Benutzer",
-    "noListing": "Kein zugehöriges Angebot"
+    "noListing": "Kein zugehöriges Angebot",
+    "newAccount": "Neues Konto",
+    "newAccountTitle": "Dieses Konto wurde kürzlich erstellt. Sei vorsichtig bei unerwarteten Anfragen, externen Links oder Zahlungsaufforderungen.",
+    "block": "Blockieren",
+    "blockTitle": "Diese Person blockieren — ihre Nachrichten werden hier ausgeblendet",
+    "unblock": "Entblocken",
+    "unblockTitle": "Diese Person entblocken",
+    "blockedNotice": {
+      "title": "Du hast {name} blockiert.",
+      "body": "Die Nachrichten sind ausgeblendet und du kannst nicht antworten. Bei Regelverstößen melde bitte eine Nachricht, damit unser Team handeln kann. Du kannst jederzeit entblocken."
+    },
+    "blockToast": {
+      "title": "Blockiert",
+      "description": "Du siehst keine Nachrichten von {name} mehr. Melde eine Nachricht bei Regelverstößen."
+    },
+    "unblockToast": {
+      "title": "Entblockt",
+      "description": "Du siehst Nachrichten von {name} wieder."
+    }
   },
   "it": {
-    "seo": { "title": "Conversazione - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "Conversazione - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "Torna ai messaggi",
     "notFound": "Conversazione non trovata",
     "chattingWith": "Stai chattando con {name}",
     "conversation": "Conversazione",
     "loadOlder": "Carica messaggi precedenti",
     "unknownUser": "Utente sconosciuto",
-    "noListing": "Nessun annuncio associato"
+    "noListing": "Nessun annuncio associato",
+    "newAccount": "Account nuovo",
+    "newAccountTitle": "Questo account è stato creato di recente. Fai attenzione a richieste inaspettate, link esterni o richieste di pagamento.",
+    "block": "Blocca",
+    "blockTitle": "Blocca questa persona: non vedrai i suoi messaggi qui",
+    "unblock": "Sblocca",
+    "unblockTitle": "Sblocca questa persona",
+    "blockedNotice": {
+      "title": "Hai bloccato {name}.",
+      "body": "I suoi messaggi sono nascosti e non puoi rispondere. Se viola le regole, segnala un messaggio così il nostro team può intervenire. Puoi sbloccare in qualsiasi momento."
+    },
+    "blockToast": {
+      "title": "Bloccato",
+      "description": "Non vedrai i messaggi di {name}. Segnala un messaggio se viola le regole."
+    },
+    "unblockToast": {
+      "title": "Sbloccato",
+      "description": "Vedrai di nuovo i messaggi di {name}."
+    }
   },
   "pt": {
-    "seo": { "title": "Conversa - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "Conversa - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "Voltar às mensagens",
     "notFound": "Conversa não encontrada",
     "chattingWith": "A conversar com {name}",
     "conversation": "Conversa",
     "loadOlder": "Carregar mensagens anteriores",
     "unknownUser": "Utilizador desconhecido",
-    "noListing": "Sem anúncio associado"
+    "noListing": "Sem anúncio associado",
+    "newAccount": "Conta nova",
+    "newAccountTitle": "Esta conta foi criada recentemente. Tenha cuidado com pedidos inesperados, links externos ou pedidos de pagamento.",
+    "block": "Bloquear",
+    "blockTitle": "Bloquear esta pessoa — você não verá as mensagens dela aqui",
+    "unblock": "Desbloquear",
+    "unblockTitle": "Desbloquear esta pessoa",
+    "blockedNotice": {
+      "title": "Você bloqueou {name}.",
+      "body": "As mensagens estão ocultas e você não pode responder. Se a pessoa violar as regras, denuncie uma mensagem para que nossa equipe possa agir. Você pode desbloquear a qualquer momento."
+    },
+    "blockToast": {
+      "title": "Bloqueado",
+      "description": "Você não verá mensagens de {name}. Denuncie uma mensagem se violar as regras."
+    },
+    "unblockToast": {
+      "title": "Desbloqueado",
+      "description": "Você verá as mensagens de {name} novamente."
+    }
   },
   "ru": {
-    "seo": { "title": "Переписка - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "Переписка - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "Назад к сообщениям",
     "notFound": "Переписка не найдена",
     "chattingWith": "Переписка с {name}",
     "conversation": "Переписка",
     "loadOlder": "Загрузить более старые сообщения",
     "unknownUser": "Неизвестный пользователь",
-    "noListing": "Нет связанного объявления"
+    "noListing": "Нет связанного объявления",
+    "newAccount": "Новый аккаунт",
+    "newAccountTitle": "Этот аккаунт создан недавно. Будьте осторожны с неожиданными просьбами, внешними ссылками или запросами оплаты.",
+    "block": "Заблокировать",
+    "blockTitle": "Заблокировать этого пользователя — его сообщения здесь не будут видны",
+    "unblock": "Разблокировать",
+    "unblockTitle": "Разблокировать этого пользователя",
+    "blockedNotice": {
+      "title": "Вы заблокировали {name}.",
+      "body": "Сообщения скрыты, и вы не можете отвечать. Если пользователь нарушает правила, пожалуйтесь на сообщение, чтобы наша команда приняла меры. Разблокировать можно в любой момент."
+    },
+    "blockToast": {
+      "title": "Заблокировано",
+      "description": "Вы не будете видеть сообщения от {name}. Пожалуйтесь на сообщение при нарушении правил."
+    },
+    "unblockToast": {
+      "title": "Разблокировано",
+      "description": "Вы снова будете видеть сообщения от {name}."
+    }
   },
   "ja": {
-    "seo": { "title": "会話 - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "会話 - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "メッセージに戻る",
     "notFound": "会話が見つかりません",
     "chattingWith": "{name} とチャット中",
     "conversation": "会話",
     "loadOlder": "過去のメッセージを読み込む",
     "unknownUser": "不明なユーザー",
-    "noListing": "関連する出品はありません"
+    "noListing": "関連する出品はありません",
+    "newAccount": "新規アカウント",
+    "newAccountTitle": "このアカウントは最近作成されました。予期しない依頼、外部リンク、支払い要求にはご注意ください。",
+    "block": "ブロック",
+    "blockTitle": "この人をブロック — ここにメッセージが表示されなくなります",
+    "unblock": "ブロック解除",
+    "unblockTitle": "この人のブロックを解除",
+    "blockedNotice": {
+      "title": "{name} さんをブロックしています。",
+      "body": "メッセージは非表示になり、返信できません。ルール違反がある場合はメッセージを報告してください。ブロックはいつでも解除できます。"
+    },
+    "blockToast": {
+      "title": "ブロックしました",
+      "description": "{name} さんからのメッセージは表示されません。ルール違反があれば報告してください。"
+    },
+    "unblockToast": {
+      "title": "ブロック解除しました",
+      "description": "{name} さんからのメッセージが再び表示されます。"
+    }
   },
   "zh": {
-    "seo": { "title": "会话 - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "会话 - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "返回消息",
     "notFound": "未找到会话",
     "chattingWith": "正在与 {name} 聊天",
     "conversation": "会话",
     "loadOlder": "加载更早的消息",
     "unknownUser": "未知用户",
-    "noListing": "无关联商品"
+    "noListing": "无关联商品",
+    "newAccount": "新账户",
+    "newAccountTitle": "该账户是最近创建的。请警惕意外的请求、站外链接或付款要求。",
+    "block": "屏蔽",
+    "blockTitle": "屏蔽此人——你将不会在这里看到其消息",
+    "unblock": "取消屏蔽",
+    "unblockTitle": "取消屏蔽此人",
+    "blockedNotice": {
+      "title": "你已屏蔽 {name}。",
+      "body": "其消息已隐藏，你无法回复。如果对方违反规则，请举报消息以便我们的团队处理。你可以随时取消屏蔽。"
+    },
+    "blockToast": {
+      "title": "已屏蔽",
+      "description": "你将不会看到 {name} 的消息。如对方违规请举报消息。"
+    },
+    "unblockToast": {
+      "title": "已取消屏蔽",
+      "description": "你将再次看到 {name} 的消息。"
+    }
   },
   "ko": {
-    "seo": { "title": "대화 - The Mini Exchange | Classic Mini DIY" },
+    "seo": {
+      "title": "대화 - The Mini Exchange | Classic Mini DIY"
+    },
     "back": "메시지로 돌아가기",
     "notFound": "대화를 찾을 수 없습니다",
     "chattingWith": "{name} 님과 대화 중",
     "conversation": "대화",
     "loadOlder": "이전 메시지 불러오기",
     "unknownUser": "알 수 없는 사용자",
-    "noListing": "연결된 매물 없음"
+    "noListing": "연결된 매물 없음",
+    "newAccount": "신규 계정",
+    "newAccountTitle": "이 계정은 최근에 생성되었습니다. 예상치 못한 요청, 외부 링크 또는 결제 요구에 주의하세요.",
+    "block": "차단",
+    "blockTitle": "이 사용자를 차단 — 여기에서 메시지가 보이지 않게 됩니다",
+    "unblock": "차단 해제",
+    "unblockTitle": "이 사용자 차단 해제",
+    "blockedNotice": {
+      "title": "{name} 님을 차단했습니다.",
+      "body": "메시지가 숨겨지고 답장할 수 없습니다. 규칙을 위반한다면 메시지를 신고해 주세요. 언제든지 차단을 해제할 수 있습니다."
+    },
+    "blockToast": {
+      "title": "차단됨",
+      "description": "{name} 님의 메시지가 보이지 않습니다. 규칙 위반 시 메시지를 신고하세요."
+    },
+    "unblockToast": {
+      "title": "차단 해제됨",
+      "description": "{name} 님의 메시지를 다시 볼 수 있습니다."
+    }
   }
 }
 </i18n>

--- a/tests/unit/exchange/composables/useBlockedUsers.test.ts
+++ b/tests/unit/exchange/composables/useBlockedUsers.test.ts
@@ -86,6 +86,24 @@ describe('useBlockedUsers', () => {
     expect(localStorage.setItem).toHaveBeenCalledWith('cmdiy_blocked_users:me-123', JSON.stringify(['scammer-1']));
   });
 
+  it('tolerates corrupted localStorage payloads (non-array / non-string members)', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { load, isBlocked, blockedIds } = useBlockedUsers();
+
+    (localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue('"not-an-array"');
+    load();
+    expect(blockedIds.value).toEqual([]);
+
+    (localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue('[1, "real-id", null]');
+    load();
+    expect(blockedIds.value).toEqual(['real-id']);
+    expect(isBlocked('real-id')).toBe(true);
+
+    (localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue('{{{not json');
+    load();
+    expect(blockedIds.value).toEqual([]);
+  });
+
   it('reloads per-user state when the signed-in user changes (no leakage)', async () => {
     const useBlockedUsers = await getUseBlockedUsers();
     const { isBlocked, blockUser } = useBlockedUsers();

--- a/tests/unit/exchange/composables/useBlockedUsers.test.ts
+++ b/tests/unit/exchange/composables/useBlockedUsers.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ref, nextTick } from 'vue';
+import { cleanupGlobalMocks } from '../../../setup/testHelpers';
+
+// useBlockedUsers depends on:
+//  - useAuth        (stubbed — user drives the per-user storage key)
+//  - usePostHog     (stubbed for capture spying)
+//  - useState       (global stub from vitest.setup; reset via __resetNuxtState)
+//  - localStorage   (happy-dom)
+
+const mockUser = ref<{ id: string } | null>({ id: 'me-123' });
+const mockCapture = vi.fn();
+
+const getUseBlockedUsers = async () => {
+  vi.resetModules();
+  vi.stubGlobal('useAuth', () => ({ user: mockUser }));
+  vi.stubGlobal('usePostHog', () => ({ capture: mockCapture, identify: vi.fn(), reset: vi.fn() }));
+  const module = await import('~/app/composables/useBlockedUsers');
+  return module.useBlockedUsers;
+};
+
+describe('useBlockedUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).__resetNuxtState?.();
+    localStorage.clear();
+    mockUser.value = { id: 'me-123' };
+  });
+
+  afterEach(() => {
+    cleanupGlobalMocks();
+  });
+
+  it('reports a user as not blocked by default', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { isBlocked } = useBlockedUsers();
+    expect(isBlocked('someone')).toBe(false);
+  });
+
+  it('blocks and unblocks a user', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { isBlocked, blockUser, unblockUser } = useBlockedUsers();
+
+    blockUser('scammer-1');
+    expect(isBlocked('scammer-1')).toBe(true);
+
+    unblockUser('scammer-1');
+    expect(isBlocked('scammer-1')).toBe(false);
+  });
+
+  it('treats a null/undefined id as not blocked', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { isBlocked } = useBlockedUsers();
+    expect(isBlocked(null)).toBe(false);
+    expect(isBlocked(undefined)).toBe(false);
+  });
+
+  it('does not add the same user twice', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { blockUser, blockedIds } = useBlockedUsers();
+
+    blockUser('dup');
+    blockUser('dup');
+
+    expect(blockedIds.value.filter((id) => id === 'dup')).toHaveLength(1);
+  });
+
+  it('captures block/unblock analytics events', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { blockUser, unblockUser } = useBlockedUsers();
+
+    blockUser('scammer-1');
+    expect(mockCapture).toHaveBeenCalledWith('user_blocked', { blocked_user_id: 'scammer-1' });
+
+    unblockUser('scammer-1');
+    expect(mockCapture).toHaveBeenCalledWith('user_unblocked', { blocked_user_id: 'scammer-1' });
+  });
+
+  it('persists the block list under a per-user storage key', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { blockUser } = useBlockedUsers();
+
+    blockUser('scammer-1');
+
+    // vitest.setup's localStorage is a bare mock — assert the write itself.
+    expect(localStorage.setItem).toHaveBeenCalledWith('cmdiy_blocked_users:me-123', JSON.stringify(['scammer-1']));
+  });
+
+  it('reloads per-user state when the signed-in user changes (no leakage)', async () => {
+    const useBlockedUsers = await getUseBlockedUsers();
+    const { isBlocked, blockUser } = useBlockedUsers();
+
+    // User A blocks someone within the same client session.
+    blockUser('scammer-1');
+    expect(isBlocked('scammer-1')).toBe(true);
+
+    // A different user signs in without a full page reload. The shared
+    // useState singleton must not carry A's block list into B's session —
+    // the user-id watcher re-loads from B's (empty) per-user storage key.
+    mockUser.value = { id: 'other-456' };
+    await nextTick();
+
+    expect(isBlocked('scammer-1')).toBe(false);
+  });
+});

--- a/tests/unit/exchange/composables/useMessages.test.ts
+++ b/tests/unit/exchange/composables/useMessages.test.ts
@@ -518,6 +518,61 @@ describe('useMessages', () => {
       );
     });
 
+    it('treats a held (pending) message as success, notifies the sender, and skips the recipient notification', async () => {
+      mockSupabase._mockSingle.mockResolvedValue({
+        data: { id: 'msg-1', moderation_status: 'pending', moderation_issues: ['external_url'] },
+        error: null,
+      });
+
+      const useMessages = await importComposable();
+      const { sendMessage } = useMessages();
+      const result = await sendMessage('conv-1', 'Check out https://example.com/parts');
+
+      expect(result).toBe(true);
+      expect(mockToast.add).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Message Pending Review', color: 'info' })
+      );
+      expect(mockCapture).toHaveBeenCalledWith(
+        'message_sent',
+        expect.objectContaining({ moderation_status: 'pending' })
+      );
+      // Recipient can't see a pending message, so we must not queue a notification email.
+      expect($fetch).not.toHaveBeenCalled();
+    });
+
+    it('shows friendly copy when the account is banned from sending', async () => {
+      mockSupabase._mockSingle.mockResolvedValue({
+        data: null,
+        error: { code: '42501', message: 'Account is banned from sending messages' },
+      });
+
+      const useMessages = await importComposable();
+      const { sendMessage } = useMessages();
+      const result = await sendMessage('conv-1', 'Hello there');
+
+      expect(result).toBe(false);
+      expect(mockToast.add).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Account Restricted', color: 'error' })
+      );
+    });
+
+    it('surfaces the fan-out cap message for new accounts', async () => {
+      const capMessage = 'New accounts are limited to 5 new conversations per 24 hours';
+      mockSupabase._mockSingle.mockResolvedValue({
+        data: null,
+        error: { code: '42501', message: capMessage },
+      });
+
+      const useMessages = await importComposable();
+      const { sendMessage } = useMessages();
+      const result = await sendMessage('conv-1', 'Hi, is this still available?');
+
+      expect(result).toBe(false);
+      expect(mockToast.add).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'New-Account Message Limit', description: capMessage, color: 'error' })
+      );
+    });
+
     it('skips the notification fetch when there is no access token', async () => {
       okInsert();
       mockSupabase.auth.getSession = vi.fn().mockResolvedValue({ data: { session: null }, error: null });
@@ -780,7 +835,7 @@ describe('useMessages', () => {
         seller: { id: 'seller-1', display_name: 'John Seller', username: 'jseller' },
       } as any);
 
-      expect(result).toEqual({ name: 'John Seller', id: 'seller-1' });
+      expect(result).toEqual({ name: 'John Seller', id: 'seller-1', created_at: null });
     });
 
     it('returns the buyer when the current user is the seller', async () => {
@@ -793,7 +848,7 @@ describe('useMessages', () => {
         buyer: { id: 'buyer-1', display_name: 'Jane Buyer', username: 'jbuyer' },
       } as any);
 
-      expect(result).toEqual({ name: 'Jane Buyer', id: 'buyer-1' });
+      expect(result).toEqual({ name: 'Jane Buyer', id: 'buyer-1', created_at: null });
     });
 
     it('falls back to username when display_name is missing', async () => {
@@ -806,7 +861,7 @@ describe('useMessages', () => {
         buyer: { id: 'buyer-1', display_name: null, username: 'mini_fan_99' },
       } as any);
 
-      expect(result).toEqual({ name: 'mini_fan_99', id: 'buyer-1' });
+      expect(result).toEqual({ name: 'mini_fan_99', id: 'buyer-1', created_at: null });
     });
 
     it('falls back to "Anonymous" and never leaks an email', async () => {
@@ -819,7 +874,7 @@ describe('useMessages', () => {
         buyer: { id: 'buyer-1', display_name: null, username: null, email: 'private@example.com' },
       } as any);
 
-      expect(result).toEqual({ name: 'Anonymous', id: 'buyer-1' });
+      expect(result).toEqual({ name: 'Anonymous', id: 'buyer-1', created_at: null });
       expect(result?.name).not.toContain('@');
       expect(result?.name).not.toContain('private');
     });


### PR DESCRIPTION
Phase 2.2 of the cutover plan — the only post-snapshot TME production drift found in the Phase 0 audit (TME PR #101, merged 2026-06-27). The backend half (messaging_probation_and_ban migration, 20260626000001) is already live in the shared database; this makes the CMDIY exchange surfaces honor it.

- **useBlockedUsers** (new): client-side per-user mute — localStorage namespaced per signed-in user with logout/login leakage protection, block/unblock analytics events.
- **MessageList**: hides counterparty `pending` (held) messages (defense-in-depth alongside RLS) and blocked users' messages; "Pending review" indicator on own held messages; "New account" badge on fresh-account counterparties.
- **Conversation page**: new-account badge (<7-day-old profile via public_profiles.created_at — no extra round-trip), Block/Unblock controls, blocked notice replacing the composer.
- **useMessages**: held message = success + sender toast, recipient notification skipped (they can't see it); DB-layer 42501 rejections (ban / new-account fan-out cap) translated to friendly copy; counterparty created_at exposed.
- **ReportMessageModal**: quick-reason presets for common scam patterns.

Adaptations from the TME original: FA6 icons per the exchange icon map (no heroicons), per-SFC `<i18n>` blocks with all 10 locales for every new string, `usePostHog`/`cmdiy_` storage prefix. Component tests intentionally not ported (repo tests business logic per the consolidation decision); composable coverage added instead.

Tests: 4,634 passing (baseline 4,624 + 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)