### PR TITLE
feat(profiles): repoint sensitive-column reads to profile_private (Phase 2)

### DIFF
--- a/app/components/exchange/listings/Comment.vue
+++ b/app/components/exchange/listings/Comment.vue
@@ -1,13 +1,7 @@
 <template>
   <div class="flex gap-3" :class="{ 'ml-12': isReply }">
     <!-- Avatar -->
-    <ExchangeAvatar
-      :avatar-url="comment.user.avatar_url"
-      :display-name="comment.user.display_name"
-      :email="comment.user.email"
-      size="sm"
-      class="shrink-0"
-    />
+    <ExchangeAvatar :avatar-url="comment.user.avatar_url" :display-name="comment.user.display_name" size="sm" class="shrink-0" />
 
     <!-- Comment Content -->
     <div class="flex-1 min-w-0">
@@ -138,15 +132,10 @@
   const showReplyForm = ref(false);
   const replyContent = ref('');
 
-  // Display name with email fallback
+  // Never derive a display name from email — commenter emails must not reach
+  // this component (profiles split; comments API returns display_name only).
   const displayName = computed(() => {
-    if (props.comment.user.display_name) {
-      return props.comment.user.display_name;
-    }
-    if (props.comment.user.email) {
-      return props.comment.user.email.split('@')[0];
-    }
-    return t('anonymous');
+    return props.comment.user.display_name || t('anonymous');
   });
 
   // Check if user is admin (you'll need to add this to your useAuth composable)

