### PR TITLE
fix(profile): stop writing email to profiles in completeOnboarding

### DIFF
--- a/app/composables/useProfile.ts
+++ b/app/composables/useProfile.ts
@@ -161,7 +161,10 @@ export const useProfile = () => {
       .upsert(
         {
           id: user.value.id,
-          email: user.value.email!,
+          // No email here: it lives on profile_private (profiles split Phase 3,
+          // written by handle_new_user at signup). Writing it to profiles was
+          // the last legacy-column writer blocking the Phase 4 column drop —
+          // and would 400 once the column is gone.
           ...profileData,
           onboarding_completed: true,
         },


### PR DESCRIPTION
## Summary

The Phase 3 bake detector caught exactly one remaining legacy-column writer: `completeOnboarding()` upserts `profiles` with `email` from the auth session. Six users tripped it since 2026-07-13 (INSERT+UPDATE pairs at the same microsecond = the upsert's `ON CONFLICT` firing both triggers).

Harmless today — the same email is already written to `profile_private` by `handle_new_user` at signup — but it blocks the [profiles split Phase 4](https://github.com/ClassicMiniDIY/classicminidiy-supabase/pull/60) column drop, and left in place it would 400 every onboarding completion the moment `profiles.email` is dropped.

Fix: remove `email` from the upsert payload. Nothing reads it from this path; the canonical copy is untouched.

TME has the same code but is retired post-cutover — no change needed there (confirmed with Cole).

## Test plan
- [x] `bun run test` — 146 files / 4643 tests green
- [ ] After deploy: Postgres logs show zero new `legacy_profiles_write` hits over a short re-bake window → clears the Phase 4 deploy gate in supabase#60

🤖 Generated with [Claude Code](https://claude.com/claude-code)