### PR TITLE
fix(exchange): order admin social posts by when they hit social media

### DIFF
--- a/app/pages/admin/exchange/promotions.vue
+++ b/app/pages/admin/exchange/promotions.vue
@@ -688,6 +688,7 @@
                 tier,
                 payment_status,
                 created_at,
+                promoted_on_social_at,
                 listing_photos (
                   id,
                   storage_path,
@@ -698,6 +699,10 @@
               )
               .in('id', listingIds)
               .not('status', 'in', '("example_free","example_paid")')
+              // Newest SOCIAL post first — when it went out on social media, not
+              // when the listing was created on the exchange. Legacy rows that
+              // predate promoted_on_social_at sort last, by listing age.
+              .order('promoted_on_social_at', { ascending: false, nullsFirst: false })
               .order('created_at', { ascending: false })
           );
 


### PR DESCRIPTION
Cole's report: the social-posting admin lists showed exchange-posting order, not social-posting order. The posted-listings query now selects and sorts by `promoted_on_social_at` desc (nulls last, `created_at` fallback for rows predating the column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)