### PR TITLE
docs(exchange): runbook — repurpose the TME Stripe webhook, don't create one

### DIFF
--- a/docs/runbooks/2026-07-12-exchange-cutover-checklist.md
+++ b/docs/runbooks/2026-07-12-exchange-cutover-checklist.md
@@ -57,9 +57,17 @@ In `classicminidiy-supabase`:
 5. [ ] Edge-fn secrets (Supabase dashboard → Edge Functions → secrets), reusing TME's
        existing values:
    - `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_ACCESS_TOKEN` (newsletter subscriber merge)
-   - `STRIPE_LISTINGS_WEBHOOK_SECRET` — create the **listing** webhook endpoint in the
-     Stripe dashboard pointing at `stripe-listings-webhook`. This is the THIRD isolated
-     Stripe webhook (membership / model-connect / listings) — secrets must not cross.
+   - `STRIPE_LISTINGS_SECRET_KEY` + `STRIPE_LISTINGS_WEBHOOK_SECRET` — NO new Stripe
+     endpoint (the account is out of webhook slots): **repurpose the existing
+     `the-mini-exchange` destination** (`theminiexchange.com/api/payments/webhook`,
+     2 events: `checkout.session.completed` + `charge.refunded` — the edge fn handles
+     exactly these). Its signing secret survives a URL edit, so set both secrets NOW
+     from the existing endpoint (`STRIPE_LISTINGS_SECRET_KEY` = the account key, same
+     value as `STRIPE_SECRET_KEY`; isolation stays at the per-endpoint-secret level),
+     then at Stage D edit the destination URL to
+     `https://psoqirvbujwohemmwplv.supabase.co/functions/v1/stripe-listings-webhook`.
+     No gap window: both handlers write the same shared-DB tables, and the old URL
+     dies behind the host 301s at DNS cutover anyway.
    - Meta + Bluesky creds for `post-listing-social`
 6. [ ] Verify: `newsletter_preview` action via the web admin proxy on a flag-on preview;
        Stripe test-mode replay against `stripe-listings-webhook`; confirm the membership


### PR DESCRIPTION
Stripe account is out of webhook destination slots. The existing `the-mini-exchange` endpoint handles exactly the 2 events the new edge fn handles (`checkout.session.completed`, `charge.refunded`), its signing secret survives a URL edit, and its URL dies behind the host 301s at DNS cutover anyway. Runbook Stage B/D updated: set `STRIPE_LISTINGS_SECRET_KEY`/`STRIPE_LISTINGS_WEBHOOK_SECRET` now from the existing endpoint; edit the destination URL to the edge function at go-live. No gap window — both handlers write the same shared-DB tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)