### PR TITLE
feat(trust): surface contributor status — progress card, ledger labels, gate copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,12 @@ Load-bearing contracts — don't "fix" these without understanding why they're t
 - **`/mcp` auth fails closed.** Valid keys come ONLY from `MCP_API_KEY` / `MCP_API_KEYS` env vars — there is no hardcoded/default key. The old `dev-mcp-key-classic-mini-diy` default is in public git history and must never be re-accepted in any environment. For local dev, set `MCP_API_KEY` in `.env`.
 - **`SUPABASE_SERVICE_KEY` is server-only.** It lives in private `runtimeConfig` and is read only via `server/utils/supabase.ts#getServiceClient`. Never import that into `app/` or move the key to `runtimeConfig.public`.
 
+## Trust System Invariants
+
+- **Every human-reviewed approval must feed trust.** Counters + `contributions` ledger + `recalculate_trust_level()` fire DB-side (submission_queue trigger, model-version RPCs, `moderate_external_model`, listings pending→active trigger). If you add a new approval surface, it must do the same — contract: `classicminidiy-supabase/docs/plans/2026-07-13-unified-trust-pipeline.md`.
+- **Public profile reads go through the `public_profiles` view, not `profiles`.** Since the profiles split, `profiles` SELECT is own-row/admin-only; the view carries the community-facing trust columns (`trust_level`, `total_submissions`, `approved_submissions`). Querying `profiles` for another user silently returns zero rows.
+- **Trust visibility:** `DashboardTrustProgressCard` on `/dashboard/submissions` is the user-facing explanation of levels/thresholds (3 approved → contributor; 10 + <20% rejections → trusted; 30-day tenure path to contributor). Keep its copy in sync with the DB thresholds if they change.
+
 ## Environment Variables
 
 ### Required Runtime Config

