### PR TITLE
fix(needles): move template type cast out of NeedleTable so Prettier can parse it

### DIFF
--- a/app/components/NeedleTable.vue
+++ b/app/components/NeedleTable.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
-  import type { SuggestedNeedles } from '../../data/models/needles';
+  import type { Item, SuggestedNeedles } from '../../data/models/needles';
 
   const { t } = useI18n();
   const { data: needlesTables, status } = await useFetch<SuggestedNeedles[]>(() => '/api/needles/suggested');
 
   // Table columns configuration
-  const tableColumns = computed(() => [
+  const tableColumns = computed<{ accessorKey: keyof Item; header: string }[]>(() => [
     {
       accessorKey: 'engineSize',
       header: t('table_headers.engine_size'),
@@ -68,7 +68,7 @@
               <tbody>
                 <tr v-for="(row, i) in table.items" :key="i">
                   <td v-for="col in tableColumns" :key="col.accessorKey">
-                    {{ (row as Record<string, any>)[col.accessorKey] }}
+                    {{ row[col.accessorKey] }}
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## Problem

`app/components/NeedleTable.vue` had `{{ (row as Record<string, any>)[col.accessorKey] }}` inside a `<td>`. Prettier's Vue parser (3.8.3 and 3.9.5) treats `<string,` as an HTML tag and fails with `SyntaxError: Unexpected closing tag "td"`, so `bun run format` / `prettier --check .` errored and the file was never formatted.

## Fix

- Type the column config as `computed<{ accessorKey: keyof Item; header: string }[]>` (importing the existing `Item` interface from `data/models/needles`)
- Template becomes a plain `{{ row[col.accessorKey] }}` — no generics in the template, and type-safe instead of `any`

## Verification

- `bunx prettier --check app/components/NeedleTable.vue` passes (file needed no reformatting)
- `/technical/needles` renders on the dev server: all 8 suggested-needle tables populate correctly, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)