### PR TITLE
fix(profile): render seller trust signals (blank fields + ~NaN day)

### DIFF
--- a/app/components/exchange/profile/SellerTrustSignals.vue
+++ b/app/components/exchange/profile/SellerTrustSignals.vue
@@ -100,7 +100,7 @@
 
       // get_seller_stats is a RETURNS TABLE function, so PostgREST hands back a
       // single-row array — unwrap it to the row object.
-      stats.value = (Array.isArray(data) ? data[0] : data) as SellerStats | null;
+      stats.value = (Array.isArray(data) ? (data[0] ?? null) : data) as SellerStats | null;
       cachedSellerId.value = props.sellerId;
     } catch (err) {
       console.error('Failed to fetch seller stats:', err);

--- a/app/components/exchange/profile/SellerTrustSignals.vue
+++ b/app/components/exchange/profile/SellerTrustSignals.vue
@@ -98,7 +98,9 @@
 
       if (error) throw error;
 
-      stats.value = data as SellerStats;
+      // get_seller_stats is a RETURNS TABLE function, so PostgREST hands back a
+      // single-row array — unwrap it to the row object.
+      stats.value = (Array.isArray(data) ? data[0] : data) as SellerStats | null;
       cachedSellerId.value = props.sellerId;
     } catch (err) {
       console.error('Failed to fetch seller stats:', err);


### PR DESCRIPTION
## Problem

The public user profile page (`/users/[id]`) rendered a broken "Seller Trust Signals" card: an empty **Member since**, missing sale/listing counts, and **Responds in ~NaN day**.

## Root cause

`SellerTrustSignals.vue` calls the `get_seller_stats` RPC, which is a `RETURNS TABLE` function. PostgREST returns those as a single-row array (`[{…}]`), but the component assigned `data` directly to `stats` as if it were an object. An array is truthy, so `v-else-if="stats"` still rendered the card, but every `stats.member_since` / `.sold_listings` / `.active_listings` / `.avg_response_time_hours` lookup was `undefined` → blank fields and `Math.round(undefined / 24)` → `~NaN day`.

## Fix

Unwrap the first row of the response, falling back to `null` when the array is empty (the template already handles `null` gracefully):

```ts
stats.value = (Array.isArray(data) ? data[0] : data) as SellerStats | null;
```

## Verification

Confirmed the RPC returns correct data, then rendered the page locally. The card now shows: **Member since Feb 2026 · Responds in ~14 hours · 3 sales completed · 9 active listings**. Only one consumer of this RPC exists in the repo.

The top profile-card "Member since" was always correct — it reads `profile.created_at` directly, independent of this RPC.
