### PR TITLE
fix(seo): stop SSR 500 on color detail pages from non-string og:image content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,10 @@ For inline icons in templates, use the traditional Font Awesome class syntax:
 - **CDN Integration**: S3 static assets with intelligent tiering
 - **Bundle Optimization**: Tree shaking and dependency optimization
 
+### SEO / Head Invariants
+
+- **Never pass a possibly-empty string (or any non-string) to `ogImage` / `twitterImage` in `useSeoMeta`.** unhead's flat-meta unpacking coerces `''` to boolean `true`, and nuxt-og-image's `tags:afterResolve` hook calls `.replaceAll()` on every `og:image`/`twitter:image` content — a truthy non-string 500s the whole SSR render (this took down `/archive/colors/[id]` for months). Derive share images with `computed()` (a lazy `watch` never fires during SSR, so a ref stays at its initial value server-side) and always fall back to a real URL. `app/plugins/seo-tag-guard.server.ts` + `app/utils/seoTagGuards.ts` are the SSR safety net that sanitizes these tags before nuxt-og-image sees them — don't remove them.
+
 ### Security Invariants
 
 Load-bearing contracts — don't "fix" these without understanding why they're this way:

--- a/app/pages/archive/colors/[...color].vue
+++ b/app/pages/archive/colors/[...color].vue
@@ -10,14 +10,14 @@
   const { data: color, status } = await useAsyncData(`color-${colorId}`, () => getColor(colorId as string));
 
   const copied = ref(false);
-  const shareImage = ref('');
-
-  watch(color, (newColor) => {
-    if (newColor?.raw.hasSwatch && newColor.raw.imageSwatch) {
-      shareImage.value = newColor.raw.imageSwatch;
-    } else {
-      shareImage.value = 'https://classicminidiy.s3.amazonaws.com/misc/noSwatch.jpeg';
+  // Computed (not ref + watch) so the value is populated during SSR — a lazy
+  // watch never fires server-side, which left og:image/twitter:image as '' and
+  // crashed nuxt-og-image's tags:afterResolve hook (unhead coerces '' to true).
+  const shareImage = computed(() => {
+    if (color.value?.raw.hasSwatch && color.value.raw.imageSwatch) {
+      return color.value.raw.imageSwatch;
     }
+    return 'https://classicminidiy.s3.amazonaws.com/misc/noSwatch.jpeg';
   });
 
   async function copyUrl() {
@@ -55,7 +55,7 @@
     link: [
       {
         rel: 'preload',
-        href: shareImage.value,
+        href: shareImage,
         as: 'image',
       },
     ],
@@ -68,7 +68,7 @@
     }),
     ogDescription: t('seo.og_description'),
     ogUrl: `classicminidiy.com/archive/colors/${color?.value?.raw.id}`,
-    ogImage: shareImage.value,
+    ogImage: shareImage,
     ogType: 'website',
     twitterCard: 'summary_large_image',
     twitterTitle: t('seo.twitter_title_template', {
@@ -76,7 +76,7 @@
       code: color.value?.pretty.Code,
     }),
     twitterDescription: t('seo.twitter_description'),
-    twitterImage: shareImage.value,
+    twitterImage: shareImage,
   });
 </script>
 

--- a/app/plugins/seo-tag-guard.server.ts
+++ b/app/plugins/seo-tag-guard.server.ts
@@ -1,0 +1,19 @@
+import { normalizeSocialImageContent } from '../utils/seoTagGuards';
+
+/**
+ * SSR-only safety net for nuxt-og-image (see app/utils/seoTagGuards.ts).
+ * `tags:beforeResolve` always runs before any `tags:afterResolve` hook, so the
+ * non-string content is sanitized before nuxt-og-image calls `.replaceAll()`
+ * on it. Without this, a page passing a non-string og:image/twitter:image
+ * (e.g. an empty string, which unhead coerces to `true`) 500s the whole page.
+ */
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.ssrContext?.head?.use({
+    key: 'cmdiy:social-image-content-guard',
+    hooks: {
+      'tags:beforeResolve': (ctx) => {
+        normalizeSocialImageContent(ctx.tags);
+      },
+    },
+  });
+});

