### PR TITLE
fix(color-mode): gate toggle icon on mount to fix SSR hydration mismatch

### DIFF
--- a/app/components/ColorModeButton.vue
+++ b/app/components/ColorModeButton.vue
@@ -9,6 +9,15 @@ const props = withDefaults(
 const { isDark, toggle } = useColorMode();
 const { track } = useAnalytics();
 
+// SSR always renders light mode, but the persisted preference (localStorage) is
+// applied during client setup — gate on mount so the first client render matches
+// the server markup and hydration stays clean.
+const hasMounted = ref(false);
+onMounted(() => {
+  hasMounted.value = true;
+});
+const showDark = computed(() => hasMounted.value && isDark.value);
+
 function handleToggle() {
   toggle();
   track('color_mode_toggled', { new_mode: isDark.value ? 'light' : 'dark' });
@@ -31,10 +40,10 @@ const sizeClass = computed(() => {
 <template>
   <button
     :class="['btn btn-ghost btn-circle', sizeClass]"
-    :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+    :aria-label="showDark ? 'Switch to light mode' : 'Switch to dark mode'"
     @click="handleToggle"
   >
-    <i v-if="isDark" class="fas fa-sun" aria-hidden="true"></i>
+    <i v-if="showDark" class="fas fa-sun" aria-hidden="true"></i>
     <i v-else class="fas fa-moon" aria-hidden="true"></i>
   </button>
 </template>


### PR DESCRIPTION
## Summary
- Every SSR page load logged a Vue hydration class mismatch from `ColorModeButton.vue`: the server always renders the light-mode default (`fas fa-moon`), but `useColorMode` applies the persisted localStorage preference during client setup, so dark-mode users hydrated against `fas fa-sun`.
- Gate the icon and aria-label on a `hasMounted` ref (`showDark = hasMounted && isDark`) so the first client render always matches the server markup; the real state swaps in immediately after mount. Same pattern as the ChatWindow hydration fix.

## Verification
- Dev-server page load with `cmdiy-theme: cmdiy-dark` persisted: zero hydration warnings, zero console errors, `data-theme="cmdiy-dark"` applied, toggle shows sun/"Switch to light mode" after mount.
- Other `useColorMode` consumers (Needles, GearboxComparisonChart) only use `isDark` for client-side Highcharts options — no SSR'd DOM, no mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)