### PR TITLE
feat(profiles): toggle-admin writes is_admin to profile_private (split Phase 3)

### DIFF
--- a/server/api/admin/users/toggle-admin.post.ts
+++ b/server/api/admin/users/toggle-admin.post.ts
@@ -21,7 +21,10 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Cannot remove your own admin access' });
   }
 
-  const { error } = await supabase.from('profiles').update({ is_admin: isAdmin }).eq('id', userId);
+  // profiles split Phase 3: is_admin is canonical on profile_private (the
+  // dual-write mirror from profiles is gone — writing profiles.is_admin here
+  // would silently do nothing).
+  const { error } = await supabase.from('profile_private').update({ is_admin: isAdmin }).eq('user_id', userId);
 
   if (error) {
     throw createError({ statusCode: 500, statusMessage: error.message });


### PR DESCRIPTION
Companion to the Phase 3 Supabase migration (profiles split): `profile_private` becomes canonical and the dual-write trigger is removed, so the admin toggle must write `profile_private.is_admin` directly — writing `profiles.is_admin` would silently stop taking effect.

One-line change (service client, admin-gated route). Full unit suite green: 4635/4635.

**Merge after** the Phase 3 Supabase migration deploys. Until this merges, toggling admin status is the one flow that would no-op post-migration (it logs via the legacy-write detector); everything else is already repointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)