--- a/app/components/dashboard/TrustProgressCard.vue
+++ b/app/components/dashboard/TrustProgressCard.vue
@@ -1,0 +1,306 @@
+<script lang="ts" setup>
+  const { t } = useI18n();
+  const { userProfile } = useAuth();
+
+  const trustLevel = computed(() => userProfile.value?.trust_level || 'new');
+  const approved = computed(() => userProfile.value?.approved_submissions ?? 0);
+  const rejected = computed(() => userProfile.value?.rejected_submissions ?? 0);
+  const total = computed(() => userProfile.value?.total_submissions ?? 0);
+
+  const rejectionRate = computed(() => (total.value > 0 ? rejected.value / total.value : 0));
+
+  const levelConfig = computed(() => {
+    const configs: Record<string, { color: string; icon: string }> = {
+      new: { color: 'neutral', icon: 'fa-seedling' },
+      contributor: { color: 'info', icon: 'fa-hand-holding-heart' },
+      trusted: { color: 'success', icon: 'fa-medal' },
+      moderator: { color: 'warning', icon: 'fa-shield-halved' },
+      admin: { color: 'primary', icon: 'fa-crown' },
+    };
+    return configs[trustLevel.value] || configs['new'];
+  });
+
+  // Next milestone: 3 approved -> contributor; 10 approved + <20% rejections -> trusted.
+  const nextLevel = computed(() => {
+    if (trustLevel.value === 'new') return 'contributor';
+    if (trustLevel.value === 'contributor') return 'trusted';
+    return null;
+  });
+
+  const nextTarget = computed(() => (nextLevel.value === 'contributor' ? 3 : 10));
+  const progressPct = computed(() => Math.min(100, Math.round((approved.value / nextTarget.value) * 100)));
+  const rejectionRateBlocks = computed(() => nextLevel.value === 'trusted' && rejectionRate.value >= 0.2);
+</script>
+
+<template>
+  <div class="card bg-base-100 shadow-sm border border-base-300">
+    <div class="card-body">
+      <div class="flex items-center justify-between flex-wrap gap-2">
+        <div class="flex items-center gap-2">
+          <i class="fad fa-ranking-star mr-2"></i>
+          <h2 class="text-lg font-semibold">{{ t('title') }}</h2>
+        </div>
+        <span class="badge badge-soft" :class="`badge-${levelConfig.color}`">
+          <i :class="`fa-duotone ${levelConfig.icon} mr-1`"></i>
+          {{ t(`level.${trustLevel}`) }}
+        </span>
+      </div>
+
+      <!-- Progress toward the next level -->
+      <div v-if="nextLevel" class="mt-2">
+        <div class="flex items-center justify-between text-sm mb-1">
+          <span class="text-base-content/70">
+            {{ t('progress_label', { next: t(`level.${nextLevel}`) }) }}
+          </span>
+          <span class="font-medium">{{ t('progress_count', { approved, target: nextTarget }) }}</span>
+        </div>
+        <progress
+          class="progress progress-primary w-full"
+          :value="approved"
+          :max="nextTarget"
+          :aria-label="t('progress_label', { next: t(`level.${nextLevel}`) })"
+        ></progress>
+        <p v-if="rejectionRateBlocks" class="text-xs text-warning mt-1">
+          <i class="fa-duotone fa-triangle-exclamation mr-1"></i>
+          {{ t('rejection_note') }}
+        </p>
+        <p v-if="trustLevel === 'new'" class="text-xs text-base-content/60 mt-1">
+          <i class="fa-duotone fa-clock mr-1"></i>
+          {{ t('tenure_note') }}
+        </p>
+      </div>
+      <p v-else class="text-sm text-base-content/70 mt-2">
+        <i class="fa-duotone fa-circle-check text-success mr-1"></i>
+        {{ t('max_level') }}
+      </p>
+
+      <!-- What counts -->
+      <p class="text-sm text-base-content/60 mt-2">
+        {{ t('what_counts') }}
+      </p>
+
+      <!-- What unlocks -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+        <div class="rounded-lg border border-base-300 p-3">
+          <p class="text-sm font-semibold">
+            <i class="fa-duotone fa-hand-holding-heart text-info mr-1"></i>
+            {{ t('level.contributor') }}
+          </p>
+          <p class="text-xs text-base-content/60 mt-1">{{ t('unlocks.contributor') }}</p>
+        </div>
+        <div class="rounded-lg border border-base-300 p-3">
+          <p class="text-sm font-semibold">
+            <i class="fa-duotone fa-medal text-success mr-1"></i>
+            {{ t('level.trusted') }}
+          </p>
+          <p class="text-xs text-base-content/60 mt-1">{{ t('unlocks.trusted') }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Contributor Status",
+    "level": {
+      "new": "New Member",
+      "contributor": "Contributor",
+      "trusted": "Trusted Contributor",
+      "moderator": "Moderator",
+      "admin": "Admin"
+    },
+    "progress_label": "Progress to {next}",
+    "progress_count": "{approved} of {target} approved",
+    "rejection_note": "Trusted status also needs fewer than 1 in 5 of your submissions rejected.",
+    "tenure_note": "Members for 30+ days who are active on Classic Mini DIY or The Mini Exchange are upgraded to Contributor automatically.",
+    "max_level": "You are at the highest community level. Thank you for everything you contribute!",
+    "what_counts": "Every approved contribution counts: archive documents, registry entries, colors, wheels, 3D models, external finds, and Exchange listings.",
+    "unlocks": {
+      "contributor": "Comments post instantly and you can sell 3D models.",
+      "trusted": "Your uploads publish immediately without review."
+    }
+  },
+  "es": {
+    "title": "Estado de Colaborador",
+    "level": {
+      "new": "Nuevo Miembro",
+      "contributor": "Colaborador",
+      "trusted": "Colaborador de Confianza",
+      "moderator": "Moderador",
+      "admin": "Admin"
+    },
+    "progress_label": "Progreso hacia {next}",
+    "progress_count": "{approved} de {target} aprobados",
+    "rejection_note": "El estado de confianza también requiere menos de 1 de cada 5 envíos rechazados.",
+    "tenure_note": "Los miembros con más de 30 días activos en Classic Mini DIY o The Mini Exchange ascienden a Colaborador automáticamente.",
+    "max_level": "Estás en el nivel comunitario más alto. ¡Gracias por todo lo que aportas!",
+    "what_counts": "Cada contribución aprobada cuenta: documentos de archivo, entradas del registro, colores, ruedas, modelos 3D, hallazgos externos y anuncios del Exchange.",
+    "unlocks": {
+      "contributor": "Los comentarios se publican al instante y puedes vender modelos 3D.",
+      "trusted": "Tus subidas se publican de inmediato sin revisión."
+    }
+  },
+  "fr": {
+    "title": "Statut de Contributeur",
+    "level": {
+      "new": "Nouveau Membre",
+      "contributor": "Contributeur",
+      "trusted": "Contributeur de Confiance",
+      "moderator": "Modérateur",
+      "admin": "Admin"
+    },
+    "progress_label": "Progression vers {next}",
+    "progress_count": "{approved} sur {target} approuvés",
+    "rejection_note": "Le statut de confiance exige aussi moins d'1 soumission sur 5 rejetée.",
+    "tenure_note": "Les membres depuis plus de 30 jours actifs sur Classic Mini DIY ou The Mini Exchange passent automatiquement Contributeur.",
+    "max_level": "Vous êtes au niveau communautaire le plus élevé. Merci pour toutes vos contributions !",
+    "what_counts": "Chaque contribution approuvée compte : documents d'archive, entrées du registre, couleurs, roues, modèles 3D, trouvailles externes et annonces de l'Exchange.",
+    "unlocks": {
+      "contributor": "Les commentaires sont publiés instantanément et vous pouvez vendre des modèles 3D.",
+      "trusted": "Vos envois sont publiés immédiatement sans relecture."
+    }
+  },
+  "de": {
+    "title": "Beitragsstatus",
+    "level": {
+      "new": "Neues Mitglied",
+      "contributor": "Beitragende",
+      "trusted": "Vertrauenswürdige Beitragende",
+      "moderator": "Moderator",
+      "admin": "Admin"
+    },
+    "progress_label": "Fortschritt zu {next}",
+    "progress_count": "{approved} von {target} genehmigt",
+    "rejection_note": "Für den Vertrauensstatus darf zudem weniger als 1 von 5 Einreichungen abgelehnt sein.",
+    "tenure_note": "Mitglieder mit 30+ Tagen, die auf Classic Mini DIY oder The Mini Exchange aktiv sind, werden automatisch zu Beitragenden hochgestuft.",
+    "max_level": "Du bist auf der höchsten Community-Stufe. Danke für alles, was du beiträgst!",
+    "what_counts": "Jeder genehmigte Beitrag zählt: Archivdokumente, Verzeichniseinträge, Farben, Felgen, 3D-Modelle, externe Funde und Exchange-Anzeigen.",
+    "unlocks": {
+      "contributor": "Kommentare erscheinen sofort und du kannst 3D-Modelle verkaufen.",
+      "trusted": "Deine Uploads werden sofort ohne Prüfung veröffentlicht."
+    }
+  },
+  "it": {
+    "title": "Stato Collaboratore",
+    "level": {
+      "new": "Nuovo Membro",
+      "contributor": "Collaboratore",
+      "trusted": "Collaboratore di Fiducia",
+      "moderator": "Moderatore",
+      "admin": "Admin"
+    },
+    "progress_label": "Progresso verso {next}",
+    "progress_count": "{approved} di {target} approvati",
+    "rejection_note": "Lo stato di fiducia richiede anche meno di 1 invio su 5 rifiutato.",
+    "tenure_note": "I membri da oltre 30 giorni attivi su Classic Mini DIY o The Mini Exchange diventano Collaboratori automaticamente.",
+    "max_level": "Sei al livello più alto della community. Grazie per tutto ciò che contribuisci!",
+    "what_counts": "Ogni contributo approvato conta: documenti d'archivio, voci del registro, colori, ruote, modelli 3D, scoperte esterne e annunci dell'Exchange.",
+    "unlocks": {
+      "contributor": "I commenti vengono pubblicati subito e puoi vendere modelli 3D.",
+      "trusted": "I tuoi caricamenti vengono pubblicati immediatamente senza revisione."
+    }
+  },
+  "pt": {
+    "title": "Status de Colaborador",
+    "level": {
+      "new": "Novo Membro",
+      "contributor": "Colaborador",
+      "trusted": "Colaborador de Confiança",
+      "moderator": "Moderador",
+      "admin": "Admin"
+    },
+    "progress_label": "Progresso para {next}",
+    "progress_count": "{approved} de {target} aprovados",
+    "rejection_note": "O status de confiança também exige menos de 1 em cada 5 envios rejeitados.",
+    "tenure_note": "Membros há mais de 30 dias ativos no Classic Mini DIY ou The Mini Exchange sobem a Colaborador automaticamente.",
+    "max_level": "Você está no nível mais alto da comunidade. Obrigado por tudo que você contribui!",
+    "what_counts": "Toda contribuição aprovada conta: documentos de arquivo, entradas do registro, cores, rodas, modelos 3D, achados externos e anúncios do Exchange.",
+    "unlocks": {
+      "contributor": "Comentários são publicados na hora e você pode vender modelos 3D.",
+      "trusted": "Seus envios são publicados imediatamente sem revisão."
+    }
+  },
+  "ru": {
+    "title": "Статус участника",
+    "level": {
+      "new": "Новый участник",
+      "contributor": "Участник",
+      "trusted": "Доверенный участник",
+      "moderator": "Модератор",
+      "admin": "Администратор"
+    },
+    "progress_label": "Прогресс до уровня «{next}»",
+    "progress_count": "{approved} из {target} одобрено",
+    "rejection_note": "Для доверенного статуса также нужно, чтобы отклонялось менее 1 из 5 заявок.",
+    "tenure_note": "Участники со стажем более 30 дней, активные на Classic Mini DIY или The Mini Exchange, автоматически получают уровень «Участник».",
+    "max_level": "Вы на высшем уровне сообщества. Спасибо за ваш вклад!",
+    "what_counts": "Учитывается каждый одобренный вклад: архивные документы, записи реестра, цвета, колёса, 3D-модели, внешние находки и объявления Exchange.",
+    "unlocks": {
+      "contributor": "Комментарии публикуются мгновенно, и вы можете продавать 3D-модели.",
+      "trusted": "Ваши загрузки публикуются сразу, без проверки."
+    }
+  },
+  "ja": {
+    "title": "投稿者ステータス",
+    "level": {
+      "new": "新規メンバー",
+      "contributor": "投稿者",
+      "trusted": "信頼された投稿者",
+      "moderator": "モデレーター",
+      "admin": "管理者"
+    },
+    "progress_label": "{next}への進捗",
+    "progress_count": "{target}件中{approved}件承認済み",
+    "rejection_note": "信頼ステータスには、却下が5件中1件未満であることも必要です。",
+    "tenure_note": "登録から30日以上で Classic Mini DIY または The Mini Exchange で活動しているメンバーは、自動的に投稿者に昇格します。",
+    "max_level": "コミュニティの最高レベルに到達しています。ご貢献ありがとうございます!",
+    "what_counts": "承認されたすべての貢献が対象です: アーカイブ文書、レジストリ登録、カラー、ホイール、3Dモデル、外部リンク、Exchange の出品。",
+    "unlocks": {
+      "contributor": "コメントが即時公開され、3Dモデルを販売できます。",
+      "trusted": "アップロードが審査なしで即時公開されます。"
+    }
+  },
+  "zh": {
+    "title": "贡献者状态",
+    "level": {
+      "new": "新成员",
+      "contributor": "贡献者",
+      "trusted": "受信任的贡献者",
+      "moderator": "版主",
+      "admin": "管理员"
+    },
+    "progress_label": "距离{next}的进度",
+    "progress_count": "已批准 {approved} / {target}",
+    "rejection_note": "获得受信任状态还需要被拒绝的提交少于五分之一。",
+    "tenure_note": "注册满 30 天且在 Classic Mini DIY 或 The Mini Exchange 上活跃的成员会自动升级为贡献者。",
+    "max_level": "您已达到社区最高等级。感谢您的所有贡献!",
+    "what_counts": "每一个获批准的贡献都算数: 档案文档、注册表条目、颜色、轮毂、3D 模型、外部发现以及 Exchange 的商品。",
+    "unlocks": {
+      "contributor": "评论即时发布，并且可以出售 3D 模型。",
+      "trusted": "您的上传无需审核即刻发布。"
+    }
+  },
+  "ko": {
+    "title": "기여자 상태",
+    "level": {
+      "new": "신규 멤버",
+      "contributor": "기여자",
+      "trusted": "신뢰된 기여자",
+      "moderator": "모더레이터",
+      "admin": "관리자"
+    },
+    "progress_label": "{next}까지의 진행률",
+    "progress_count": "{target}건 중 {approved}건 승인됨",
+    "rejection_note": "신뢰 상태가 되려면 거부된 제출이 5건 중 1건 미만이어야 합니다.",
+    "tenure_note": "가입 30일 이상이며 Classic Mini DIY 또는 The Mini Exchange에서 활동한 멤버는 자동으로 기여자로 승급됩니다.",
+    "max_level": "커뮤니티 최고 레벨에 도달했습니다. 모든 기여에 감사드립니다!",
+    "what_counts": "승인된 모든 기여가 반영됩니다: 아카이브 문서, 레지스트리 등록, 색상, 휠, 3D 모델, 외부 발견, Exchange 판매글.",
+    "unlocks": {
+      "contributor": "댓글이 즉시 게시되고 3D 모델을 판매할 수 있습니다.",
+      "trusted": "업로드가 검토 없이 즉시 게시됩니다."
+    }
+  }
+}
+</i18n>