--- a/app/composables/useAdmin.ts
+++ b/app/composables/useAdmin.ts
@@ -16,7 +16,7 @@ export interface MessageQueueItem {
   sender?: {
     id: string;
     display_name: string | null;
-    email: string;
+    email: string | null;
     warning_count: number;
     is_banned: boolean;
   };
@@ -33,12 +33,12 @@ export interface MessageQueueItem {
     buyer?: {
       id: string;
       display_name: string | null;
-      email: string;
+      email: string | null;
     };
     seller?: {
       id: string;
       display_name: string | null;
-      email: string;
+      email: string | null;
     };
   };
   context_messages?: Array<{
@@ -49,7 +49,7 @@ export interface MessageQueueItem {
     sender?: {
       id: string;
       display_name: string | null;
-      email: string;
+      email: string | null;
     };
   }>;
 }
@@ -64,12 +64,12 @@ export interface AdminConversation {
   buyer?: {
     id: string;
     display_name: string | null;
-    email: string;
+    email: string | null;
   };
   seller?: {
     id: string;
     display_name: string | null;
-    email: string;
+    email: string | null;
   };
   listing?: {
     id: string;
@@ -79,6 +79,18 @@ export interface AdminConversation {
   message_count?: number;
   flagged_count?: number;
 }
+
+/**
+ * Merge an embedded `profile_private` row into its parent profile object so
+ * existing consumers keep reading flat fields (email, warning_count, is_admin).
+ * Sensitive columns moved to `profile_private` in the profiles split — admin
+ * views read them via a PostgREST embed and flatten here.
+ */
+const flattenProfilePrivate = <T extends Record<string, any>>(profile: T | null | undefined): any => {
+  if (!profile || typeof profile !== 'object') return profile;
+  const { profile_private: priv, ...rest } = profile as any;
+  return { ...rest, ...(priv ?? {}) };
+};
 
 export const useAdmin = () => {
   const supabase = useSupabase();
@@ -102,7 +114,11 @@ export const useAdmin = () => {
   const isAdmin = async () => {
     if (!user.value) return false;
 
-    const { data, error } = await supabase.from('profiles').select('is_admin').eq('id', user.value.id).single();
+    const { data, error } = await supabase
+      .from('profile_private')
+      .select('is_admin')
+      .eq('user_id', user.value.id)
+      .single();
 
     if (error) return false;
     return data?.is_admin || false;
@@ -181,8 +197,8 @@ export const useAdmin = () => {
         profiles!listings_user_id_fkey (
           id,
           display_name,
-          email,
-          location
+          location,
+          profile_private ( email )
         )
       `,
         { count: 'exact' }
@@ -201,7 +217,7 @@ export const useAdmin = () => {
     }
 
     return {
-      listings: data || [],
+      listings: (data || []).map((l: any) => ({ ...l, profiles: flattenProfilePrivate(l.profiles) })),
       total: count || 0,
     };
   };
@@ -215,7 +231,7 @@ export const useAdmin = () => {
 
     const { data, error, count } = await supabase
       .from('profiles')
-      .select('*', { count: 'exact' })
+      .select('*, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )', { count: 'exact' })
       .order('created_at', { ascending: false })
       .range(start, end);
 
@@ -224,7 +240,7 @@ export const useAdmin = () => {
     }
 
     return {
-      users: data || [],
+      users: (data || []).map(flattenProfilePrivate),
       total: count || 0,
     };
   };
@@ -381,7 +397,11 @@ export const useAdmin = () => {
    */
   const getUserDetails = async (userId: string) => {
     const [profileResult, listingsResult] = await Promise.all([
-      supabase.from('profiles').select('*').eq('id', userId).single(),
+      supabase
+        .from('profiles')
+        .select('*, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )')
+        .eq('id', userId)
+        .single(),
       applyPhotoOrdering(
         supabase
           .from('listings')
@@ -405,7 +425,7 @@ export const useAdmin = () => {
     }
 
     return {
-      profile: profileResult.data,
+      profile: flattenProfilePrivate(profileResult.data),
       listings: listingsResult.data || [],
     };
   };
@@ -541,7 +561,8 @@ export const useAdmin = () => {
         `
       *,
       sender:profiles!messages_sender_id_fkey (
-        id, display_name, email, warning_count, is_banned
+        id, display_name, is_banned,
+        profile_private ( email, warning_count )
       ),
       conversation:conversations!messages_conversation_id_fkey (
         id, listing_id, buyer_id, seller_id,
@@ -549,10 +570,12 @@ export const useAdmin = () => {
           id, title, slug
         ),
         buyer:profiles!conversations_buyer_id_fkey (
-          id, display_name, email
+          id, display_name,
+          profile_private ( email )
         ),
         seller:profiles!conversations_seller_id_fkey (
-          id, display_name, email
+          id, display_name,
+          profile_private ( email )
         )
       )
     `,
@@ -567,8 +590,20 @@ export const useAdmin = () => {
       handleError(error, { toastTitle: 'Failed to fetch message queue', rethrow: true });
     }
 
+    const items = (data || []).map((m: any) => ({
+      ...m,
+      sender: flattenProfilePrivate(m.sender),
+      conversation: m.conversation
+        ? {
+            ...m.conversation,
+            buyer: flattenProfilePrivate(m.conversation.buyer),
+            seller: flattenProfilePrivate(m.conversation.seller),
+          }
+        : m.conversation,
+    }));
+
     return {
-      items: (data || []) as MessageQueueItem[],
+      items: items as MessageQueueItem[],
       total: count || 0,
     };
   };
@@ -625,12 +660,17 @@ export const useAdmin = () => {
     if (filters?.search) {
       const q = `%${filters.search}%`;
 
-      const [profileResult, listingResult] = await Promise.all([
-        supabase.from('profiles').select('id').or(`display_name.ilike.${q},email.ilike.${q}`),
+      // Email lives on profile_private (sensitive-column split) — search it
+      // separately from display_name and merge the id sets.
+      const [nameResult, emailResult, listingResult] = await Promise.all([
+        supabase.from('profiles').select('id').ilike('display_name', q),
+        supabase.from('profile_private').select('user_id').ilike('email', q),
         supabase.from('listings').select('id').ilike('title', q),
       ]);
 
-      const profileIds = (profileResult.data || []).map((p) => p.id);
+      const profileIds = [
+        ...new Set([...(nameResult.data || []).map((p) => p.id), ...(emailResult.data || []).map((p) => p.user_id)]),
+      ];
       const listingIds = (listingResult.data || []).map((l) => l.id);
 
       // Find conversations matching these profiles or listings
@@ -669,10 +709,12 @@ export const useAdmin = () => {
         `
       *,
       buyer:profiles!conversations_buyer_id_fkey (
-        id, display_name, email
+        id, display_name,
+        profile_private ( email )
       ),
       seller:profiles!conversations_seller_id_fkey (
-        id, display_name, email
+        id, display_name,
+        profile_private ( email )
       ),
       listing:listings!conversations_listing_id_fkey (
         id, title, slug
@@ -701,8 +743,14 @@ export const useAdmin = () => {
       handleError(error, { toastTitle: 'Failed to fetch conversations', rethrow: true });
     }
 
+    const conversations = (data || []).map((c: any) => ({
+      ...c,
+      buyer: flattenProfilePrivate(c.buyer),
+      seller: flattenProfilePrivate(c.seller),
+    }));
+
     return {
-      conversations: (data || []) as AdminConversation[],
+      conversations: conversations as AdminConversation[],
       total: count || 0,
     };
   };
@@ -717,7 +765,8 @@ export const useAdmin = () => {
         `
       *,
       sender:profiles!messages_sender_id_fkey (
-        id, display_name, email, warning_count, is_banned
+        id, display_name, is_banned,
+        profile_private ( email, warning_count )
       )
     `
       )
@@ -727,7 +776,7 @@ export const useAdmin = () => {
     if (error) {
       handleError(error, { toastTitle: 'Failed to fetch messages', rethrow: true });
     }
-    return data || [];
+    return (data || []).map((m: any) => ({ ...m, sender: flattenProfilePrivate(m.sender) }));
   };
 
   /**
@@ -820,7 +869,7 @@ export const useAdmin = () => {
       .select(
         `
       id, sender_id, content, created_at,
-      sender:profiles!messages_sender_id_fkey (id, display_name, email)
+      sender:profiles!messages_sender_id_fkey (id, display_name, profile_private ( email ))
     `
       )
       .eq('conversation_id', conversationId)
@@ -833,7 +882,7 @@ export const useAdmin = () => {
       .select(
         `
       id, sender_id, content, created_at,
-      sender:profiles!messages_sender_id_fkey (id, display_name, email)
+      sender:profiles!messages_sender_id_fkey (id, display_name, profile_private ( email ))
     `
       )
       .eq('conversation_id', conversationId)
@@ -841,7 +890,10 @@ export const useAdmin = () => {
       .order('created_at', { ascending: true })
       .limit(3);
 
-    return [...(before || []).reverse(), ...(after || [])];
+    return [...(before || []).reverse(), ...(after || [])].map((m: any) => ({
+      ...m,
+      sender: flattenProfilePrivate(m.sender),
+    }));
   };
 
   return {

--- a/app/composables/useAdmin.ts
+++ b/app/composables/useAdmin.ts
@@ -1,4 +1,4 @@
-import { ADMIN_CACHE_TTL_MS } from '~/utils/constants';
+import { ADMIN_CACHE_TTL_MS, PROFILE_PUBLIC_COLUMNS } from '~/utils/constants';
 
 export interface MessageQueueItem {
   id: string;
@@ -231,7 +231,9 @@ export const useAdmin = () => {
 
     const { data, error, count } = await supabase
       .from('profiles')
-      .select('*, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )', { count: 'exact' })
+      .select(`${PROFILE_PUBLIC_COLUMNS}, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )`, {
+        count: 'exact',
+      })
       .order('created_at', { ascending: false })
       .range(start, end);
 
@@ -399,7 +401,7 @@ export const useAdmin = () => {
     const [profileResult, listingsResult] = await Promise.all([
       supabase
         .from('profiles')
-        .select('*, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )')
+        .select(`${PROFILE_PUBLIC_COLUMNS}, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )`)
         .eq('id', userId)
         .single(),
       applyPhotoOrdering(

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -63,26 +63,38 @@ export const useAuth = () => {
     }
   };
 
-  // Fetch user profile including admin status + Sustaining Member status
+  // Fetch user profile including admin status + Sustaining Member status.
+  // Sensitive columns live on profile_private (profiles split): is_admin is
+  // read from the user's own profile_private row (RLS: own-row SELECT), and
+  // the user's own email comes from the Supabase auth user object — never
+  // from profiles.
   const fetchUserProfile = async (userId: string) => {
     try {
-      const { data, error } = await supabase
-        .from('profiles')
-        .select(
-          'is_admin, display_name, email, avatar_url, trust_level, total_submissions, approved_submissions, rejected_submissions, onboarding_completed'
-        )
-        .eq('id', userId)
-        .single();
+      const [profileResult, privateResult] = await Promise.all([
+        supabase
+          .from('profiles')
+          .select(
+            'display_name, avatar_url, trust_level, total_submissions, approved_submissions, rejected_submissions, onboarding_completed'
+          )
+          .eq('id', userId)
+          .single(),
+        supabase.from('profile_private').select('is_admin').eq('user_id', userId).maybeSingle(),
+      ]);
 
-      if (error) {
-        console.error('Error fetching user profile:', error);
+      if (profileResult.error) {
+        console.error('Error fetching user profile:', profileResult.error);
         userProfile.value = null;
         return;
       }
 
       // Membership is computed, not a profiles column — fold it into shared state.
       const isSustaining = await fetchMembership(userId);
-      userProfile.value = { ...data, is_sustaining_member: isSustaining } as UserProfile;
+      userProfile.value = {
+        ...profileResult.data,
+        email: user.value?.email ?? '',
+        is_admin: privateResult.data?.is_admin ?? false,
+        is_sustaining_member: isSustaining,
+      } as UserProfile;
     } catch (error) {
       console.error('Error fetching user profile:', error);
       userProfile.value = null;

--- a/app/composables/useComments.ts
+++ b/app/composables/useComments.ts
@@ -17,7 +17,6 @@ export interface Comment {
     id: string;
     display_name: string | null;
     avatar_url: string | null;
-    email: string;
   };
   replies?: Comment[];
 }

--- a/app/composables/useProfile.ts
+++ b/app/composables/useProfile.ts
@@ -34,15 +34,28 @@ export const useProfile = () => {
   const { capture } = usePostHog();
 
   /**
-   * Fetch the authenticated user's full profile
+   * Fetch the authenticated user's full profile.
+   * Sensitive columns live on profile_private (profiles split): is_admin is
+   * embedded from the user's own profile_private row, and email comes from
+   * the Supabase auth user object — never from profiles.
    */
   const fetchProfile = async () => {
     if (!user.value) throw new Error('Not authenticated');
 
-    const { data, error } = await supabase.from('profiles').select('*').eq('id', user.value.id).single();
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('*, profile_private ( is_admin )')
+      .eq('id', user.value.id)
+      .single();
 
     if (error) throw error;
-    return data;
+
+    const { profile_private: priv, ...profile } = (data ?? {}) as any;
+    return {
+      ...profile,
+      email: user.value.email ?? '',
+      is_admin: priv?.is_admin ?? false,
+    };
   };
 
   /**
@@ -59,12 +72,7 @@ export const useProfile = () => {
   }) => {
     if (!user.value) throw new Error('Not authenticated');
 
-    const { data, error } = await supabase
-      .from('profiles')
-      .update(updates)
-      .eq('id', user.value.id)
-      .select()
-      .single();
+    const { data, error } = await supabase.from('profiles').update(updates).eq('id', user.value.id).select().single();
 
     if (error) throw error;
     return data;
@@ -181,11 +189,7 @@ export const useProfile = () => {
     const { data, error } = await supabase.rpc('get_public_profile_by_id', { p_user_id: identifier }).single();
 
     if (error || !data) {
-      const { data: exists } = await supabase
-        .from('profiles')
-        .select('id')
-        .eq('id', identifier)
-        .maybeSingle();
+      const { data: exists } = await supabase.from('profiles').select('id').eq('id', identifier).maybeSingle();
       if (exists) return { private: true };
       return null;
     }

--- a/app/composables/useProfile.ts
+++ b/app/composables/useProfile.ts
@@ -26,6 +26,8 @@ export interface Vehicle {
   color: string | null;
 }
 
+import { PROFILE_PUBLIC_COLUMNS } from '~/utils/constants';
+
 const AVATAR_BUCKET = 'avatars';
 
 export const useProfile = () => {
@@ -37,14 +39,15 @@ export const useProfile = () => {
    * Fetch the authenticated user's full profile.
    * Sensitive columns live on profile_private (profiles split): is_admin is
    * embedded from the user's own profile_private row, and email comes from
-   * the Supabase auth user object — never from profiles.
+   * the Supabase auth user object — never from profiles. Explicit column list
+   * so legacy sensitive-column reads can't sneak back in before Phase 4.
    */
   const fetchProfile = async () => {
     if (!user.value) throw new Error('Not authenticated');
 
     const { data, error } = await supabase
       .from('profiles')
-      .select('*, profile_private ( is_admin )')
+      .select(`${PROFILE_PUBLIC_COLUMNS}, profile_private ( is_admin )`)
       .eq('id', user.value.id)
       .single();
 

--- a/app/pages/admin/exchange/moderation.vue
+++ b/app/pages/admin/exchange/moderation.vue
@@ -95,7 +95,11 @@
                     <i class="fas fa-circle-check"></i>
                     Approve
                   </button>
-                  <NuxtLink :to="`/exchange/listings/${listing.slug}`" target="_blank" class="btn btn-ghost btn-sm gap-1">
+                  <NuxtLink
+                    :to="`/exchange/listings/${listing.slug}`"
+                    target="_blank"
+                    class="btn btn-ghost btn-sm gap-1"
+                  >
                     <i class="fas fa-eye"></i>
                     View
                   </NuxtLink>
@@ -508,14 +512,20 @@
   const loadWantedPosts = async () => {
     tabErrors.value.wanted = null;
     try {
+      // Email lives on profile_private (sensitive-column split) — embed via
+      // profiles and flatten so the template keeps reading profiles.email.
       const { data, error } = await supabase
         .from('wanted_posts')
-        .select('*, profiles!wanted_posts_user_id_fkey(id, display_name, email, avatar_url)')
+        .select('*, profiles!wanted_posts_user_id_fkey(id, display_name, avatar_url, profile_private ( email ))')
         .in('moderation_status', ['pending', 'flagged'])
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      wantedPosts.value = (data as unknown as WantedPost[]) || [];
+      wantedPosts.value = ((data as any[]) || []).map((p) => {
+        if (!p.profiles) return p;
+        const { profile_private: priv, ...profile } = p.profiles;
+        return { ...p, profiles: { ...profile, email: priv?.email ?? null } };
+      }) as WantedPost[];
     } catch (error: any) {
       console.error('Error loading wanted posts:', error);
       tabErrors.value.wanted = 'Failed to load wanted posts';

--- a/app/pages/admin/exchange/wanted.vue
+++ b/app/pages/admin/exchange/wanted.vue
@@ -20,11 +20,7 @@
             <label for="status-filter" class="label">
               <span class="label-text">Filter by Status</span>
             </label>
-            <select
-              id="status-filter"
-              v-model="selectedStatus"
-              class="select select-bordered w-full max-w-xs"
-            >
+            <select id="status-filter" v-model="selectedStatus" class="select select-bordered w-full max-w-xs">
               <option value="all">All Statuses</option>
               <option value="flagged">Flagged</option>
               <option value="active">Active</option>
@@ -165,10 +161,7 @@
                 <th class="cursor-pointer select-none" @click="toggleSort('status')">
                   <span class="flex items-center gap-1">
                     Status
-                    <i
-                      class="text-xs"
-                      :class="[getSortIcon('status'), { 'opacity-30': !isSortedBy('status') }]"
-                    ></i>
+                    <i class="text-xs" :class="[getSortIcon('status'), { 'opacity-30': !isSortedBy('status') }]"></i>
                   </span>
                 </th>
                 <th class="cursor-pointer select-none" @click="toggleSort('moderation_status')">
@@ -421,9 +414,11 @@
     loading.value = true;
 
     try {
+      // Email lives on profile_private (sensitive-column split) — embed via
+      // profiles and flatten so the template keeps reading profiles.email.
       let query = supabase
         .from('wanted_posts')
-        .select('*, profiles!wanted_posts_user_id_fkey(id, display_name, email, avatar_url)')
+        .select('*, profiles!wanted_posts_user_id_fkey(id, display_name, avatar_url, profile_private ( email ))')
         .order('created_at', { ascending: false });
 
       if (selectedStatus.value && selectedStatus.value !== 'all') {
@@ -439,7 +434,11 @@
 
       if (error) throw error;
 
-      posts.value = (data as unknown as WantedPost[]) || [];
+      posts.value = ((data as any[]) || []).map((p) => {
+        if (!p.profiles) return p;
+        const { profile_private: priv, ...profile } = p.profiles;
+        return { ...p, profiles: { ...profile, email: priv?.email ?? null } };
+      }) as WantedPost[];
     } catch (error) {
       handleError(error, { toastTitle: 'Failed to load wanted posts' });
     } finally {

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -21,3 +21,12 @@ export const ADMIN_CACHE_TTL_MS = 2 * 60 * 1000;
 
 /** Maximum budget value for wanted posts */
 export const MAX_BUDGET = 10_000_000;
+
+/**
+ * Non-sensitive columns of public.profiles, for explicit selects during the
+ * profiles sensitive-column split. email/is_admin/warning_count/firebase_uid/
+ * auth_provider live on profile_private — never select them from profiles
+ * (they are dropped from profiles in Phase 4 of the split).
+ */
+export const PROFILE_PUBLIC_COLUMNS =
+  'id, username, display_name, avatar_url, location, bio, social_links, show_vehicles, is_public, is_banned, preferred_currency, unit_system, trust_level, total_submissions, approved_submissions, rejected_submissions, onboarding_completed, onboarding_completed_app, profile_completed_at, created_at, updated_at';

--- a/server/api/admin/queue/list.ts
+++ b/server/api/admin/queue/list.ts
@@ -11,7 +11,9 @@ export default defineEventHandler(async (event) => {
 
   let q = supabase
     .from('submission_queue')
-    .select('*, submitter:profiles!submission_queue_submitted_by_fkey(display_name, email, avatar_url, trust_level)')
+    .select(
+      '*, submitter:profiles!submission_queue_submitted_by_fkey(display_name, avatar_url, trust_level, profile_private ( email ))'
+    )
     .order('created_at', { ascending: false });
 
   if (status !== 'all') q = q.eq('status', status);
@@ -54,8 +56,8 @@ export default defineEventHandler(async (event) => {
     reviewedAt: item.reviewed_at,
     createdAt: item.created_at,
     submittedBy: item.submitted_by,
-    submitterName: item.submitter?.display_name || item.submitter?.email || 'Unknown',
-    submitterEmail: item.submitter?.email || null,
+    submitterName: item.submitter?.display_name || item.submitter?.profile_private?.email || 'Unknown',
+    submitterEmail: item.submitter?.profile_private?.email || null,
     submitterAvatar: item.submitter?.avatar_url || null,
     submitterTrustLevel: item.submitter?.trust_level || 'new',
   }));

--- a/server/api/admin/users/list.ts
+++ b/server/api/admin/users/list.ts
@@ -11,26 +11,49 @@ export default defineEventHandler(async (event) => {
   const limit = parseInt(query.limit?.toString() || '50');
   const offset = parseInt(query.offset?.toString() || '0');
 
+  // Sensitive columns (email, is_admin, warning_count, ...) live on
+  // profile_private (profiles split) — embed and flatten so the response
+  // shape is unchanged for the admin users table.
   let q = supabase
     .from('profiles')
-    .select('*', { count: 'exact' })
+    .select('*, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )', { count: 'exact' })
     .order('created_at', { ascending: false })
     .range(offset, offset + limit - 1);
 
   if (trustLevel && trustLevel !== 'all') {
     if (trustLevel === 'admin') {
-      q = q.eq('is_admin', true);
+      // is_admin moved to profile_private — resolve admin ids first.
+      const { data: adminRows, error: adminError } = await supabase
+        .from('profile_private')
+        .select('user_id')
+        .eq('is_admin', true);
+      if (adminError) throw createError({ statusCode: 500, statusMessage: adminError.message });
+      const adminIds = (adminRows || []).map((r) => r.user_id);
+      if (adminIds.length === 0) return { users: [], total: 0 };
+      q = q.in('id', adminIds);
     } else {
       q = q.eq('trust_level', trustLevel);
     }
   }
-  if (search) q = q.or(`display_name.ilike.%${search}%,email.ilike.%${search}%`);
+  if (search) {
+    // Email search runs against profile_private; merge matches into the
+    // display_name filter by id.
+    const { data: emailRows, error: emailError } = await supabase
+      .from('profile_private')
+      .select('user_id')
+      .ilike('email', `%${search}%`);
+    if (emailError) throw createError({ statusCode: 500, statusMessage: emailError.message });
+    const emailIds = (emailRows || []).map((r) => r.user_id);
+    const orParts = [`display_name.ilike.%${search}%`];
+    if (emailIds.length > 0) orParts.push(`id.in.(${emailIds.join(',')})`);
+    q = q.or(orParts.join(','));
+  }
 
   const { data, error, count } = await q;
   if (error) throw createError({ statusCode: 500, statusMessage: error.message });
 
   return {
-    users: data || [],
+    users: (data || []).map(({ profile_private: priv, ...rest }: any) => ({ ...rest, ...(priv ?? {}) })),
     total: count || 0,
   };
 });

--- a/server/api/admin/users/list.ts
+++ b/server/api/admin/users/list.ts
@@ -13,10 +13,16 @@ export default defineEventHandler(async (event) => {
 
   // Sensitive columns (email, is_admin, warning_count, ...) live on
   // profile_private (profiles split) — embed and flatten so the response
-  // shape is unchanged for the admin users table.
+  // shape is unchanged for the admin users table. Explicit column list (not *)
+  // so legacy sensitive-column reads can't sneak back in before the Phase 4
+  // column drop. Keep in sync with PROFILE_PUBLIC_COLUMNS in app/utils/constants.ts.
+  const profilePublicColumns =
+    'id, username, display_name, avatar_url, location, bio, social_links, show_vehicles, is_public, is_banned, preferred_currency, unit_system, trust_level, total_submissions, approved_submissions, rejected_submissions, onboarding_completed, onboarding_completed_app, profile_completed_at, created_at, updated_at';
   let q = supabase
     .from('profiles')
-    .select('*, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )', { count: 'exact' })
+    .select(`${profilePublicColumns}, profile_private ( email, is_admin, warning_count, auth_provider, firebase_uid )`, {
+      count: 'exact',
+    })
     .order('created_at', { ascending: false })
     .range(offset, offset + limit - 1);
 

--- a/server/api/exchange/comments/[id]/delete.delete.ts
+++ b/server/api/exchange/comments/[id]/delete.delete.ts
@@ -15,8 +15,8 @@ export default defineEventHandler(async (event) => {
       });
     }
 
-    // Get user profile to check admin status
-    const { data: profile } = await supabase.from('profiles').select('is_admin').eq('id', user.id).single();
+    // Get admin status from profile_private (sensitive-column split)
+    const { data: profile } = await supabase.from('profile_private').select('is_admin').eq('user_id', user.id).single();
 
     // Verify comment exists and check ownership
     const { data: comment, error: fetchError } = await supabase

--- a/server/api/exchange/external-listings/[id].delete.ts
+++ b/server/api/exchange/external-listings/[id].delete.ts
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
 
     if (fetchError || !find) throw createError({ statusCode: 404, message: 'Find not found' });
 
-    const { data: profile } = await supabase.from('profiles').select('is_admin').eq('id', user.id).single();
+    const { data: profile } = await supabase.from('profile_private').select('is_admin').eq('user_id', user.id).single();
     const isAdmin = profile?.is_admin === true;
     const isOwner = find.submitted_by === user.id;
 

--- a/server/api/exchange/wanted/[id].delete.ts
+++ b/server/api/exchange/wanted/[id].delete.ts
@@ -40,8 +40,8 @@ export default defineEventHandler(async (event) => {
       });
     }
 
-    // Check if user is admin
-    const { data: profile } = await supabase.from('profiles').select('is_admin').eq('id', user.id).single();
+    // Check if user is admin (is_admin lives on profile_private — sensitive-column split)
+    const { data: profile } = await supabase.from('profile_private').select('is_admin').eq('user_id', user.id).single();
 
     const isOwner = existingPost.user_id === user.id;
     const isAdmin = profile?.is_admin === true;

--- a/server/api/exchange/wanted/[id].put.ts
+++ b/server/api/exchange/wanted/[id].put.ts
@@ -62,11 +62,15 @@ export default defineEventHandler(async (event) => {
       });
     }
 
-    // Check if user is admin
-    const { data: profile } = await supabase.from('profiles').select('is_admin, is_banned').eq('id', user.id).single();
+    // Check if user is admin (is_admin lives on profile_private; is_banned
+    // stays on profiles — sensitive-column split)
+    const [{ data: profile }, { data: privateProfile }] = await Promise.all([
+      supabase.from('profiles').select('is_banned').eq('id', user.id).single(),
+      supabase.from('profile_private').select('is_admin').eq('user_id', user.id).single(),
+    ]);
 
     const isOwner = existingPost.user_id === user.id;
-    const isAdmin = profile?.is_admin === true;
+    const isAdmin = privateProfile?.is_admin === true;
 
     // Verify ownership or admin access
     if (!isOwner && !isAdmin) {
@@ -179,7 +183,12 @@ export default defineEventHandler(async (event) => {
     // an invalid range against the stored value.
     const resolvedBudgetMin = updateData.budget_min !== undefined ? updateData.budget_min : existingPost.budget_min;
     const resolvedBudgetMax = updateData.budget_max !== undefined ? updateData.budget_max : existingPost.budget_max;
-    if (resolvedBudgetMin !== null && resolvedBudgetMin !== undefined && resolvedBudgetMax !== null && resolvedBudgetMax !== undefined) {
+    if (
+      resolvedBudgetMin !== null &&
+      resolvedBudgetMin !== undefined &&
+      resolvedBudgetMax !== null &&
+      resolvedBudgetMax !== undefined
+    ) {
       validateBudgetRange(resolvedBudgetMin, resolvedBudgetMax);
     }
 

--- a/server/api/exchange/wanted/create.post.ts
+++ b/server/api/exchange/wanted/create.post.ts
@@ -105,7 +105,7 @@ export default defineEventHandler(async (event) => {
     // Check if user is banned
     const { data: profile, error: profileError } = await supabase
       .from('profiles')
-      .select('id, is_banned, display_name, email')
+      .select('id, is_banned, display_name')
       .eq('id', user.id)
       .single();
 

--- a/server/utils/adminAuth.ts
+++ b/server/utils/adminAuth.ts
@@ -54,11 +54,11 @@ export async function requireAdminAuth(event: any) {
     });
   }
 
-  // Check admin status from profiles table
+  // Check admin status from profile_private (sensitive-column split)
   const { data: profile, error: profileError } = await supabase
-    .from('profiles')
+    .from('profile_private')
     .select('is_admin')
-    .eq('id', user.id)
+    .eq('user_id', user.id)
     .single();
 
   if (profileError || !profile?.is_admin) {

--- a/server/utils/exchange/notificationQueue.ts
+++ b/server/utils/exchange/notificationQueue.ts
@@ -139,11 +139,13 @@ export async function queueAdminNotification(params: {
   try {
     const supabase = getServiceClient();
 
+    // is_admin lives on profile_private, is_banned stays on profiles
+    // (sensitive-column split) — join through the user_id FK and filter both.
     const { data: admins, error: adminErr } = await supabase
-      .from('profiles')
-      .select('id')
+      .from('profile_private')
+      .select('user_id, profiles!inner ( is_banned )')
       .eq('is_admin', true)
-      .eq('is_banned', false);
+      .eq('profiles.is_banned', false);
 
     if (adminErr) {
       console.error('[NotificationQueue] Failed to resolve admins:', adminErr);
@@ -152,8 +154,8 @@ export async function queueAdminNotification(params: {
     if (!admins || admins.length === 0) return;
 
     const key = batchKey ?? eventType;
-    const rows = admins.map((a: { id: string }) => ({
-      user_id: a.id,
+    const rows = admins.map((a: { user_id: string }) => ({
+      user_id: a.user_id,
       event_type: eventType,
       payload,
       channel: 'email' as const,

--- a/tests/unit/composables/useAuth.test.ts
+++ b/tests/unit/composables/useAuth.test.ts
@@ -388,8 +388,9 @@ describe('useAuth', () => {
   // ---------------------------------------------------------------------------
   describe('isAdmin', () => {
     it('returns true when userProfile.is_admin is true', async () => {
-      const adminProfile = { ...mockProfile, is_admin: true };
-      mockSupabase._mockSingle.mockResolvedValue({ data: adminProfile, error: null });
+      mockSupabase._mockSingle.mockResolvedValue({ data: mockProfile, error: null });
+      // is_admin now comes from the user's own profile_private row (maybeSingle).
+      mockSupabase._mockMaybeSingle.mockResolvedValue({ data: { is_admin: true }, error: null });
 
       const { useAuth } = await import('~/app/composables/useAuth');
       const auth = useAuth();
@@ -400,8 +401,9 @@ describe('useAuth', () => {
     });
 
     it('returns false when userProfile.is_admin is false', async () => {
-      mockSupabase._mockSingle.mockResolvedValue({
-        data: { ...mockProfile, is_admin: false },
+      mockSupabase._mockSingle.mockResolvedValue({ data: mockProfile, error: null });
+      mockSupabase._mockMaybeSingle.mockResolvedValue({
+        data: { is_admin: false },
         error: null,
       });
 
@@ -432,7 +434,7 @@ describe('useAuth', () => {
   // fetchUserProfile()
   // ---------------------------------------------------------------------------
   describe('fetchUserProfile()', () => {
-    it('queries profiles table with correct user id and fields', async () => {
+    it('queries profiles and profile_private with correct user id and fields', async () => {
       mockSupabase._mockSingle.mockResolvedValue({ data: mockProfile, error: null });
 
       const { useAuth } = await import('~/app/composables/useAuth');
@@ -440,12 +442,19 @@ describe('useAuth', () => {
 
       await auth.fetchUserProfile('user-123');
 
+      // Public fields from profiles; is_admin from the user's own
+      // profile_private row (sensitive-column split). Email is NOT selected
+      // from profiles — it comes from the auth user object.
       expect(mockSupabase.from).toHaveBeenCalledWith('profiles');
+      expect(mockSupabase.from).toHaveBeenCalledWith('profile_private');
       expect(mockSupabase._mockSelect).toHaveBeenCalledWith(
-        'is_admin, display_name, email, avatar_url, trust_level, total_submissions, approved_submissions, rejected_submissions, onboarding_completed'
+        'display_name, avatar_url, trust_level, total_submissions, approved_submissions, rejected_submissions, onboarding_completed'
       );
+      expect(mockSupabase._mockSelect).toHaveBeenCalledWith('is_admin');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', 'user-123');
+      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('user_id', 'user-123');
       expect(mockSupabase._mockSingle).toHaveBeenCalled();
+      expect(mockSupabase._mockMaybeSingle).toHaveBeenCalled();
     });
 
     it('sets userProfile when profile data is returned', async () => {
@@ -456,7 +465,15 @@ describe('useAuth', () => {
 
       await auth.fetchUserProfile('user-123');
 
-      expect(auth.userProfile.value).toEqual({ ...mockProfile, is_sustaining_member: false });
+      // Email is '' here because user.value was never set (no initAuth) —
+      // own email comes from the auth user object, not profiles. is_admin
+      // defaults to false when the profile_private row is absent.
+      expect(auth.userProfile.value).toEqual({
+        ...mockProfile,
+        email: '',
+        is_admin: false,
+        is_sustaining_member: false,
+      });
     });
 
     it('sets userProfile to null when supabase returns an error', async () => {
@@ -518,10 +535,11 @@ describe('useAuth', () => {
       // Canonical gate: RPC called with the user id (keystone §9).
       expect(mockSupabase.rpc).toHaveBeenCalledWith('user_has_subscription', { p_user_id: 'user-123' });
 
-      // Regression guard: is_sustaining_member is NOT a profiles column.
-      const selectArg = mockSupabase._mockSelect.mock.calls[0][0] as string;
-      expect(selectArg).toContain('is_admin');
-      expect(selectArg).not.toContain('is_sustaining_member');
+      // Regression guard: is_sustaining_member is NOT a profiles or
+      // profile_private column. is_admin is selected from profile_private.
+      const selectArgs = mockSupabase._mockSelect.mock.calls.map((c) => c[0] as string);
+      expect(selectArgs).toContain('is_admin');
+      selectArgs.forEach((arg) => expect(arg).not.toContain('is_sustaining_member'));
     });
 
     it('is true when the gate RPC returns true', async () => {

--- a/tests/unit/composables/useProfile.test.ts
+++ b/tests/unit/composables/useProfile.test.ts
@@ -45,7 +45,11 @@ describe('useProfile', () => {
       await fetchProfile();
 
       expect(mockSupabase.from).toHaveBeenCalledWith('profiles');
-      expect(mockSupabase._mockSelect).toHaveBeenCalledWith('*, profile_private ( is_admin )');
+      const selectArg = mockSupabase._mockSelect.mock.calls[0][0];
+      // Explicit column list (never *) + is_admin via the profile_private embed
+      expect(selectArg).not.toContain('*');
+      expect(selectArg).toContain('profile_private ( is_admin )');
+      expect(selectArg).not.toMatch(/\bemail\b|firebase_uid|warning_count|auth_provider/);
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', 'test-user-id');
       expect(mockSupabase._mockSingle).toHaveBeenCalled();
     });

--- a/tests/unit/composables/useProfile.test.ts
+++ b/tests/unit/composables/useProfile.test.ts
@@ -45,7 +45,7 @@ describe('useProfile', () => {
       await fetchProfile();
 
       expect(mockSupabase.from).toHaveBeenCalledWith('profiles');
-      expect(mockSupabase._mockSelect).toHaveBeenCalledWith('*');
+      expect(mockSupabase._mockSelect).toHaveBeenCalledWith('*, profile_private ( is_admin )');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', 'test-user-id');
       expect(mockSupabase._mockSingle).toHaveBeenCalled();
     });
@@ -55,14 +55,27 @@ describe('useProfile', () => {
       const mockAuth = createMockAuth(mockUser);
       vi.stubGlobal('useAuth', () => mockAuth);
 
-      const profileData = { id: 'test-user-id', display_name: 'Test User', bio: 'Mini fan' };
+      const profileData = {
+        id: 'test-user-id',
+        display_name: 'Test User',
+        bio: 'Mini fan',
+        profile_private: { is_admin: true },
+      };
       mockSupabase._mockSingle.mockResolvedValue({ data: profileData, error: null });
 
       const { useProfile } = await import('~/app/composables/useProfile');
       const { fetchProfile } = useProfile();
       const result = await fetchProfile();
 
-      expect(result).toEqual(profileData);
+      // is_admin is flattened from the profile_private embed; email comes from
+      // the auth user object, not profiles (sensitive-column split).
+      expect(result).toEqual({
+        id: 'test-user-id',
+        display_name: 'Test User',
+        bio: 'Mini fan',
+        email: mockUser.email,
+        is_admin: true,
+      });
     });
 
     it('throws when Supabase returns an error', async () => {
@@ -392,9 +405,7 @@ describe('useProfile', () => {
       const mockAuth = createMockAuth(null);
       vi.stubGlobal('useAuth', () => mockAuth);
 
-      const vehicles = [
-        { id: 'v1', name: 'Red Mini', year: 1970, make: 'BMC', model: 'Cooper S', color: 'Red' },
-      ];
+      const vehicles = [{ id: 'v1', name: 'Red Mini', year: 1970, make: 'BMC', model: 'Cooper S', color: 'Red' }];
       mockSupabase._queryBuilder.then = vi.fn((resolve: any) => resolve({ data: vehicles, error: null }));
 
       const { useProfile } = await import('~/app/composables/useProfile');

--- a/tests/unit/exchange/server/notificationQueue.test.ts
+++ b/tests/unit/exchange/server/notificationQueue.test.ts
@@ -7,19 +7,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // notificationQueue.ts imports `getServiceClient` from '../supabase' (relative);
 // the `~~/` alias resolves to the same absolute module, so this mock intercepts
 // it. The query builder is chainable: select/eq return `this`, insert resolves
-// to { error } and the profiles select resolves via the awaited builder (.then).
+// to { error } and the profile_private select resolves via the awaited builder
+// (.then).
 // ---------------------------------------------------------------------------
 
 // notification_queue.insert(...) — resolves to { error } by default (success).
 const mockInsert = vi.fn().mockResolvedValue({ error: null });
 
-// profiles select chain: .select().eq().eq() then awaited -> { data, error }.
+// profile_private select chain: .select().eq().eq() then awaited -> { data, error }.
 // We control the awaited result via mockAdminThen.
 const mockAdminThen = vi.fn((resolve: (v: any) => any) => resolve({ data: [], error: null }));
 const mockSelect = vi.fn().mockReturnThis();
 const mockEq = vi.fn().mockReturnThis();
 
-const profilesBuilder: Record<string, any> = {
+const adminLookupBuilder: Record<string, any> = {
   select: mockSelect,
   eq: mockEq,
   then: mockAdminThen,
@@ -29,9 +30,10 @@ const notificationBuilder: Record<string, any> = {
   insert: mockInsert,
 };
 
-// `from('notification_queue')` returns the insert builder; `from('profiles')`
-// returns the chainable select builder.
-const mockFrom = vi.fn((table: string) => (table === 'profiles' ? profilesBuilder : notificationBuilder));
+// `from('notification_queue')` returns the insert builder; `from('profile_private')`
+// returns the chainable select builder (admin fan-out resolves admins there
+// since the profiles sensitive-column split).
+const mockFrom = vi.fn((table: string) => (table === 'profile_private' ? adminLookupBuilder : notificationBuilder));
 
 const mockSupabase = { from: mockFrom };
 
@@ -82,7 +84,9 @@ describe('buildBatchKey', () => {
       'price_drop',
     ];
     // Each produces a unique, defined key with the documented prefix shape.
-    const keys = all.map((t) => buildBatchKey(t, { conversationId: 'x', listingId: 'x', parentCommentId: 'x', userId: 'x', inquiryId: 'x' }));
+    const keys = all.map((t) =>
+      buildBatchKey(t, { conversationId: 'x', listingId: 'x', parentCommentId: 'x', userId: 'x', inquiryId: 'x' })
+    );
     expect(keys).toHaveLength(9);
     keys.forEach((k) => expect(typeof k).toBe('string'));
     // All distinct prefixes -> distinct keys for the same context.
@@ -98,7 +102,9 @@ describe('buildBatchKey', () => {
     });
 
     it('ignores unrelated context fields and uses only the relevant one', () => {
-      expect(buildBatchKey('listing_status', { listingId: 'L', conversationId: 'NOPE', userId: 'NOPE' })).toBe('status:L');
+      expect(buildBatchKey('listing_status', { listingId: 'L', conversationId: 'NOPE', userId: 'NOPE' })).toBe(
+        'status:L'
+      );
     });
 
     it('preserves empty-string ids verbatim', () => {
@@ -153,7 +159,12 @@ describe('queueNotification', () => {
     });
 
     expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({ channel: 'email', user_id: 'user-2', event_type: 'price_drop', batch_key: 'price_drop:l5' })
+      expect.objectContaining({
+        channel: 'email',
+        user_id: 'user-2',
+        event_type: 'price_drop',
+        batch_key: 'price_drop:l5',
+      })
     );
   });
 
@@ -202,7 +213,10 @@ describe('queueNotification', () => {
         queueNotification({ userId: 'u', eventType: 'new_message', payload: {}, batchKey: 'k' })
       ).resolves.toBeUndefined();
 
-      expect(spy).toHaveBeenCalledWith('[NotificationQueue] Unexpected error queueing notification:', expect.any(Error));
+      expect(spy).toHaveBeenCalledWith(
+        '[NotificationQueue] Unexpected error queueing notification:',
+        expect.any(Error)
+      );
       spy.mockRestore();
     });
 
@@ -217,7 +231,10 @@ describe('queueNotification', () => {
         queueNotification({ userId: 'u', eventType: 'new_message', payload: {}, batchKey: 'k' })
       ).resolves.toBeUndefined();
 
-      expect(spy).toHaveBeenCalledWith('[NotificationQueue] Unexpected error queueing notification:', expect.any(Error));
+      expect(spy).toHaveBeenCalledWith(
+        '[NotificationQueue] Unexpected error queueing notification:',
+        expect.any(Error)
+      );
       spy.mockRestore();
     });
   });
@@ -227,52 +244,70 @@ describe('queueNotification', () => {
 // queueAdminNotification — admin fan-out
 // ===========================================================================
 describe('queueAdminNotification', () => {
-  const setAdmins = (admins: Array<{ id: string }> | null, error: any = null) => {
+  const setAdmins = (admins: Array<{ user_id: string }> | null, error: any = null) => {
     mockAdminThen.mockImplementation((resolve: (v: any) => any) => resolve({ data: admins, error }));
   };
 
-  it('queries active (non-banned) admins from profiles', async () => {
-    setAdmins([{ id: 'a1' }]);
+  it('queries active (non-banned) admins from profile_private joined to profiles', async () => {
+    setAdmins([{ user_id: 'a1' }]);
     await queueAdminNotification({ eventType: 'admin_listing_pending', payload: { x: 1 } });
 
-    expect(mockFrom).toHaveBeenCalledWith('profiles');
-    expect(mockSelect).toHaveBeenCalledWith('id');
+    expect(mockFrom).toHaveBeenCalledWith('profile_private');
+    expect(mockSelect).toHaveBeenCalledWith('user_id, profiles!inner ( is_banned )');
     expect(mockEq).toHaveBeenCalledWith('is_admin', true);
-    expect(mockEq).toHaveBeenCalledWith('is_banned', false);
+    expect(mockEq).toHaveBeenCalledWith('profiles.is_banned', false);
   });
 
   it('fans out one row per admin, all sharing the default batch key (= eventType)', async () => {
-    setAdmins([{ id: 'a1' }, { id: 'a2' }, { id: 'a3' }]);
+    setAdmins([{ user_id: 'a1' }, { user_id: 'a2' }, { user_id: 'a3' }]);
     await queueAdminNotification({ eventType: 'admin_wanted_pending', payload: { listingId: 'L' } });
 
     expect(mockInsert).toHaveBeenCalledTimes(1);
     const rows = mockInsert.mock.calls[0][0];
     expect(rows).toHaveLength(3);
     expect(rows).toEqual([
-      { user_id: 'a1', event_type: 'admin_wanted_pending', payload: { listingId: 'L' }, channel: 'email', batch_key: 'admin_wanted_pending' },
-      { user_id: 'a2', event_type: 'admin_wanted_pending', payload: { listingId: 'L' }, channel: 'email', batch_key: 'admin_wanted_pending' },
-      { user_id: 'a3', event_type: 'admin_wanted_pending', payload: { listingId: 'L' }, channel: 'email', batch_key: 'admin_wanted_pending' },
+      {
+        user_id: 'a1',
+        event_type: 'admin_wanted_pending',
+        payload: { listingId: 'L' },
+        channel: 'email',
+        batch_key: 'admin_wanted_pending',
+      },
+      {
+        user_id: 'a2',
+        event_type: 'admin_wanted_pending',
+        payload: { listingId: 'L' },
+        channel: 'email',
+        batch_key: 'admin_wanted_pending',
+      },
+      {
+        user_id: 'a3',
+        event_type: 'admin_wanted_pending',
+        payload: { listingId: 'L' },
+        channel: 'email',
+        batch_key: 'admin_wanted_pending',
+      },
     ]);
     // Shared batch key across all rows.
     expect(new Set(rows.map((r: any) => r.batch_key)).size).toBe(1);
   });
 
   it('always uses the "email" channel for admin rows', async () => {
-    setAdmins([{ id: 'a1' }, { id: 'a2' }]);
+    setAdmins([{ user_id: 'a1' }, { user_id: 'a2' }]);
     await queueAdminNotification({ eventType: 'admin_find_pending', payload: {} });
     const rows = mockInsert.mock.calls[0][0];
     rows.forEach((r: any) => expect(r.channel).toBe('email'));
   });
 
   it('uses a custom batchKey when provided (overrides the eventType default)', async () => {
-    setAdmins([{ id: 'a1' }, { id: 'a2' }]);
+    setAdmins([{ user_id: 'a1' }, { user_id: 'a2' }]);
     await queueAdminNotification({ eventType: 'admin_listing_pending', payload: {}, batchKey: 'custom-window-key' });
     const rows = mockInsert.mock.calls[0][0];
     rows.forEach((r: any) => expect(r.batch_key).toBe('custom-window-key'));
   });
 
   it('inserts into notification_queue (not profiles)', async () => {
-    setAdmins([{ id: 'a1' }]);
+    setAdmins([{ user_id: 'a1' }]);
     await queueAdminNotification({ eventType: 'admin_listing_pending', payload: {} });
     // from() called for both profiles (select) and notification_queue (insert).
     expect(mockFrom).toHaveBeenCalledWith('notification_queue');
@@ -308,14 +343,16 @@ describe('queueAdminNotification', () => {
 
     it('logs but does not throw when the fan-out insert errors', async () => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      setAdmins([{ id: 'a1' }]);
+      setAdmins([{ user_id: 'a1' }]);
       mockInsert.mockResolvedValueOnce({ error: { message: 'insert failed' } });
 
       await expect(
         queueAdminNotification({ eventType: 'admin_listing_pending', payload: {} })
       ).resolves.toBeUndefined();
 
-      expect(spy).toHaveBeenCalledWith('[NotificationQueue] Failed to insert admin notifications:', { message: 'insert failed' });
+      expect(spy).toHaveBeenCalledWith('[NotificationQueue] Failed to insert admin notifications:', {
+        message: 'insert failed',
+      });
       spy.mockRestore();
     });
 
@@ -329,7 +366,10 @@ describe('queueAdminNotification', () => {
         queueAdminNotification({ eventType: 'admin_listing_pending', payload: {} })
       ).resolves.toBeUndefined();
 
-      expect(spy).toHaveBeenCalledWith('[NotificationQueue] Unexpected error queueing admin notification:', expect.any(Error));
+      expect(spy).toHaveBeenCalledWith(
+        '[NotificationQueue] Unexpected error queueing admin notification:',
+        expect.any(Error)
+      );
       spy.mockRestore();
     });
 
@@ -344,7 +384,10 @@ describe('queueAdminNotification', () => {
         queueAdminNotification({ eventType: 'admin_listing_pending', payload: {} })
       ).resolves.toBeUndefined();
 
-      expect(spy).toHaveBeenCalledWith('[NotificationQueue] Unexpected error queueing admin notification:', expect.any(Error));
+      expect(spy).toHaveBeenCalledWith(
+        '[NotificationQueue] Unexpected error queueing admin notification:',
+        expect.any(Error)
+      );
       spy.mockRestore();
     });
   });

--- a/tests/unit/exchange/server/routes/comments--id--delete.delete.test.ts
+++ b/tests/unit/exchange/server/routes/comments--id--delete.delete.test.ts
@@ -87,10 +87,10 @@ describe('server/api/exchange/comments/[id]/delete.delete', () => {
   it('looks up the profile admin flag keyed by the authenticated user id', async () => {
     await handler(evt());
 
-    expect(mockSupabase.from).toHaveBeenCalledWith('profiles');
+    expect(mockSupabase.from).toHaveBeenCalledWith('profile_private');
     const profileSelect = (mockSupabase._mockSelect as any).mock.calls.find((c: any[]) => c[0] === 'is_admin');
     expect(profileSelect).toBeTruthy();
-    expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', USER.id);
+    expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('user_id', USER.id);
   });
 
   it('fetches the comment ownership row (id, user_id) filtered by the comment id', async () => {
@@ -107,7 +107,10 @@ describe('server/api/exchange/comments/[id]/delete.delete', () => {
   //  Happy path — admin (not owner)
   // =========================================================================
   it('allows an admin to delete a comment they do not own', async () => {
-    wire({ data: { is_admin: true }, error: null }, { data: { id: 'comment-1', user_id: 'someone-else' }, error: null });
+    wire(
+      { data: { is_admin: true }, error: null },
+      { data: { id: 'comment-1', user_id: 'someone-else' }, error: null }
+    );
 
     const result = await handler(evt());
     expect(result).toEqual({ success: true, message: 'Comment deleted successfully' });
@@ -144,7 +147,10 @@ describe('server/api/exchange/comments/[id]/delete.delete', () => {
   //  Forbidden (403) — not owner, not admin
   // =========================================================================
   it('throws 403 when the requester is neither owner nor admin', async () => {
-    wire({ data: { is_admin: false }, error: null }, { data: { id: 'comment-1', user_id: 'someone-else' }, error: null });
+    wire(
+      { data: { is_admin: false }, error: null },
+      { data: { id: 'comment-1', user_id: 'someone-else' }, error: null }
+    );
     await expect(handler(evt())).rejects.toMatchObject({
       statusCode: 403,
       message: 'You do not have permission to delete this comment',

--- a/tests/unit/exchange/server/routes/external-listings--id-.delete.test.ts
+++ b/tests/unit/exchange/server/routes/external-listings--id-.delete.test.ts
@@ -113,10 +113,10 @@ describe('server/api/exchange/external-listings/[id].delete', () => {
   it('looks up the profile admin flag keyed by the authenticated user id', async () => {
     await handler(evt());
 
-    expect(mockSupabase.from).toHaveBeenCalledWith('profiles');
+    expect(mockSupabase.from).toHaveBeenCalledWith('profile_private');
     const profileSelect = (mockSupabase._mockSelect as any).mock.calls.find((c: any[]) => c[0] === 'is_admin');
     expect(profileSelect).toBeTruthy();
-    expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', USER.id);
+    expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('user_id', USER.id);
   });
 
   // =========================================================================

--- a/tests/unit/exchange/server/routes/wanted--id-.delete.test.ts
+++ b/tests/unit/exchange/server/routes/wanted--id-.delete.test.ts
@@ -119,10 +119,10 @@ describe('server/api/exchange/wanted/[id].delete', () => {
     it('looks up the profile admin flag keyed by the authenticated user id', async () => {
       await handler(evt());
 
-      expect(mockSupabase.from).toHaveBeenCalledWith('profiles');
+      expect(mockSupabase.from).toHaveBeenCalledWith('profile_private');
       const profileSelect = (mockSupabase._mockSelect as any).mock.calls.find((c: any[]) => c[0] === 'is_admin');
       expect(profileSelect).toBeTruthy();
-      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', USER.id);
+      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('user_id', USER.id);
     });
 
     it('verifies authentication via requireUserClient exactly once', async () => {

--- a/tests/unit/exchange/server/routes/wanted--id-.put.test.ts
+++ b/tests/unit/exchange/server/routes/wanted--id-.put.test.ts
@@ -69,13 +69,15 @@ function validBody(overrides: Record<string, any> = {}) {
 let mockSupabase: ReturnType<typeof createMockSupabaseClient>;
 
 /**
- * Configure the service-client mock. The route calls `.single()` up to three
+ * Configure the service-client mock. The route calls `.single()` up to four
  * times in order:
  *   1. wanted_posts fetch (ownership check)
- *   2. profiles fetch (admin / ban)
- *   3. wanted_posts update (final write)
- * Provide the resolutions in that order. The update resolution is omitted when
- * an earlier branch short-circuits.
+ *   2. profiles fetch (is_banned) — first arm of the parallel profile reads
+ *   3. profile_private fetch (is_admin) — second arm (sensitive-column split)
+ *   4. wanted_posts update (final write)
+ * `profile` still takes the combined { is_admin, is_banned } shape and is
+ * split across the two reads here. The update resolution is omitted when an
+ * earlier branch short-circuits.
  */
 function wireSupabase(
   opts: {
@@ -87,10 +89,19 @@ function wireSupabase(
   mockSupabase = createMockSupabaseClient();
   const existingRes = opts.existing ?? { data: { ...EXISTING_POST }, error: null };
   const profileRes = opts.profile ?? { data: { ...OWNER_PROFILE }, error: null };
+  const bannedRes = {
+    data: profileRes.data ? { is_banned: profileRes.data.is_banned } : null,
+    error: profileRes.error,
+  };
+  const adminRes = {
+    data: profileRes.data ? { is_admin: profileRes.data.is_admin } : null,
+    error: profileRes.error,
+  };
   const updateRes = opts.update ?? { data: { ...EXISTING_POST, ...{ id: POST_ID } }, error: null };
   mockSupabase._mockSingle
     .mockResolvedValueOnce(existingRes)
-    .mockResolvedValueOnce(profileRes)
+    .mockResolvedValueOnce(bannedRes)
+    .mockResolvedValueOnce(adminRes)
     .mockResolvedValueOnce(updateRes);
   (getServiceClient as any).mockReturnValue(mockSupabase);
 }

--- a/tests/unit/server/api/admin/queue.test.ts
+++ b/tests/unit/server/api/admin/queue.test.ts
@@ -138,7 +138,7 @@ describe('server/api/admin/queue/list', () => {
 
     expect(mockFrom).toHaveBeenCalledWith('submission_queue');
     expect(mockSelect).toHaveBeenCalledWith(
-      '*, submitter:profiles!submission_queue_submitted_by_fkey(display_name, email, avatar_url, trust_level)'
+      '*, submitter:profiles!submission_queue_submitted_by_fkey(display_name, avatar_url, trust_level, profile_private ( email ))'
     );
     expect(mockOrder).toHaveBeenCalledWith('created_at', { ascending: false });
   });
@@ -193,9 +193,9 @@ describe('server/api/admin/queue/list', () => {
       submitted_by: 'user-456',
       submitter: {
         display_name: 'John Doe',
-        email: 'john@example.com',
         avatar_url: 'https://example.com/avatar.jpg',
         trust_level: 'trusted',
+        profile_private: { email: 'john@example.com' },
       },
     };
 
@@ -236,7 +236,12 @@ describe('server/api/admin/queue/list', () => {
           reviewed_at: null,
           created_at: '2026-01-01',
           submitted_by: 'u1',
-          submitter: { display_name: null, email: 'fallback@email.com', avatar_url: null, trust_level: null },
+          submitter: {
+            display_name: null,
+            avatar_url: null,
+            trust_level: null,
+            profile_private: { email: 'fallback@email.com' },
+          },
         },
       ],
     });
@@ -259,7 +264,7 @@ describe('server/api/admin/queue/list', () => {
           reviewed_at: null,
           created_at: '2026-01-01',
           submitted_by: 'u2',
-          submitter: { display_name: null, email: null, avatar_url: null, trust_level: null },
+          submitter: { display_name: null, avatar_url: null, trust_level: null, profile_private: { email: null } },
         },
       ],
     });

--- a/tests/unit/server/utils/adminAuth.test.ts
+++ b/tests/unit/server/utils/adminAuth.test.ts
@@ -243,9 +243,9 @@ describe('server/utils/adminAuth', () => {
       const result = await requireAdminAuth(event);
 
       expect(result).toEqual({ user, profile });
-      expect(mockFrom).toHaveBeenCalledWith('profiles');
+      expect(mockFrom).toHaveBeenCalledWith('profile_private');
       expect(mockSelect).toHaveBeenCalledWith('is_admin');
-      expect(mockEq).toHaveBeenCalledWith('id', 'admin-user');
+      expect(mockEq).toHaveBeenCalledWith('user_id', 'admin-user');
     });
 
     it('prefers Bearer token over cookie when both are present', async () => {

--- a/types/database.ts
+++ b/types/database.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.1"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -2889,6 +2909,54 @@ export type Database = {
         }
         Relationships: []
       }
+      profile_private: {
+        Row: {
+          auth_provider: string | null
+          created_at: string
+          email: string | null
+          firebase_uid: string | null
+          is_admin: boolean
+          updated_at: string
+          user_id: string
+          warning_count: number
+        }
+        Insert: {
+          auth_provider?: string | null
+          created_at?: string
+          email?: string | null
+          firebase_uid?: string | null
+          is_admin?: boolean
+          updated_at?: string
+          user_id: string
+          warning_count?: number
+        }
+        Update: {
+          auth_provider?: string | null
+          created_at?: string
+          email?: string | null
+          firebase_uid?: string | null
+          is_admin?: boolean
+          updated_at?: string
+          user_id?: string
+          warning_count?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_private_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profile_private_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "public_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           approved_submissions: number
@@ -3227,8 +3295,8 @@ export type Database = {
           filters: Json
           id: string
           is_active: boolean
-          last_notified_at: string | null
           name: string
+          notified_listing_ids: string[]
           notify_email: boolean
           user_id: string
         }
@@ -3237,8 +3305,8 @@ export type Database = {
           filters?: Json
           id?: string
           is_active?: boolean
-          last_notified_at?: string | null
           name: string
+          notified_listing_ids?: string[]
           notify_email?: boolean
           user_id: string
         }
@@ -3247,8 +3315,8 @@ export type Database = {
           filters?: Json
           id?: string
           is_active?: boolean
-          last_notified_at?: string | null
           name?: string
+          notified_listing_ids?: string[]
           notify_email?: boolean
           user_id?: string
         }
@@ -4006,6 +4074,10 @@ export type Database = {
           status: string
         }[]
       }
+      count_probation_cold_outreach: {
+        Args: { p_sender: string }
+        Returns: number
+      }
       find_user_id_by_email: { Args: { p_email: string }; Returns: string }
       generate_location_string: {
         Args: { p_city: string; p_country: string; p_state_province: string }
@@ -4191,6 +4263,7 @@ export type Database = {
         Args: { listing_id_param: string }
         Returns: undefined
       }
+      is_account_on_probation: { Args: { p_user_id: string }; Returns: boolean }
       is_admin: { Args: { user_id?: string }; Returns: boolean }
       is_username_available: { Args: { p_username: string }; Returns: boolean }
       is_watchlisted: {
@@ -4613,6 +4686,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       announcement_type_enum: ["error", "warning", "info", "success"],
@@ -4812,3 +4888,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/types/database.ts
+++ b/types/database.ts
@@ -7,30 +7,10 @@ export type Json =
   | Json[]
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.1"
   }
   public: {
     Tables: {
@@ -3295,8 +3275,8 @@ export type Database = {
           filters: Json
           id: string
           is_active: boolean
+          last_notified_at: string | null
           name: string
-          notified_listing_ids: string[]
           notify_email: boolean
           user_id: string
         }
@@ -3305,8 +3285,8 @@ export type Database = {
           filters?: Json
           id?: string
           is_active?: boolean
+          last_notified_at?: string | null
           name: string
-          notified_listing_ids?: string[]
           notify_email?: boolean
           user_id: string
         }
@@ -3315,8 +3295,8 @@ export type Database = {
           filters?: Json
           id?: string
           is_active?: boolean
+          last_notified_at?: string | null
           name?: string
-          notified_listing_ids?: string[]
           notify_email?: boolean
           user_id?: string
         }
@@ -4686,9 +4666,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       announcement_type_enum: ["error", "warning", "info", "success"],
@@ -4888,4 +4865,3 @@ export const Constants = {
     },
   },
 } as const
-


### PR DESCRIPTION
## ⚠️ DO NOT MERGE YET

**This PR must NOT be merged until classicminidiy-supabase PR #51 (the `profile_private` table + dual-write trigger + RLS) is deployed to production.** The code reads from `profile_private`, which does not exist in prod until that migration lands. After deploy, `types/database.ts` should be regenerated from prod (`supabase gen types typescript --project-id <ref>`) to replace the pre-generated copy in this PR.

## What this does

Phase 2 of the profiles sensitive-column split: every **read** of `email`, `is_admin`, `warning_count`, `auth_provider`, `firebase_uid` moves from `profiles` to `profile_private` (key column changes `id` → `user_id`). **Writes are untouched** — they stay on `profiles` and the dual-write trigger mirrors them (e.g. `server/api/admin/users/toggle-admin.post.ts` still writes `is_admin` to `profiles`). `is_banned` and `trust_level` reads stay on `profiles`.

## Repointed call sites

- `app/composables/useAdmin.ts` — `isAdmin()` reads `profile_private`; admin listings/users/user-detail/message-queue/conversation views now use `profile_private(...)` embeds and flatten them so consumer shapes (`.email`, `.warning_count`) are unchanged; admin conversation search splits `display_name` (profiles) from `email` (profile_private) and merges id sets
- `app/composables/useAuth.ts` — profile fetch splits into public fields (profiles) + `is_admin` (own `profile_private` row); own email now comes from the Supabase auth user object, not profiles
- `app/composables/useProfile.ts` — `fetchProfile()` embeds `profile_private(is_admin)`; email from auth user
- `server/utils/adminAuth.ts` — admin gate reads `profile_private` (service role)
- `server/api/admin/users/list.ts` — embed + flatten; admin filter resolves ids from `profile_private`; search splits display_name/email and merges
- `server/api/admin/queue/list.ts` — submitter email via nested `profile_private(email)` embed
- `server/api/exchange/wanted/[id].put.ts` — split read: `is_banned` stays on profiles, `is_admin` from `profile_private`
- `server/api/exchange/wanted/[id].delete.ts`, `comments/[id]/delete.delete.ts`, `external-listings/[id].delete.ts` — `is_admin` reads repointed
- `server/api/exchange/wanted/create.post.ts` — dropped unused `email` from the profile select
- `server/utils/exchange/notificationQueue.ts` — admin fan-out resolves recipients from `profile_private` (`is_admin`) inner-joined to profiles (`is_banned`)
- `app/pages/admin/exchange/wanted.vue`, `moderation.vue` — wanted-post embeds nest `profile_private(email)` and flatten for the templates
- `types/database.ts` — regenerated from the migrated schema (includes `profile_private`); regenerate from prod after deploy

## Email-leak check (messaging UI)

`useMessages.ts` and the messaging pages were audited for buyer/seller email fallbacks: on `main` they already read via `public_profiles` embeds and fall back `display_name → username → 'Anonymous'` — no email is selected or rendered in user-facing messaging, so no leak existed here to fix. Admin-only surfaces (moderation queue, conversation browser) intentionally keep email visibility, now gated by `profile_private` RLS (admin-only) instead of plain `profiles` columns.

## Tests

`bun run test`: 145 files, 4635 tests passing. Updated mocks/assertions in `useAuth`, `useProfile`, `adminAuth`, `admin/queue`, `notificationQueue`, and the wanted/comments/external-listings route tests to match the new read paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)