### PR TITLE
fix(vercel): leave the build container memory headroom — 8GB heap → 6GB

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "bun install --frozen-lockfile",
-  "buildCommand": "NODE_OPTIONS=--max-old-space-size=8192 bun run build",
+  "buildCommand": "NODE_OPTIONS=--max-old-space-size=6144 bun run build",
   "rewrites": [
     {
       "source": "/t/static/:path*",


### PR DESCRIPTION
Follow-on to the deploy-stall fix (#650). With the stall gone, today's ~11-build burst exposed a second, pre-existing reliability issue: `--max-old-space-size=8192` on Vercel's 8GB standard build machine leaves zero headroom. Observed failure modes: SIGKILL at 16m (container OOM) and indefinite grinding in the Nitro/Rollup server-build step (4 preview builds wedged >25m), while warm-cache dev builds completed in ~5m. Local builds with the default (~4GB) heap OOM in the vite phase, so the bump is still needed — 6144 keeps ~2GB of headroom for bun/vite workers and the OS.

This PR's own preview deploy is the experiment: a cold-cache preview build that completes normally supports the headroom theory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)