--- a/app/components/dashboard/TrustProgressCard.vue
+++ b/app/components/dashboard/TrustProgressCard.vue
@@ -28,7 +28,6 @@
   });
 
   const nextTarget = computed(() => (nextLevel.value === 'contributor' ? 3 : 10));
-  const progressPct = computed(() => Math.min(100, Math.round((approved.value / nextTarget.value) * 100)));
   const rejectionRateBlocks = computed(() => nextLevel.value === 'trusted' && rejectionRate.value >= 0.2);
 </script>
 

--- a/app/components/models/ModelComments.vue
+++ b/app/components/models/ModelComments.vue
@@ -173,7 +173,7 @@
   "en": {
     "title": "Comments ({count})",
     "placeholder": "Share tips, ask a question…",
-    "pendingModeration": "Your comment is awaiting moderation.",
+    "pendingModeration": "Your comment is awaiting moderation — first comments from new members are reviewed. Contributors post instantly.",
     "post": "Post",
     "signIn": "Sign in",
     "joinConversation": "to join the conversation.",
@@ -188,7 +188,7 @@
   "es": {
     "title": "Comentarios ({count})",
     "placeholder": "Comparte consejos, haz una pregunta…",
-    "pendingModeration": "Tu comentario está pendiente de moderación.",
+    "pendingModeration": "Tu comentario está pendiente de moderación — los primeros comentarios de miembros nuevos se revisan. Los colaboradores publican al instante.",
     "post": "Publicar",
     "signIn": "Inicia sesión",
     "joinConversation": "para unirte a la conversación.",
@@ -203,7 +203,7 @@
   "fr": {
     "title": "Commentaires ({count})",
     "placeholder": "Partagez des astuces, posez une question…",
-    "pendingModeration": "Votre commentaire est en attente de modération.",
+    "pendingModeration": "Votre commentaire est en attente de modération — les premiers commentaires des nouveaux membres sont relus. Les contributeurs publient instantanément.",
     "post": "Publier",
     "signIn": "Connectez-vous",
     "joinConversation": "pour rejoindre la conversation.",
@@ -218,7 +218,7 @@
   "de": {
     "title": "Kommentare ({count})",
     "placeholder": "Tipps teilen, eine Frage stellen…",
-    "pendingModeration": "Ihr Kommentar wartet auf Moderation.",
+    "pendingModeration": "Ihr Kommentar wartet auf Moderation — erste Kommentare neuer Mitglieder werden geprüft. Beitragende posten sofort.",
     "post": "Posten",
     "signIn": "Anmelden",
     "joinConversation": "um an der Unterhaltung teilzunehmen.",
@@ -233,7 +233,7 @@
   "it": {
     "title": "Commenti ({count})",
     "placeholder": "Condividi consigli, fai una domanda…",
-    "pendingModeration": "Il tuo commento è in attesa di moderazione.",
+    "pendingModeration": "Il tuo commento è in attesa di moderazione — i primi commenti dei nuovi membri vengono revisionati. I collaboratori pubblicano subito.",
     "post": "Pubblica",
     "signIn": "Accedi",
     "joinConversation": "per partecipare alla conversazione.",
@@ -248,7 +248,7 @@
   "pt": {
     "title": "Comentários ({count})",
     "placeholder": "Compartilhe dicas, faça uma pergunta…",
-    "pendingModeration": "Seu comentário está aguardando moderação.",
+    "pendingModeration": "Seu comentário está aguardando moderação — os primeiros comentários de novos membros são revisados. Colaboradores publicam na hora.",
     "post": "Publicar",
     "signIn": "Entre",
     "joinConversation": "para participar da conversa.",
@@ -263,7 +263,7 @@
   "ru": {
     "title": "Комментарии ({count})",
     "placeholder": "Поделитесь советами, задайте вопрос…",
-    "pendingModeration": "Ваш комментарий ожидает модерации.",
+    "pendingModeration": "Ваш комментарий ожидает модерации — первые комментарии новых участников проверяются. Участники публикуют мгновенно.",
     "post": "Отправить",
     "signIn": "Войдите",
     "joinConversation": "чтобы присоединиться к разговору.",
@@ -278,7 +278,7 @@
   "ja": {
     "title": "コメント ({count})",
     "placeholder": "ヒントを共有したり、質問したりしましょう…",
-    "pendingModeration": "コメントは審査待ちです。",
+    "pendingModeration": "コメントは審査待ちです — 新規メンバーの最初のコメントは審査されます。投稿者は即時公開されます。",
     "post": "投稿",
     "signIn": "ログイン",
     "joinConversation": "して会話に参加しましょう。",
@@ -293,7 +293,7 @@
   "zh": {
     "title": "评论 ({count})",
     "placeholder": "分享技巧，提出问题…",
-    "pendingModeration": "您的评论正在等待审核。",
+    "pendingModeration": "您的评论正在等待审核 — 新成员的首批评论需要审核。贡献者可即时发布。",
     "post": "发布",
     "signIn": "登录",
     "joinConversation": "加入讨论。",
@@ -308,7 +308,7 @@
   "ko": {
     "title": "댓글 ({count})",
     "placeholder": "팁을 공유하거나 질문하세요…",
-    "pendingModeration": "댓글이 검토 중입니다.",
+    "pendingModeration": "댓글이 검토 중입니다 — 신규 멤버의 첫 댓글은 검토를 거칩니다. 기여자는 즉시 게시됩니다.",
     "post": "게시",
     "signIn": "로그인",
     "joinConversation": "하여 대화에 참여하세요.",

--- a/app/composables/useContributions.ts
+++ b/app/composables/useContributions.ts
@@ -1,7 +1,7 @@
 export interface ContributionItem {
   id: string;
   action: 'submitted' | 'edited' | 'approved' | 'rejected';
-  targetType: 'document' | 'collection' | 'registry' | 'color' | 'wheel';
+  targetType: 'document' | 'collection' | 'registry' | 'color' | 'wheel' | 'model_version' | 'external_model' | 'listing';
   targetId: string;
   targetTitle: string | null;
   details: string | null;
@@ -33,8 +33,11 @@ export const useContributions = () => {
   });
 
   const getContributorProfile = async (userId: string): Promise<ContributorProfile | null> => {
+    // public_profiles, not profiles: since the profiles split, profiles is
+    // own-row/admin SELECT only — the view is the safe public projection and
+    // carries the community-facing trust columns (20260713000007).
     const { data, error } = await supabase
-      .from('profiles')
+      .from('public_profiles')
       .select('id, display_name, avatar_url, bio, trust_level, total_submissions, approved_submissions, created_at')
       .eq('id', userId)
       .maybeSingle();

--- a/app/pages/contributors/[id].vue
+++ b/app/pages/contributors/[id].vue
@@ -66,6 +66,9 @@
       registry: 'fa-clipboard-list',
       color: 'fa-palette',
       wheel: 'fa-tire',
+      model_version: 'fa-cube',
+      external_model: 'fa-up-right-from-square',
+      listing: 'fa-store',
     };
     return icons[targetType] || 'fa-file';
   };
@@ -234,6 +237,27 @@
                   <p class="text-xs text-base-content/60">{{ t('stats_breakdown.wheels') }}</p>
                 </div>
               </div>
+              <div v-if="stats!['model_version']" class="flex items-center gap-3">
+                <i class="fa-duotone fa-cube text-2xl text-secondary"></i>
+                <div>
+                  <p class="font-bold text-xl">{{ stats!['model_version'] }}</p>
+                  <p class="text-xs text-base-content/60">{{ t('contributions.target.model_version') }}</p>
+                </div>
+              </div>
+              <div v-if="stats!['external_model']" class="flex items-center gap-3">
+                <i class="fa-duotone fa-up-right-from-square text-2xl text-info"></i>
+                <div>
+                  <p class="font-bold text-xl">{{ stats!['external_model'] }}</p>
+                  <p class="text-xs text-base-content/60">{{ t('contributions.target.external_model') }}</p>
+                </div>
+              </div>
+              <div v-if="stats!['listing']" class="flex items-center gap-3">
+                <i class="fa-duotone fa-store text-2xl text-warning"></i>
+                <div>
+                  <p class="font-bold text-xl">{{ stats!['listing'] }}</p>
+                  <p class="text-xs text-base-content/60">{{ t('contributions.target.listing') }}</p>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -328,7 +352,10 @@
         "collection": "Collection",
         "registry": "Registry",
         "color": "Color",
-        "wheel": "Wheel"
+        "wheel": "Wheel",
+        "model_version": "3D Model",
+        "external_model": "External Find",
+        "listing": "Exchange Listing"
       }
     },
     "stats_breakdown": {
@@ -382,7 +409,10 @@
         "collection": "Sammlung",
         "registry": "Verzeichnis",
         "color": "Farbe",
-        "wheel": "Felge"
+        "wheel": "Felge",
+        "model_version": "3D-Modell",
+        "external_model": "Externer Fund",
+        "listing": "Exchange-Anzeige"
       }
     },
     "stats_breakdown": {
@@ -436,7 +466,10 @@
         "collection": "Colección",
         "registry": "Registro",
         "color": "Color",
-        "wheel": "Rueda"
+        "wheel": "Rueda",
+        "model_version": "Modelo 3D",
+        "external_model": "Hallazgo Externo",
+        "listing": "Anuncio del Exchange"
       }
     },
     "stats_breakdown": {
@@ -490,7 +523,10 @@
         "collection": "Collection",
         "registry": "Registre",
         "color": "Couleur",
-        "wheel": "Roue"
+        "wheel": "Roue",
+        "model_version": "Modèle 3D",
+        "external_model": "Trouvaille Externe",
+        "listing": "Annonce Exchange"
       }
     },
     "stats_breakdown": {
@@ -544,7 +580,10 @@
         "collection": "Collezione",
         "registry": "Registro",
         "color": "Colore",
-        "wheel": "Ruota"
+        "wheel": "Ruota",
+        "model_version": "Modello 3D",
+        "external_model": "Scoperta Esterna",
+        "listing": "Annuncio Exchange"
       }
     },
     "stats_breakdown": {
@@ -598,7 +637,10 @@
         "collection": "Coleção",
         "registry": "Registro",
         "color": "Cor",
-        "wheel": "Roda"
+        "wheel": "Roda",
+        "model_version": "Modelo 3D",
+        "external_model": "Achado Externo",
+        "listing": "Anúncio do Exchange"
       }
     },
     "stats_breakdown": {
@@ -652,7 +694,10 @@
         "collection": "Коллекция",
         "registry": "Реестр",
         "color": "Цвет",
-        "wheel": "Колесо"
+        "wheel": "Колесо",
+        "model_version": "3D-модель",
+        "external_model": "Внешняя находка",
+        "listing": "Объявление Exchange"
       }
     },
     "stats_breakdown": {
@@ -706,7 +751,10 @@
         "collection": "コレクション",
         "registry": "レジストリ",
         "color": "カラー",
-        "wheel": "ホイール"
+        "wheel": "ホイール",
+        "model_version": "3Dモデル",
+        "external_model": "外部リンク",
+        "listing": "Exchange出品"
       }
     },
     "stats_breakdown": {
@@ -760,7 +808,10 @@
         "collection": "集合",
         "registry": "注册表",
         "color": "颜色",
-        "wheel": "轮毂"
+        "wheel": "轮毂",
+        "model_version": "3D 模型",
+        "external_model": "外部发现",
+        "listing": "Exchange 商品"
       }
     },
     "stats_breakdown": {
@@ -814,7 +865,10 @@
         "collection": "컬렉션",
         "registry": "레지스트리",
         "color": "색상",
-        "wheel": "휠"
+        "wheel": "휠",
+        "model_version": "3D 모델",
+        "external_model": "외부 발견",
+        "listing": "Exchange 판매글"
       }
     },
     "stats_breakdown": {

--- a/app/pages/dashboard/selling.vue
+++ b/app/pages/dashboard/selling.vue
@@ -163,7 +163,10 @@
 
           <div v-if="!trustOk" role="alert" class="alert alert-warning alert-soft text-sm">
             <i class="fas fa-lock"></i>
-            <span>{{ t('onboarding.trustWarning', { level: trustLevel }) }}</span>
+            <span>
+              {{ t('onboarding.trustWarning', { level: trustLevel }) }}
+              <NuxtLink to="/dashboard/submissions" class="link">{{ t('onboarding.trustStatusLink') }}</NuxtLink>
+            </span>
           </div>
 
           <div v-if="onboardError" role="alert" class="alert alert-error alert-soft text-sm">
@@ -317,6 +320,7 @@
       "bullet2": "Buyers get every version, past and future",
       "bullet3": "Payouts, refunds, and taxes handled in Stripe",
       "trustWarning": "Selling unlocks at contributor trust. Share a model or contribute to the archive to get there — your current level is {level}.",
+      "trustStatusLink": "See your contributor status",
       "startBtn": "Start selling with Stripe",
       "continueBtn": "Continue Stripe onboarding",
       "redirectNote": "You'll be redirected to Stripe to set up payouts, then back here."
@@ -357,6 +361,7 @@
       "bullet2": "Los compradores obtienen todas las versiones, pasadas y futuras",
       "bullet3": "Pagos, reembolsos e impuestos gestionados en Stripe",
       "trustWarning": "Las ventas se desbloquean con el nivel de confianza contribuidor. Comparte un modelo o contribuye al archivo para llegar ahí — tu nivel actual es {level}.",
+      "trustStatusLink": "Ver tu estado de colaborador",
       "startBtn": "Empieza a vender con Stripe",
       "continueBtn": "Continuar el registro en Stripe",
       "redirectNote": "Serás redirigido a Stripe para configurar los pagos y luego volverás aquí."
@@ -397,6 +402,7 @@
       "bullet2": "Les acheteurs reçoivent toutes les versions, passées et futures",
       "bullet3": "Paiements, remboursements et taxes gérés dans Stripe",
       "trustWarning": "Les ventes se débloquent au niveau de confiance contributeur. Partagez un modèle ou contribuez aux archives pour y parvenir — votre niveau actuel est {level}.",
+      "trustStatusLink": "Voir votre statut de contributeur",
       "startBtn": "Commencer à vendre avec Stripe",
       "continueBtn": "Continuer l'inscription Stripe",
       "redirectNote": "Vous serez redirigé vers Stripe pour configurer les paiements, puis ramené ici."
@@ -437,6 +443,7 @@
       "bullet2": "Käufer erhalten jede Version, vergangene und zukünftige",
       "bullet3": "Auszahlungen, Rückerstattungen und Steuern werden in Stripe verwaltet",
       "trustWarning": "Verkaufen wird mit dem Vertrauenslevel Beitragender freigeschaltet. Teile ein Modell oder trage zum Archiv bei, um es zu erreichen — dein aktuelles Level ist {level}.",
+      "trustStatusLink": "Deinen Beitragsstatus ansehen",
       "startBtn": "Mit Stripe verkaufen starten",
       "continueBtn": "Stripe-Onboarding fortsetzen",
       "redirectNote": "Du wirst zu Stripe weitergeleitet, um Auszahlungen einzurichten, und dann zurück hierher."
@@ -477,6 +484,7 @@
       "bullet2": "Gli acquirenti ricevono ogni versione, passata e futura",
       "bullet3": "Pagamenti, rimborsi e tasse gestiti in Stripe",
       "trustWarning": "Le vendite si sbloccano al livello di fiducia collaboratore. Condividi un modello o contribuisci all'archivio per arrivarci — il tuo livello attuale è {level}.",
+      "trustStatusLink": "Vedi il tuo stato di collaboratore",
       "startBtn": "Inizia a vendere con Stripe",
       "continueBtn": "Continua l'iscrizione a Stripe",
       "redirectNote": "Verrai reindirizzato a Stripe per configurare i pagamenti, poi tornerai qui."
@@ -517,6 +525,7 @@
       "bullet2": "Compradores recebem todas as versões, passadas e futuras",
       "bullet3": "Pagamentos, reembolsos e impostos gerenciados no Stripe",
       "trustWarning": "As vendas se desbloqueiam no nível de confiança colaborador. Compartilhe um modelo ou contribua com o arquivo para chegar lá — seu nível atual é {level}.",
+      "trustStatusLink": "Ver seu status de colaborador",
       "startBtn": "Comece a vender com o Stripe",
       "continueBtn": "Continuar integração com o Stripe",
       "redirectNote": "Você será redirecionado ao Stripe para configurar os pagamentos e, em seguida, voltará aqui."
@@ -557,6 +566,7 @@
       "bullet2": "Покупатели получают все версии — прошлые и будущие",
       "bullet3": "Выплаты, возвраты и налоги управляются в Stripe",
       "trustWarning": "Продажи открываются на уровне доверия участник. Поделитесь моделью или внесите вклад в архив, чтобы достичь его — ваш текущий уровень: {level}.",
+      "trustStatusLink": "Посмотреть статус участника",
       "startBtn": "Начать продажи через Stripe",
       "continueBtn": "Продолжить регистрацию в Stripe",
       "redirectNote": "Вы будете перенаправлены на Stripe для настройки выплат, а затем вернётесь сюда."
@@ -597,6 +607,7 @@
       "bullet2": "購入者は過去・未来のすべてのバージョンを入手できます",
       "bullet3": "支払い、返金、税金はStripeで管理",
       "trustWarning": "販売はコントリビューターの信頼レベルで解除されます。モデルをシェアするかアーカイブに貢献してください — 現在のレベルは{level}です。",
+      "trustStatusLink": "投稿者ステータスを見る",
       "startBtn": "Stripeで販売を開始する",
       "continueBtn": "Stripeオンボーディングを続ける",
       "redirectNote": "支払いを設定するためStripeにリダイレクトされ、その後こちらに戻ります。"
@@ -637,6 +648,7 @@
       "bullet2": "买家获得所有版本，包括过去和未来的",
       "bullet3": "付款、退款和税务均在Stripe中处理",
       "trustWarning": "在贡献者信任等级时解锁销售功能。分享模型或为存档做贡献即可达到——您当前的等级是{level}。",
+      "trustStatusLink": "查看您的贡献者状态",
       "startBtn": "通过Stripe开始销售",
       "continueBtn": "继续Stripe入驻",
       "redirectNote": "您将被重定向到Stripe设置付款，然后返回此处。"
@@ -677,6 +689,7 @@
       "bullet2": "구매자는 과거와 미래의 모든 버전을 받습니다",
       "bullet3": "지급, 환불, 세금은 Stripe에서 처리됩니다",
       "trustWarning": "판매는 기여자 신뢰 수준에서 잠금 해제됩니다. 모델을 공유하거나 아카이브에 기여하여 도달하세요 — 현재 레벨은 {level}입니다.",
+      "trustStatusLink": "기여자 상태 보기",
       "startBtn": "Stripe로 판매 시작하기",
       "continueBtn": "Stripe 온보딩 계속하기",
       "redirectNote": "지급을 설정하기 위해 Stripe로 이동하며, 그 후 여기로 돌아옵니다."

--- a/app/pages/dashboard/submissions.vue
+++ b/app/pages/dashboard/submissions.vue
@@ -103,6 +103,7 @@
 </script>
 
 <template>
+  <DashboardTrustProgressCard class="mb-6" />
   <div class="card bg-base-100 shadow-sm border border-base-300">
     <div class="card-body">
       <div class="flex items-center justify-between">

--- a/tests/unit/composables/useContributions.test.ts
+++ b/tests/unit/composables/useContributions.test.ts
@@ -40,7 +40,7 @@ const makeContributionRow = (overrides: Record<string, any> = {}) => ({
 
 describe('useContributions', () => {
   describe('getContributorProfile()', () => {
-    it('queries profiles table by userId with maybeSingle()', async () => {
+    it('queries the public_profiles view by userId with maybeSingle()', async () => {
       const profileRow = makeProfileRow();
       mockSupabase._mockMaybeSingle.mockResolvedValue({
         data: profileRow,
@@ -51,7 +51,7 @@ describe('useContributions', () => {
       const { getContributorProfile } = useContributions();
       await getContributorProfile('user-1');
 
-      expect(mockSupabase.from).toHaveBeenCalledWith('profiles');
+      expect(mockSupabase.from).toHaveBeenCalledWith('public_profiles');
       expect(mockSupabase._mockSelect).toHaveBeenCalledWith(
         'id, display_name, avatar_url, bio, trust_level, total_submissions, approved_submissions, created_at'
       );

--- a/types/database.ts
+++ b/types/database.ts
@@ -3958,6 +3958,7 @@ export type Database = {
       }
       public_profiles: {
         Row: {
+          approved_submissions: number | null
           avatar_url: string | null
           bio: string | null
           created_at: string | null
@@ -3966,10 +3967,13 @@ export type Database = {
           location: string | null
           show_vehicles: boolean | null
           social_links: Json | null
+          total_submissions: number | null
+          trust_level: Database["public"]["Enums"]["trust_level_enum"] | null
           updated_at: string | null
           username: string | null
         }
         Insert: {
+          approved_submissions?: number | null
           avatar_url?: string | null
           bio?: string | null
           created_at?: string | null
@@ -3978,10 +3982,13 @@ export type Database = {
           location?: string | null
           show_vehicles?: boolean | null
           social_links?: Json | null
+          total_submissions?: number | null
+          trust_level?: Database["public"]["Enums"]["trust_level_enum"] | null
           updated_at?: string | null
           username?: string | null
         }
         Update: {
+          approved_submissions?: number | null
           avatar_url?: string | null
           bio?: string | null
           created_at?: string | null
@@ -3990,6 +3997,8 @@ export type Database = {
           location?: string | null
           show_vehicles?: boolean | null
           social_links?: Json | null
+          total_submissions?: number | null
+          trust_level?: Database["public"]["Enums"]["trust_level_enum"] | null
           updated_at?: string | null
           username?: string | null
         }

--- a/types/database.ts
+++ b/types/database.ts
@@ -2945,7 +2945,7 @@ export type Database = {
           bio: string | null
           created_at: string | null
           display_name: string | null
-          email: string
+          email: string | null
           firebase_uid: string | null
           id: string
           is_admin: boolean | null
@@ -2973,7 +2973,7 @@ export type Database = {
           bio?: string | null
           created_at?: string | null
           display_name?: string | null
-          email: string
+          email?: string | null
           firebase_uid?: string | null
           id: string
           is_admin?: boolean | null
@@ -3001,7 +3001,7 @@ export type Database = {
           bio?: string | null
           created_at?: string | null
           display_name?: string | null
-          email?: string
+          email?: string | null
           firebase_uid?: string | null
           id?: string
           is_admin?: boolean | null
@@ -4011,7 +4011,6 @@ export type Database = {
         Args: { p_user_id: string }
         Returns: number
       }
-      approve_listing_edit: { Args: { edit_id: string }; Returns: boolean }
       approve_model_version: {
         Args: { p_notes?: string; p_version_id: string }
         Returns: undefined
@@ -4258,6 +4257,7 @@ export type Database = {
         Args: { p_id: string; p_notes?: string; p_status: string }
         Returns: undefined
       }
+      promote_tenured_users: { Args: never; Returns: number }
       publish_model_version: {
         Args: { p_version_id: string }
         Returns: undefined
@@ -4495,6 +4495,8 @@ export type Database = {
         | "color"
         | "wheel"
         | "model_version"
+        | "external_model"
+        | "listing"
       trust_level_enum:
         | "new"
         | "contributor"
@@ -4817,6 +4819,8 @@ export const Constants = {
         "color",
         "wheel",
         "model_version",
+        "external_model",
+        "listing",
       ],
       trust_level_enum: ["new", "contributor", "trusted", "moderator", "admin"],
       underside_condition_enum: ["excellent", "good", "fair", "needs_work"],


### PR DESCRIPTION
## Why

Companion to [supabase#57](https://github.com/ClassicMiniDIY/classicminidiy-supabase/pull/57) (trust pipeline unification). Trust was completely invisible to users — they only felt the gates (comments held for review, seller onboarding blocked) with no explanation, which read as broken onboarding.

## What

- **`DashboardTrustProgressCard`** on `/dashboard/submissions`: current level badge, progress bar to contributor (3 approved) / trusted (10 + <20% rejections), the 30-day tenure note, what-counts copy listing every surface, and unlock tiles. Full 10-locale i18n block, FA6 icons.
- **`/contributors/[id]` fixed + extended**: now reads `public_profiles` instead of `profiles` — the profiles split made `profiles` own-row-only, so the page silently showed "Contributor Not Found" for everyone. Adds icons/labels/breakdown tiles for the `model_version`, `external_model`, and `listing` ledger types (`model_version` was already leaking as a raw i18n key).
- **Gate copy**: comment-pending note now explains moderation skips at contributor; the seller trust-gate links to the status card.
- **Types regenerated** (new `target_type_enum` values).

Requires supabase migration `20260713000007` (public_profiles trust columns) in prod for the contributor-page fix — see supabase#57 deploy status.

## Verification

Verified end-to-end against the local Supabase stack (magic-link login as a seeded test user): card renders with live counters ("1 of 3 approved"), contributor page resolves via the view and shows "External Find" ledger entries. `bun run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)