### PR TITLE
fix(exchange): daisyUI 5 button spinners on the social + newsletter admin pages

### DIFF
--- a/app/pages/admin/exchange/newsletter.vue
+++ b/app/pages/admin/exchange/newsletter.vue
@@ -81,8 +81,9 @@
             </p>
           </div>
           <div class="flex gap-2">
-            <button @click="refreshPreview" class="btn btn-ghost btn-sm" :class="{ loading: loading }">
-              <i v-if="!loading" class="fas fa-arrows-rotate"></i>
+            <button @click="refreshPreview" class="btn btn-ghost btn-sm" :disabled="loading">
+              <span v-if="loading" class="loading loading-spinner loading-xs"></span>
+              <i v-else class="fas fa-arrows-rotate"></i>
               Refresh
             </button>
           </div>
@@ -226,8 +227,9 @@
         </fieldset>
         <div class="modal-action">
           <button @click="closeTestModal" class="btn btn-ghost">Cancel</button>
-          <button @click="handleSendTest" class="btn btn-primary" :class="{ loading: testSending }">
-            <i v-if="!testSending" class="fas fa-paper-plane"></i>
+          <button @click="handleSendTest" class="btn btn-primary" :disabled="testSending">
+            <span v-if="testSending" class="loading loading-spinner loading-sm"></span>
+            <i v-else class="fas fa-paper-plane"></i>
             Send Test
           </button>
         </div>
@@ -271,10 +273,10 @@
           <button
             @click="handleSendToAll"
             class="btn btn-primary"
-            :class="{ loading: sending }"
-            :disabled="!canSendNewsletter && !forceOverride"
+            :disabled="sending || (!canSendNewsletter && !forceOverride)"
           >
-            <i v-if="!sending" class="fas fa-envelope"></i>
+            <span v-if="sending" class="loading loading-spinner loading-sm"></span>
+            <i v-else class="fas fa-envelope"></i>
             Send Newsletter
           </button>
         </div>

--- a/app/pages/admin/exchange/promotions.vue
+++ b/app/pages/admin/exchange/promotions.vue
@@ -109,30 +109,30 @@
                       v-if="!item.hasFacebook"
                       @click="retrySocialPost(item.listing.id, ['facebook'])"
                       class="btn btn-sm btn-primary"
-                      :class="{ loading: retryingId === item.listing.id }"
                       :disabled="retryingId === item.listing.id"
                     >
-                      <i v-if="retryingId !== item.listing.id" class="fas fa-arrows-rotate"></i>
+                      <span v-if="retryingId === item.listing.id" class="loading loading-spinner loading-xs"></span>
+                      <i v-else class="fas fa-arrows-rotate"></i>
                       Retry FB
                     </button>
                     <button
                       v-if="!item.hasInstagram"
                       @click="retrySocialPost(item.listing.id, ['instagram'])"
                       class="btn btn-sm btn-primary"
-                      :class="{ loading: retryingId === item.listing.id }"
                       :disabled="retryingId === item.listing.id"
                     >
-                      <i v-if="retryingId !== item.listing.id" class="fas fa-arrows-rotate"></i>
+                      <span v-if="retryingId === item.listing.id" class="loading loading-spinner loading-xs"></span>
+                      <i v-else class="fas fa-arrows-rotate"></i>
                       Retry IG
                     </button>
                     <button
                       v-if="!item.hasBluesky"
                       @click="retrySocialPost(item.listing.id, ['bluesky'])"
                       class="btn btn-sm btn-primary"
-                      :class="{ loading: retryingId === item.listing.id }"
                       :disabled="retryingId === item.listing.id"
                     >
-                      <i v-if="retryingId !== item.listing.id" class="fas fa-arrows-rotate"></i>
+                      <span v-if="retryingId === item.listing.id" class="loading loading-spinner loading-xs"></span>
+                      <i v-else class="fas fa-arrows-rotate"></i>
                       Retry Bsky
                     </button>
                   </div>
@@ -250,10 +250,10 @@
                   <button
                     @click="autoPostToSocials(listing.id)"
                     class="btn btn-primary btn-sm flex-1"
-                    :class="{ loading: postingId === listing.id }"
                     :disabled="postingId === listing.id"
                   >
-                    <i v-if="postingId !== listing.id" class="fas fa-paper-plane"></i>
+                    <span v-if="postingId === listing.id" class="loading loading-spinner loading-xs"></span>
+                    <i v-else class="fas fa-paper-plane"></i>
                     Post to Socials
                   </button>
                 </div>
@@ -325,11 +325,11 @@
                       <button
                         @click="autoPostToSocials(listing.id)"
                         class="btn btn-primary btn-sm"
-                        :class="{ loading: postingId === listing.id }"
                         :disabled="postingId === listing.id"
                         title="Auto-post to all social platforms"
                       >
-                        <i v-if="postingId !== listing.id" class="fas fa-paper-plane"></i>
+                        <span v-if="postingId === listing.id" class="loading loading-spinner loading-xs"></span>
+                        <i v-else class="fas fa-paper-plane"></i>
                         Post
                       </button>
                     </div>


### PR DESCRIPTION
Fixes the mangled loading spinner Cole flagged on /admin/exchange/promotions: eight buttons across the social-posting and newsletter admin pages used the daisyUI v3 `:class="{ loading }"`-on-the-btn pattern, which daisyUI 5 renders as a broken spinner mask over the button text. Converted to the [v5 button-with-loading-spinner treatment](https://daisyui.com/components/button/#button-with-loading-spinner): a `loading loading-spinner` span swaps in for the button icon while in flight. Bonus: the newsletter Send button is now disabled during send (previously only styled, so double-send was possible). Repo-wide grep confirms zero v3-style usages remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)