### PR TITLE
fix(chat): stop hydration DOM corruption on /chat refresh with a persisted thread

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ A weekly remote agent updates the rolling [Weekly Cascade Report](https://github
 - **CMDIY Assistant** - LangGraph-powered conversational AI with context awareness
 - **Model Context Protocol (MCP) Server** - AI integration with calculators and tools
 - **Streaming Responses** - Real-time AI chat with persistent conversation threads
+- **Hydration invariant**: `/chat` is SSR'd and the server always renders the empty/welcome branch. The persisted thread (localStorage, `usePersistentThread`) is read synchronously during setup, so nothing may branch the template on it until after `onMounted` (see `hasMounted` gate in `ChatWindow.vue`) — otherwise refreshing with a <24h-old thread causes a structural hydration mismatch that corrupts the page DOM. Also note `createStreamSession()`/`provideStreamContext()` call `useI18n()`/`provide()` and must keep running synchronously during setup (the `immediate: true` watch), never deferred to post-mount.
 
 #### Administrative Features (`app/admin`)
 

--- a/app/components/Chat/ChatWindow.vue
+++ b/app/components/Chat/ChatWindow.vue
@@ -16,9 +16,9 @@
                   {{ t('welcome_title') }}
                 </h3>
                 <p class="text-base opacity-70 leading-relaxed">
-                  I'm your Classic Mini DIY assistant, here to help you with technical questions, decode chassis numbers,
-                  find parts information, navigate the archives, and provide guidance on Classic Mini restoration and
-                  maintenance. Ask me anything about your Classic Mini project!
+                  I'm your Classic Mini DIY assistant, here to help you with technical questions, decode chassis
+                  numbers, find parts information, navigate the archives, and provide guidance on Classic Mini
+                  restoration and maintenance. Ask me anything about your Classic Mini project!
                 </p>
               </div>
             </div>
@@ -198,8 +198,23 @@
   const messagesContainer = ref<HTMLDivElement>();
   const showScrollButton = ref(false);
 
+  // The server never has a persisted thread, so SSR always renders the empty
+  // (welcome) branch. The client reads localStorage during setup, so without
+  // this gate a restored thread flips isChatEmpty to false on the very first
+  // client render — a structural hydration mismatch that mangles the page DOM
+  // on refresh (chat + footer interleaved). Stay "empty" until after mount.
+  const hasMounted = ref(false);
+  onMounted(() => {
+    hasMounted.value = true;
+  });
+
   // Check if chat is empty (no messages and no persisted thread)
   const isChatEmpty = computed(() => {
+    // Match the server-rendered welcome branch during hydration
+    if (!hasMounted.value) {
+      return true;
+    }
+
     // If we have messages in the current context, chat is not empty
     if (streamContext?.messages.value && streamContext.messages.value.length > 0) {
       return false;

--- a/app/composables/usePersistentThread.ts
+++ b/app/composables/usePersistentThread.ts
@@ -206,7 +206,10 @@ export function usePersistentThread() {
     }
   });
 
-  // Initialize on creation
+  // Initialize on creation. NOTE: this reads localStorage synchronously during
+  // setup, so client state can differ from the SSR HTML — anything that renders
+  // from currentThreadId/getThreadData must not branch on it until after mount
+  // (see isChatEmpty in ChatWindow.vue) or hydration mismatches corrupt the DOM.
   initializeThread();
 
   // Watch for thread expiry and clean up automatically


### PR DESCRIPTION
## Summary
- Refreshing `/chat` within 24h of chatting corrupted the page DOM (chat messages and footer interleaved in a translucent mess — see mobile screenshot report). Root cause: SSR always renders ChatWindow's empty/welcome branch, but `usePersistentThread` restores the saved thread synchronously during setup, so the client's first render took the other `v-if` branch → structural hydration mismatch inside the Suspense boundary.
- Fix: `hasMounted` gate in `ChatWindow.vue` — `isChatEmpty` stays true until `onMounted`, so the first client render matches the SSR HTML and the restored thread swaps in as a normal post-mount update.
- Note: deferring the localStorage read itself to `onMounted` is NOT viable — ChatWindow's immediate watcher calls `createStreamSession()`/`provideStreamContext()` which need setup context (`useI18n()`/`provide()`). Invariant documented in CLAUDE.md.

## Verification
- Reproduced the mismatch locally (`Hydration node mismatch … at <ChatWindow>`) by seeding `cmdiy_chat_thread` in localStorage and reloading; gone after the fix.
- End-to-end in dev: sent a real message through LangGraph, refreshed with the live thread on desktop + mobile viewports — no mismatches, conversation restores, layout intact; empty-state welcome path unchanged.
- Full vitest suite passes (4635 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)