--- a/app/plugins/seo-tag-guard.server.ts
+++ b/app/plugins/seo-tag-guard.server.ts
@@ -1,4 +1,4 @@
-import { normalizeSocialImageContent } from '../utils/seoTagGuards';
+import { normalizeSocialImageContent } from '~/utils/seoTagGuards';
 
 /**
  * SSR-only safety net for nuxt-og-image (see app/utils/seoTagGuards.ts).

--- a/app/utils/seoTagGuards.ts
+++ b/app/utils/seoTagGuards.ts
@@ -1,0 +1,34 @@
+/**
+ * Guard for social-image meta tags before nuxt-og-image's `tags:afterResolve`
+ * hook runs. That hook calls `.replaceAll()` on the `content` of every
+ * `og:image` / `twitter:image` / `twitter:image:src` meta tag and only skips
+ * falsy values — a truthy non-string crashes SSR with a 500.
+ *
+ * Non-strings reach that hook more easily than you'd expect: unhead's flat-meta
+ * unpacking (useSeoMeta) coerces an empty-string value to boolean `true`, and a
+ * numeric value stays a number. This normalizes both cases: numbers are
+ * stringified, everything else non-string is emptied so nuxt-og-image's own
+ * falsy guard drops the tag.
+ */
+
+interface HeadTagLike {
+  tag: string;
+  props?: Record<string, unknown>;
+}
+
+const SOCIAL_IMAGE_NAMES = new Set(['twitter:image', 'twitter:image:src']);
+
+export function isSocialImageMetaTag(tag: HeadTagLike): boolean {
+  if (tag.tag !== 'meta' || !tag.props) return false;
+  return tag.props.property === 'og:image' || SOCIAL_IMAGE_NAMES.has(tag.props.name as string);
+}
+
+export function normalizeSocialImageContent<T extends HeadTagLike>(tags: T[]): T[] {
+  for (const tag of tags) {
+    if (!isSocialImageMetaTag(tag)) continue;
+    const content = tag.props!.content;
+    if (typeof content === 'string' || content == null) continue;
+    tag.props!.content = typeof content === 'number' && Number.isFinite(content) ? String(content) : '';
+  }
+  return tags;
+}

