### PR TITLE
fix(archive): guard non-uuid route params before querying — stray paths threw 22P02 in Postgres

### DIFF
--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -1,5 +1,7 @@
 import type { Color, PrettyColor } from '../../data/models/colors';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const useColors = () => {
   const supabase = useSupabase();
   const config = useRuntimeConfig();
@@ -32,6 +34,9 @@ export const useColors = () => {
   };
 
   const getColor = async (id: string): Promise<PrettyColor | null> => {
+    // colors.id is a uuid; the catch-all route param can be anything (e.g. /archive/colors/review),
+    // and passing a non-uuid straight through throws 22P02 in Postgres.
+    if (!UUID_RE.test(id)) return null;
     const { data, error } = await supabase.from('colors').select('*').eq('id', id).eq('status', 'approved').single();
 
     if (error) return null;

--- a/app/composables/useWheels.ts
+++ b/app/composables/useWheels.ts
@@ -1,5 +1,7 @@
 import type { IWheelsData } from '../../data/models/wheels';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const useWheels = () => {
   const supabase = useSupabase();
   const config = useRuntimeConfig();
@@ -82,6 +84,9 @@ export const useWheels = () => {
   };
 
   const getWheel = async (id: string): Promise<IWheelsData | null> => {
+    // wheels.id is a uuid; the catch-all route param can be anything (including the 'noWheel'
+    // fallback), and passing a non-uuid straight through throws 22P02 in Postgres.
+    if (!UUID_RE.test(id)) return null;
     const { data, error } = await supabase.from('wheels').select('*').eq('id', id).eq('status', 'approved').single();
 
     if (error) return null;

--- a/tests/unit/composables/useColors.test.ts
+++ b/tests/unit/composables/useColors.test.ts
@@ -235,11 +235,11 @@ describe('useColors', () => {
 
       const { useColors } = await import('~/app/composables/useColors');
       const { getColor } = useColors();
-      await getColor('color-1');
+      await getColor('11111111-2222-4333-8444-555555555555');
 
       expect(mockSupabase.from).toHaveBeenCalledWith('colors');
       expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
-      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', 'color-1');
+      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', '11111111-2222-4333-8444-555555555555');
       expect(mockSupabase._queryBuilder.single).toHaveBeenCalled();
     });
 
@@ -251,7 +251,7 @@ describe('useColors', () => {
 
       const { useColors } = await import('~/app/composables/useColors');
       const { getColor } = useColors();
-      const result = await getColor('color-1');
+      const result = await getColor('11111111-2222-4333-8444-555555555555');
 
       expect(result).not.toBeNull();
       expect(result!.raw).toEqual({
@@ -288,7 +288,7 @@ describe('useColors', () => {
 
       const { useColors } = await import('~/app/composables/useColors');
       const { getColor } = useColors();
-      const result = await getColor('nonexistent-id');
+      const result = await getColor('11111111-2222-4333-8444-555555555555');
 
       expect(result).toBeNull();
     });
@@ -301,9 +301,21 @@ describe('useColors', () => {
 
       const { useColors } = await import('~/app/composables/useColors');
       const { getColor } = useColors();
-      const result = await getColor('no-such-id');
+      const result = await getColor('11111111-2222-4333-8444-555555555555');
 
       expect(result).toBeNull();
+    });
+
+    it('returns null for a non-uuid id without querying Supabase', async () => {
+      const { useColors } = await import('~/app/composables/useColors');
+      const { getColor } = useColors();
+
+      // Non-uuid route params (e.g. /archive/colors/review) must never reach
+      // Postgres — a raw eq('id', 'review') throws 22P02 on the uuid column.
+      const result = await getColor('review');
+
+      expect(result).toBeNull();
+      expect(mockSupabase.from).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/composables/useWheels.test.ts
+++ b/tests/unit/composables/useWheels.test.ts
@@ -300,11 +300,11 @@ describe('useWheels', () => {
 
       const { useWheels } = await import('~/app/composables/useWheels');
       const { getWheel } = useWheels();
-      const result = await getWheel('wheel-42');
+      const result = await getWheel('11111111-2222-4333-8444-555555555555');
 
       expect(mockSupabase.from).toHaveBeenCalledWith('wheels');
       expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
-      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', 'wheel-42');
+      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', '11111111-2222-4333-8444-555555555555');
       expect(mockSupabase._mockSingle).toHaveBeenCalled();
       expect(result).not.toBeNull();
       expect(result!.uuid).toBe('wheel-42');
@@ -317,9 +317,9 @@ describe('useWheels', () => {
 
       const { useWheels } = await import('~/app/composables/useWheels');
       const { getWheel } = useWheels();
-      const result = await getWheel('wheel-42');
+      const result = await getWheel('11111111-2222-4333-8444-555555555555');
 
-      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', 'wheel-42');
+      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', '11111111-2222-4333-8444-555555555555');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('status', 'approved');
       expect(result).not.toBeNull();
     });
@@ -332,9 +332,22 @@ describe('useWheels', () => {
 
       const { useWheels } = await import('~/app/composables/useWheels');
       const { getWheel } = useWheels();
-      const result = await getWheel('nonexistent');
+      const result = await getWheel('11111111-2222-4333-8444-555555555555');
 
       expect(result).toBeNull();
+    });
+
+    it('returns null for a non-uuid id without querying Supabase', async () => {
+      const { useWheels } = await import('~/app/composables/useWheels');
+      const { getWheel } = useWheels();
+
+      // Non-uuid route params (e.g. /archive/wheels/review, or the page's
+      // 'noWheel' fallback) must never reach Postgres — a raw eq('id', ...)
+      // throws 22P02 on the uuid column.
+      const result = await getWheel('noWheel');
+
+      expect(result).toBeNull();
+      expect(mockSupabase.from).not.toHaveBeenCalled();
     });
 
     it('maps the fetched row to IWheelsData', async () => {
@@ -351,7 +364,7 @@ describe('useWheels', () => {
 
       const { useWheels } = await import('~/app/composables/useWheels');
       const { getWheel } = useWheels();
-      const result = await getWheel('w-mapped');
+      const result = await getWheel('11111111-2222-4333-8444-555555555555');
 
       expect(result!.uuid).toBe('w-mapped');
       expect(result!.name).toBe('Cosmic');


### PR DESCRIPTION
## What

`getWheel` / `getColor` passed the raw catch-all route segment straight into `.eq('id', ...)` on a uuid column. Any non-uuid path — `/archive/colors/review` (seen live in the Postgres error logs today: `22P02 invalid input syntax for type uuid: "review"`), crawler junk, or the wheel page's literal `'noWheel'` fallback — reached Postgres and threw. The client already swallowed the error into a not-found state, so the only symptom was server-side error noise.

## Fix

Validate the id against the repo's existing `UUID_RE` idiom (same regex as the `server/api` routes) and return `null` before querying. User-visible behavior is unchanged — non-uuid paths land on the same not-found rendering as before, just without a Postgres round-trip.

## Tests

- Updated `getWheel`/`getColor` test call args to valid uuids (row fixture ids unchanged).
- New regression tests assert a non-uuid id returns `null` and Supabase is never called.
- `bun run test` on both suites: 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)