--- a/tests/unit/utils/seoTagGuards.test.ts
+++ b/tests/unit/utils/seoTagGuards.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { isSocialImageMetaTag, normalizeSocialImageContent } from '~/app/utils/seoTagGuards';
+
+// Regression for the /archive/colors/[id] SSR 500:
+// "TypeError: tag.props.content.replaceAll is not a function" in
+// nuxt-og-image's tags:afterResolve hook. useSeoMeta({ ogImage: '' }) is
+// unpacked by unhead's flat-meta handling into og:image content === true
+// (boolean), which that hook then calls .replaceAll() on.
+describe('normalizeSocialImageContent', () => {
+  const meta = (props: Record<string, unknown>) => ({ tag: 'meta', props });
+
+  it('empties boolean content (unhead coerces empty-string useSeoMeta values to true)', () => {
+    const tags = [meta({ property: 'og:image', content: true }), meta({ name: 'twitter:image', content: true })];
+    normalizeSocialImageContent(tags);
+    expect(tags[0]?.props.content).toBe('');
+    expect(tags[1]?.props.content).toBe('');
+  });
+
+  it('stringifies numeric content', () => {
+    const tags = [meta({ property: 'og:image', content: 1275 })];
+    normalizeSocialImageContent(tags);
+    expect(tags[0]?.props.content).toBe('1275');
+  });
+
+  it('empties object/array content and non-finite numbers', () => {
+    const tags = [
+      meta({ property: 'og:image', content: { url: 'x' } }),
+      meta({ name: 'twitter:image:src', content: ['a', 'b'] }),
+      meta({ property: 'og:image', content: NaN }),
+    ];
+    normalizeSocialImageContent(tags);
+    for (const tag of tags) expect(tag.props.content).toBe('');
+  });
+
+  it('leaves string, null, and undefined content untouched', () => {
+    const url = 'https://classicminidiy.s3.amazonaws.com/misc/noSwatch.jpeg';
+    const tags = [
+      meta({ property: 'og:image', content: url }),
+      meta({ name: 'twitter:image', content: null }),
+      meta({ property: 'og:image' }),
+    ];
+    normalizeSocialImageContent(tags);
+    expect(tags[0]?.props.content).toBe(url);
+    expect(tags[1]?.props.content).toBeNull();
+    expect(tags[2]?.props.content).toBeUndefined();
+  });
+
+  it('ignores meta tags nuxt-og-image does not touch', () => {
+    const widthTag = meta({ property: 'og:image:width', content: 1200 });
+    const descTag = meta({ name: 'description', content: 42 });
+    normalizeSocialImageContent([widthTag, descTag]);
+    expect(widthTag.props.content).toBe(1200);
+    expect(descTag.props.content).toBe(42);
+  });
+
+  it('matches exactly the tags nuxt-og-image rewrites', () => {
+    expect(isSocialImageMetaTag({ tag: 'meta', props: { property: 'og:image' } })).toBe(true);
+    expect(isSocialImageMetaTag({ tag: 'meta', props: { name: 'twitter:image' } })).toBe(true);
+    expect(isSocialImageMetaTag({ tag: 'meta', props: { name: 'twitter:image:src' } })).toBe(true);
+    expect(isSocialImageMetaTag({ tag: 'meta', props: { property: 'og:image:height' } })).toBe(false);
+    expect(isSocialImageMetaTag({ tag: 'link', props: { property: 'og:image' } })).toBe(false);
+    expect(isSocialImageMetaTag({ tag: 'meta' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`/archive/colors/[id]` has been 500ing in production since 2026-02-09 (~2,066 occurrences / 199 users) with:

```
TypeError: B.props.content.replaceAll is not a function
    at tags:afterResolve (chunks/build/server.mjs)
```

## Root cause (two stacked gotchas)

1. **Lazy watch is inert during SSR.** `shareImage` was a `ref('')` populated by a `watch(color, ...)` registered *after* `await useAsyncData` had already resolved — the watch never fires server-side, so `useSeoMeta` received `ogImage: ''` / `twitterImage: ''` on every SSR render.
2. **unhead coerces `''` meta content to boolean `true`.** unhead's flat-meta (`useSeoMeta`) unpacking turns the empty string into `content: true`. nuxt-og-image's `ogImageCanonicalUrls` hook (`tags:afterResolve`) only guards *falsy* content before calling `.replaceAll()` on every `og:image`/`twitter:image` tag, so the truthy boolean crashes the whole render.

Confirmed by reproducing locally against the exact prod URLs and instrumenting the hook: the offending tag was `{"tag":"meta","props":{"property":"og:image","content":true}}`, traced to the color page's `useSeoMeta` entry.

## Fix

- **Source:** derive `shareImage` with `computed()` (same pattern the wheels detail page already uses), falling back to the noSwatch URL — SSR now emits the real swatch image, which also un-breaks social sharing previews for colors.
- **Safety net:** new SSR-only plugin `app/plugins/seo-tag-guard.server.ts` + pure util `app/utils/seoTagGuards.ts` sanitize non-string `og:image`/`twitter:image`/`twitter:image:src` content in `tags:beforeResolve`, before nuxt-og-image ever sees it. Verified independently: with the page fix reverted and only the guard active, the page returns 200.
- Invariant documented in CLAUDE.md ("SEO / Head Invariants").

## Verification

- Both prod-failing URLs (`5a47ef27…`, `b3b1fb70…`) now SSR 200 locally with correct `og:image`/`twitter:image` swatch URLs
- New Vitest regression suite for the guard (6 tests); full suite passes (146 files / 4,641 tests)
- `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)