### PR TITLE
feat(marketing): admin marketing email composer + public unsubscribe

### DIFF
--- a/app/components/admin/ExchangeShell.vue
+++ b/app/components/admin/ExchangeShell.vue
@@ -84,6 +84,12 @@
                 User Management
               </NuxtLink>
             </li>
+            <li>
+              <NuxtLink to="/admin/marketing" active-class="active">
+                <i class="fas fa-envelope-open-text w-4"></i>
+                Marketing Email
+              </NuxtLink>
+            </li>
           </ul>
         </nav>
       </aside>

--- a/app/composables/useMarketingEmail.ts
+++ b/app/composables/useMarketingEmail.ts
@@ -1,0 +1,294 @@
+/**
+ * Marketing email composer state + actions (/admin/marketing).
+ *
+ * Reads marketing_emails client-side via the is_admin() RLS SELECT policy
+ * (mirrors useNewsletter's newsletter_sends reads); all writes and edge-fn
+ * actions go through the allowlist-gated /api/admin/marketing/* proxies with
+ * $adminFetch. While a send is running the edge fn checkpoints
+ * recipient_count per batch — pollWhileSending() watches the row so the UI
+ * shows live progress even after the send proxy times out (the Deno loop
+ * outlives the Vercel request window by design).
+ */
+
+export type MarketingBlock =
+  | { type: 'heading'; text: string }
+  | { type: 'text'; markdown: string }
+  | { type: 'image'; url: string; alt?: string; href?: string }
+  | { type: 'button'; href: string; label: string }
+  | { type: 'divider' };
+
+export type MarketingEmailStatus = 'draft' | 'sending' | 'sent' | 'partial' | 'failed';
+
+export interface MarketingAudienceCounts {
+  profile: number;
+  shopify: number;
+  ghost: number;
+  patreon: number;
+  suppressed: number;
+  total: number;
+}
+
+export interface MarketingEmailRecord {
+  id: string;
+  subject: string;
+  preheader: string | null;
+  blocks: MarketingBlock[];
+  status: MarketingEmailStatus;
+  audience_counts: MarketingAudienceCounts | null;
+  total_recipients: number | null;
+  recipient_count: number;
+  sent_by: string | null;
+  sent_at: string | null;
+  error_message: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MarketingDraftPayload {
+  subject: string;
+  preheader?: string;
+  blocks: MarketingBlock[];
+}
+
+export const useMarketingEmail = () => {
+  const supabase = useSupabase();
+  const toast = useToast();
+
+  const emails = useState<MarketingEmailRecord[]>('marketing:emails', () => []);
+  const emailsLoading = ref(false);
+  const previewHtml = ref('');
+  const previewLoading = ref(false);
+  const audience = ref<MarketingAudienceCounts | null>(null);
+  const audienceLoading = ref(false);
+  const saving = ref(false);
+  const sending = ref(false);
+  const testSending = ref(false);
+
+  const drafts = computed(() => emails.value.filter((e) => e.status === 'draft'));
+  const history = computed(() => emails.value.filter((e) => e.status !== 'draft'));
+  const activeSend = computed(() => emails.value.find((e) => e.status === 'sending') ?? null);
+
+  const fetchEmails = async () => {
+    emailsLoading.value = true;
+    try {
+      // marketing_emails is newer than the generated Database types — cast
+      // until `bun run gen:types` runs against the migrated schema.
+      const { data, error } = await (supabase as any)
+        .from('marketing_emails')
+        .select('*')
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      emails.value = (data as MarketingEmailRecord[]) || [];
+    } catch (error: any) {
+      console.error('Failed to load marketing emails:', error);
+      toast.add({ title: 'Error', description: 'Failed to load marketing emails', color: 'error' });
+    } finally {
+      emailsLoading.value = false;
+    }
+  };
+
+  const createDraft = async (payload: MarketingDraftPayload): Promise<MarketingEmailRecord | null> => {
+    saving.value = true;
+    try {
+      const row = await $adminFetch<MarketingEmailRecord>('/api/admin/marketing/drafts', {
+        method: 'POST',
+        body: payload,
+      });
+      emails.value = [row, ...emails.value];
+      toast.add({ title: 'Draft saved', color: 'success' });
+      return row;
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error?.data?.message || 'Failed to save draft', color: 'error' });
+      return null;
+    } finally {
+      saving.value = false;
+    }
+  };
+
+  const updateDraft = async (id: string, payload: MarketingDraftPayload): Promise<MarketingEmailRecord | null> => {
+    saving.value = true;
+    try {
+      const row = await $adminFetch<MarketingEmailRecord>(`/api/admin/marketing/drafts/${id}`, {
+        method: 'PUT',
+        body: payload,
+      });
+      emails.value = emails.value.map((e) => (e.id === id ? row : e));
+      toast.add({ title: 'Draft saved', color: 'success' });
+      return row;
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error?.data?.message || 'Failed to save draft', color: 'error' });
+      return null;
+    } finally {
+      saving.value = false;
+    }
+  };
+
+  const deleteDraft = async (id: string): Promise<boolean> => {
+    try {
+      await $adminFetch(`/api/admin/marketing/drafts/${id}`, { method: 'DELETE' });
+      emails.value = emails.value.filter((e) => e.id !== id);
+      toast.add({ title: 'Draft deleted', color: 'success' });
+      return true;
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error?.data?.message || 'Failed to delete draft', color: 'error' });
+      return false;
+    }
+  };
+
+  const fetchPreview = async (payload: MarketingDraftPayload) => {
+    previewLoading.value = true;
+    try {
+      const result = await $adminFetch<{ emailHtml: string }>('/api/admin/marketing/preview', {
+        method: 'POST',
+        body: payload,
+      });
+      previewHtml.value = result.emailHtml || '';
+    } catch (error: any) {
+      // Preview runs debounced on every edit — half-typed content will fail
+      // validation constantly, so surface it inline, never as toast spam.
+      previewHtml.value = '';
+      console.debug('Marketing preview not renderable yet:', error?.data?.message || error?.message);
+    } finally {
+      previewLoading.value = false;
+    }
+  };
+
+  const fetchAudience = async (): Promise<MarketingAudienceCounts | null> => {
+    audienceLoading.value = true;
+    try {
+      const result = await $adminFetch<{ counts: MarketingAudienceCounts }>('/api/admin/marketing/audience', {
+        timeout: 120_000,
+      });
+      audience.value = result.counts;
+      return result.counts;
+    } catch (error: any) {
+      toast.add({
+        title: 'Error',
+        description: error?.data?.message || 'Failed to resolve audience',
+        color: 'error',
+      });
+      return null;
+    } finally {
+      audienceLoading.value = false;
+    }
+  };
+
+  const sendTest = async (payload: MarketingDraftPayload, email?: string): Promise<boolean> => {
+    testSending.value = true;
+    try {
+      const result = await $adminFetch<{ success: boolean; sentTo: string }>('/api/admin/marketing/test', {
+        method: 'POST',
+        body: { ...payload, email },
+      });
+      toast.add({ title: 'Test sent', description: `Sent to ${result.sentTo}`, color: 'success' });
+      return true;
+    } catch (error: any) {
+      toast.add({ title: 'Error', description: error?.data?.message || 'Failed to send test', color: 'error' });
+      return false;
+    } finally {
+      testSending.value = false;
+    }
+  };
+
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  const stopPolling = () => {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  /** Refresh the sending row every 5s until it reaches a terminal status. */
+  const pollWhileSending = (id: string) => {
+    stopPolling();
+    // If the row is still 'draft' after a few polls, the proxy timed out on a
+    // request that never reached the edge fn — stop and say so instead of
+    // spinning forever.
+    let draftPolls = 0;
+    pollTimer = setInterval(async () => {
+      try {
+        const { data } = await (supabase as any).from('marketing_emails').select('*').eq('id', id).maybeSingle();
+        if (!data) return;
+        emails.value = emails.value.map((e) => (e.id === id ? (data as MarketingEmailRecord) : e));
+        if (data.status === 'draft') {
+          if (++draftPolls >= 3) {
+            stopPolling();
+            sending.value = false;
+            toast.add({ title: 'Send did not start', description: 'Please try again', color: 'error' });
+          }
+          return;
+        }
+        if (data.status !== 'sending') {
+          stopPolling();
+          sending.value = false;
+          toast.add({
+            title: data.status === 'sent' ? 'Marketing email sent' : `Send finished: ${data.status}`,
+            description: `${data.recipient_count}/${data.total_recipients ?? data.recipient_count} delivered`,
+            color: data.status === 'sent' ? 'success' : data.status === 'partial' ? 'warning' : 'error',
+          });
+        }
+      } catch {
+        // transient — keep polling
+      }
+    }, 5000);
+  };
+
+  const sendMarketingEmail = async (id: string): Promise<boolean> => {
+    sending.value = true;
+    try {
+      const result = await $adminFetch<any>('/api/admin/marketing/send', { method: 'POST', body: { id } });
+      await fetchEmails();
+      if (result?.polling || emails.value.find((e) => e.id === id)?.status === 'sending') {
+        // Proxy timed out (or send still running) — the edge loop continues.
+        pollWhileSending(id);
+        return true;
+      }
+      sending.value = false;
+      if (result?.success) {
+        toast.add({
+          title: 'Marketing email sent',
+          description: `${result.recipientCount}/${result.totalAttempted} delivered`,
+          color: result.status === 'sent' ? 'success' : 'warning',
+        });
+      }
+      return !!result?.success;
+    } catch (error: any) {
+      sending.value = false;
+      const status = error?.statusCode || error?.response?.status;
+      toast.add({
+        title: status === 429 ? 'Already sent' : 'Send failed',
+        description: error?.data?.message || 'Failed to send marketing email',
+        color: 'error',
+      });
+      await fetchEmails();
+      return false;
+    }
+  };
+
+  onUnmounted(stopPolling);
+
+  return {
+    emails,
+    emailsLoading,
+    drafts,
+    history,
+    activeSend,
+    previewHtml,
+    previewLoading,
+    audience,
+    audienceLoading,
+    saving,
+    sending,
+    testSending,
+    fetchEmails,
+    createDraft,
+    updateDraft,
+    deleteDraft,
+    fetchPreview,
+    fetchAudience,
+    sendTest,
+    sendMarketingEmail,
+    pollWhileSending,
+  };
+};

--- a/app/pages/admin/marketing.vue
+++ b/app/pages/admin/marketing.vue
@@ -552,11 +552,20 @@
     () => {
       if (previewTimer) clearTimeout(previewTimer);
       previewTimer = setTimeout(() => {
-        if (formValid.value) fetchPreview(toPayload());
+        previewTimer = null;
+        if (formValid.value) {
+          fetchPreview(toPayload());
+        } else {
+          // Don't leave a stale preview up when the draft is no longer renderable.
+          previewHtml.value = '';
+        }
       }, 600);
     },
     { deep: true }
   );
+  onBeforeUnmount(() => {
+    if (previewTimer) clearTimeout(previewTimer);
+  });
 
   const resizeIframe = () => {
     const iframe = emailPreviewFrame.value;

--- a/app/pages/admin/marketing.vue
+++ b/app/pages/admin/marketing.vue
@@ -1,0 +1,660 @@
+<template>
+  <AdminExchangeShell>
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold mb-2">Marketing Email</h1>
+      <p class="text-base-content/70">
+        Compose one-off CMDIY marketing emails — sent to newsletter subscribers, Shopify, Ghost, and Patreon supporters
+      </p>
+    </div>
+
+    <!-- Active send progress -->
+    <div v-if="activeSend" class="alert alert-info mb-6">
+      <span class="loading loading-spinner loading-sm"></span>
+      <span>
+        Sending "{{ activeSend.subject }}" — {{ activeSend.recipient_count }}/{{ activeSend.total_recipients ?? '?' }}
+        delivered
+      </span>
+    </div>
+
+    <div class="grid lg:grid-cols-2 gap-6 mb-8 items-start">
+      <!-- Composer -->
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+          <div class="flex items-center justify-between mb-2">
+            <h2 class="card-title">
+              <i class="fas fa-pen-to-square text-xl"></i>
+              {{ editingId ? 'Edit Draft' : 'New Email' }}
+            </h2>
+            <button v-if="editingId" class="btn btn-ghost btn-xs" @click="resetForm">
+              <i class="fas fa-plus"></i>
+              New
+            </button>
+          </div>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Subject</legend>
+            <input
+              v-model="form.subject"
+              type="text"
+              maxlength="200"
+              placeholder="Big news from the garage…"
+              class="input input-bordered w-full"
+            />
+          </fieldset>
+
+          <fieldset class="fieldset">
+            <legend class="fieldset-legend">Preheader (optional)</legend>
+            <input
+              v-model="form.preheader"
+              type="text"
+              maxlength="200"
+              placeholder="Short line shown after the subject in the inbox"
+              class="input input-bordered w-full"
+            />
+          </fieldset>
+
+          <div class="divider my-2">Content blocks</div>
+
+          <draggable v-model="form.blocks" item-key="key" handle=".drag-handle" class="flex flex-col gap-3">
+            <template #item="{ element: block, index }">
+              <div class="border border-base-300 rounded-lg p-3 bg-base-200/40">
+                <div class="flex items-center justify-between mb-2">
+                  <div class="flex items-center gap-2 text-sm font-semibold text-base-content/70">
+                    <i class="fas fa-grip-vertical drag-handle cursor-grab text-base-content/40"></i>
+                    <i :class="blockIcon(block.type)"></i>
+                    {{ blockLabel(block.type) }}
+                  </div>
+                  <button class="btn btn-ghost btn-xs text-error" @click="removeBlock(index)">
+                    <i class="fas fa-xmark"></i>
+                  </button>
+                </div>
+
+                <template v-if="block.type === 'heading'">
+                  <input
+                    v-model="block.text"
+                    type="text"
+                    maxlength="200"
+                    placeholder="Section heading"
+                    class="input input-bordered input-sm w-full"
+                  />
+                </template>
+
+                <template v-else-if="block.type === 'text'">
+                  <textarea
+                    v-model="block.markdown"
+                    rows="4"
+                    maxlength="5000"
+                    placeholder="Write your message…"
+                    class="textarea textarea-bordered w-full text-sm"
+                  ></textarea>
+                  <p class="text-xs text-base-content/50 mt-1">
+                    **bold** &nbsp; *italic* &nbsp; [link text](https://…) &nbsp; blank line = new paragraph
+                  </p>
+                </template>
+
+                <template v-else-if="block.type === 'image'">
+                  <div v-if="block.url" class="mb-2">
+                    <img :src="block.url" alt="" class="max-h-40 rounded-lg border border-base-300 mx-auto" />
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <input
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+                      class="file-input file-input-bordered file-input-sm w-full"
+                      :disabled="uploadingIndex === index"
+                      @change="(e) => handleImageUpload(e, index)"
+                    />
+                    <div v-if="uploadingIndex === index" class="flex items-center gap-2 text-sm text-base-content/60">
+                      <span class="loading loading-spinner loading-xs"></span>
+                      Optimizing & uploading…
+                    </div>
+                    <input
+                      v-model="block.alt"
+                      type="text"
+                      maxlength="200"
+                      placeholder="Alt text (accessibility)"
+                      class="input input-bordered input-sm w-full"
+                    />
+                    <input
+                      v-model="block.href"
+                      type="url"
+                      placeholder="Optional link when clicked (https://…)"
+                      class="input input-bordered input-sm w-full"
+                    />
+                  </div>
+                </template>
+
+                <template v-else-if="block.type === 'button'">
+                  <div class="flex flex-col sm:flex-row gap-2">
+                    <input
+                      v-model="block.label"
+                      type="text"
+                      maxlength="80"
+                      placeholder="Button label"
+                      class="input input-bordered input-sm w-full sm:w-1/3"
+                    />
+                    <input
+                      v-model="block.href"
+                      type="url"
+                      placeholder="https://classicminidiy.com/…"
+                      class="input input-bordered input-sm w-full sm:flex-1"
+                    />
+                  </div>
+                </template>
+
+                <template v-else>
+                  <div class="border-t border-base-300 my-2"></div>
+                </template>
+              </div>
+            </template>
+          </draggable>
+
+          <div class="flex flex-wrap gap-2 mt-3">
+            <button class="btn btn-outline btn-xs" @click="addBlock('heading')">
+              <i class="fas fa-heading"></i> Heading
+            </button>
+            <button class="btn btn-outline btn-xs" @click="addBlock('text')">
+              <i class="fas fa-align-left"></i> Text
+            </button>
+            <button class="btn btn-outline btn-xs" @click="addBlock('image')">
+              <i class="fas fa-image"></i> Image
+            </button>
+            <button class="btn btn-outline btn-xs" @click="addBlock('button')">
+              <i class="fas fa-arrow-pointer"></i> Button
+            </button>
+            <button class="btn btn-outline btn-xs" @click="addBlock('divider')">
+              <i class="fas fa-minus"></i> Divider
+            </button>
+          </div>
+
+          <div class="divider my-2"></div>
+
+          <div class="flex flex-wrap gap-2 justify-end">
+            <button class="btn btn-outline btn-sm" :disabled="!formValid || saving" @click="handleSaveDraft">
+              <span v-if="saving" class="loading loading-spinner loading-xs"></span>
+              <i v-else class="fas fa-floppy-disk"></i>
+              Save Draft
+            </button>
+            <button class="btn btn-outline btn-sm" :disabled="!formValid || testSending" @click="openTestModal">
+              <i class="fas fa-paper-plane"></i>
+              Send Test
+            </button>
+            <button
+              class="btn btn-primary btn-sm"
+              :disabled="!formValid || sending || !!activeSend"
+              @click="openSendModal"
+            >
+              <i class="fas fa-envelope"></i>
+              Send…
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Preview + audience -->
+      <div class="flex flex-col gap-6">
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <h2 class="card-title mb-2">
+              <i class="fas fa-eye text-xl"></i>
+              Preview
+              <span v-if="previewLoading" class="loading loading-spinner loading-xs"></span>
+            </h2>
+            <div v-if="previewHtml">
+              <iframe
+                ref="emailPreviewFrame"
+                :srcdoc="previewHtml"
+                class="w-full border border-base-300 rounded-lg"
+                style="min-height: 500px"
+                sandbox="allow-same-origin"
+                @load="resizeIframe"
+              ></iframe>
+            </div>
+            <div v-else class="text-center py-12 text-base-content/50">
+              <i class="fas fa-envelope-open text-4xl mb-2 opacity-50"></i>
+              <p>Add a subject and at least one block to preview</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <div class="flex items-center justify-between mb-2">
+              <h2 class="card-title">
+                <i class="fas fa-users text-xl"></i>
+                Audience
+              </h2>
+              <button class="btn btn-ghost btn-sm" :disabled="audienceLoading" @click="fetchAudience">
+                <span v-if="audienceLoading" class="loading loading-spinner loading-xs"></span>
+                <i v-else class="fas fa-arrows-rotate"></i>
+                Refresh
+              </button>
+            </div>
+            <p class="text-xs text-base-content/50 mb-3">
+              Live union of all marketing lists — takes ~30&ndash;60s to resolve
+            </p>
+            <div v-if="audience" class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <div class="stat bg-base-200/50 rounded-lg p-3">
+                <div class="text-xs text-base-content/60">Site opt-ins</div>
+                <div class="text-xl font-bold">{{ audience.profile }}</div>
+              </div>
+              <div class="stat bg-base-200/50 rounded-lg p-3">
+                <div class="text-xs text-base-content/60">Shopify</div>
+                <div class="text-xl font-bold">{{ audience.shopify }}</div>
+              </div>
+              <div class="stat bg-base-200/50 rounded-lg p-3">
+                <div class="text-xs text-base-content/60">Ghost</div>
+                <div class="text-xl font-bold">{{ audience.ghost }}</div>
+              </div>
+              <div class="stat bg-base-200/50 rounded-lg p-3">
+                <div class="text-xs text-base-content/60">Patreon</div>
+                <div class="text-xl font-bold">{{ audience.patreon }}</div>
+              </div>
+              <div class="stat bg-base-200/50 rounded-lg p-3">
+                <div class="text-xs text-base-content/60">Suppressed</div>
+                <div class="text-xl font-bold text-error">-{{ audience.suppressed }}</div>
+              </div>
+              <div class="stat bg-primary/10 rounded-lg p-3">
+                <div class="text-xs text-base-content/60">Total</div>
+                <div class="text-xl font-bold text-primary">{{ audience.total }}</div>
+              </div>
+            </div>
+            <div v-else class="text-center py-6 text-base-content/50 text-sm">
+              <p>Refresh to resolve the current audience</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Drafts -->
+    <div class="card bg-base-100 shadow mb-8">
+      <div class="card-body">
+        <h2 class="card-title mb-4">
+          <i class="fas fa-file-lines text-xl"></i>
+          Drafts
+        </h2>
+        <div v-if="emailsLoading" class="flex justify-center py-6">
+          <span class="loading loading-spinner loading-md"></span>
+        </div>
+        <div v-else-if="drafts.length === 0" class="text-center py-6 text-base-content/50">
+          <p>No drafts yet</p>
+        </div>
+        <div v-else class="overflow-x-auto">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Subject</th>
+                <th>Blocks</th>
+                <th>Updated</th>
+                <th class="text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="draft in drafts" :key="draft.id">
+                <td class="font-medium">{{ draft.subject || '(untitled)' }}</td>
+                <td>{{ draft.blocks?.length || 0 }}</td>
+                <td>{{ formatDateTime(draft.updated_at) }}</td>
+                <td class="text-right">
+                  <button class="btn btn-ghost btn-xs" @click="loadDraft(draft)">
+                    <i class="fas fa-pen"></i>
+                    Edit
+                  </button>
+                  <button class="btn btn-ghost btn-xs text-error" @click="handleDeleteDraft(draft.id)">
+                    <i class="fas fa-trash"></i>
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- Send history -->
+    <div class="card bg-base-100 shadow">
+      <div class="card-body">
+        <h2 class="card-title mb-4">
+          <i class="fas fa-clock text-xl"></i>
+          Send History
+        </h2>
+        <div v-if="emailsLoading" class="flex justify-center py-6">
+          <span class="loading loading-spinner loading-md"></span>
+        </div>
+        <div v-else-if="history.length === 0" class="text-center py-6 text-base-content/50">
+          <p>No marketing emails have been sent yet</p>
+        </div>
+        <div v-else class="overflow-x-auto">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Sent</th>
+                <th>Subject</th>
+                <th>Delivered</th>
+                <th>Audience</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="record in history" :key="record.id">
+                <td>{{ formatDateTime(record.sent_at || record.updated_at) }}</td>
+                <td class="font-medium">{{ record.subject }}</td>
+                <td>
+                  {{ record.recipient_count
+                  }}<span v-if="record.total_recipients"> / {{ record.total_recipients }}</span>
+                </td>
+                <td class="text-xs text-base-content/60">
+                  <template v-if="record.audience_counts">
+                    {{ record.audience_counts.profile }} site &bull; {{ record.audience_counts.shopify }} shopify &bull;
+                    {{ record.audience_counts.ghost }} ghost &bull; {{ record.audience_counts.patreon }} patreon
+                  </template>
+                  <template v-else>—</template>
+                </td>
+                <td>
+                  <span :class="statusBadgeClass(record.status)">{{ record.status }}</span>
+                  <div v-if="record.error_message" class="text-xs text-error mt-0.5">{{ record.error_message }}</div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- Test modal -->
+    <dialog ref="testModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Send Test Email</h3>
+        <p class="text-base-content/70 mb-4">
+          Sends the current composition with a <span class="badge badge-sm">[TEST]</span> subject prefix and a real
+          unsubscribe link.
+        </p>
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend">Email Address</legend>
+          <input v-model="testEmail" type="email" placeholder="your@email.com" class="input input-bordered w-full" />
+          <p class="text-xs text-base-content/50 mt-1">Leave blank to send to your account email</p>
+        </fieldset>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="testModal?.close()">Cancel</button>
+          <button class="btn btn-primary" :disabled="testSending" @click="handleSendTest">
+            <span v-if="testSending" class="loading loading-spinner loading-sm"></span>
+            <i v-else class="fas fa-paper-plane"></i>
+            Send Test
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop"><button>close</button></form>
+    </dialog>
+
+    <!-- Send confirmation modal -->
+    <dialog ref="sendModal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Send Marketing Email</h3>
+        <div class="bg-warning/10 border border-warning/30 rounded-lg p-4 mb-4">
+          <p class="text-sm">
+            <i class="fas fa-triangle-exclamation inline mr-1 text-warning"></i>
+            "<strong>{{ form.subject }}</strong
+            >" will be sent to <strong>{{ audience?.total ?? '?' }}</strong> recipients.
+          </p>
+          <p v-if="audience" class="text-xs text-base-content/50 mt-1 ml-6">
+            {{ audience.profile }} site + {{ audience.shopify }} Shopify + {{ audience.ghost }} Ghost +
+            {{ audience.patreon }} Patreon ({{ audience.suppressed }} suppressed)
+          </p>
+        </div>
+        <div v-if="!audience" class="bg-info/10 border border-info/30 rounded-lg p-4 mb-4">
+          <p class="text-sm">
+            <i class="fas fa-circle-info inline mr-1 text-info"></i>
+            Refresh the audience first so you know how many people this reaches.
+          </p>
+        </div>
+        <p class="text-base-content/70 mb-4 text-sm">
+          The draft is saved first, then the send runs server-side with live progress above. This cannot be undone.
+        </p>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="sendModal?.close()">Cancel</button>
+          <button class="btn btn-primary" :disabled="sending || !audience" @click="handleSend">
+            <span v-if="sending" class="loading loading-spinner loading-sm"></span>
+            <i v-else class="fas fa-envelope"></i>
+            Send to {{ audience?.total ?? '?' }} recipients
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop"><button>close</button></form>
+    </dialog>
+  </AdminExchangeShell>
+</template>
+
+<script setup lang="ts">
+  import draggable from 'vuedraggable';
+  import type { MarketingBlock, MarketingEmailRecord } from '~/composables/useMarketingEmail';
+
+  definePageMeta({ layout: 'admin' });
+  useHead({ title: 'Marketing Email - Admin - Classic Mini DIY' });
+  useSeoMeta({ robots: 'noindex, nofollow' });
+
+  const toast = useToast();
+  const { capture } = usePostHog();
+  const {
+    emailsLoading,
+    drafts,
+    history,
+    activeSend,
+    previewHtml,
+    previewLoading,
+    audience,
+    audienceLoading,
+    saving,
+    sending,
+    testSending,
+    fetchEmails,
+    createDraft,
+    updateDraft,
+    deleteDraft,
+    fetchPreview,
+    fetchAudience,
+    sendTest,
+    sendMarketingEmail,
+    pollWhileSending,
+  } = useMarketingEmail();
+
+  // Editor state. Blocks carry a local `key` for draggable identity — stripped
+  // before anything is sent to the server.
+  type EditorBlock = MarketingBlock & { key: string };
+  const form = ref<{ subject: string; preheader: string; blocks: EditorBlock[] }>({
+    subject: '',
+    preheader: '',
+    blocks: [],
+  });
+  const editingId = ref<string | null>(null);
+  const uploadingIndex = ref<number | null>(null);
+  const testEmail = ref('');
+  const testModal = ref<HTMLDialogElement | null>(null);
+  const sendModal = ref<HTMLDialogElement | null>(null);
+  const emailPreviewFrame = ref<HTMLIFrameElement | null>(null);
+
+  let keyCounter = 0;
+  const nextKey = () => `blk-${++keyCounter}`;
+
+  const blockLabel = (type: MarketingBlock['type']) =>
+    ({ heading: 'Heading', text: 'Text', image: 'Image', button: 'Button', divider: 'Divider' })[type];
+  const blockIcon = (type: MarketingBlock['type']) =>
+    ({
+      heading: 'fas fa-heading',
+      text: 'fas fa-align-left',
+      image: 'fas fa-image',
+      button: 'fas fa-arrow-pointer',
+      divider: 'fas fa-minus',
+    })[type];
+
+  const addBlock = (type: MarketingBlock['type']) => {
+    const key = nextKey();
+    const block: EditorBlock =
+      type === 'heading'
+        ? { type, text: '', key }
+        : type === 'text'
+          ? { type, markdown: '', key }
+          : type === 'image'
+            ? { type, url: '', alt: '', href: '', key }
+            : type === 'button'
+              ? { type, href: '', label: '', key }
+              : { type: 'divider', key };
+    form.value.blocks.push(block);
+  };
+
+  const removeBlock = (index: number) => {
+    form.value.blocks.splice(index, 1);
+  };
+
+  /** Strip editor keys + empty optionals into the API payload shape. */
+  const toPayload = () => ({
+    subject: form.value.subject.trim(),
+    preheader: form.value.preheader.trim() || undefined,
+    blocks: form.value.blocks.map(({ key: _key, ...block }) => {
+      if (block.type === 'image') {
+        return { type: 'image', url: block.url, alt: block.alt || undefined, href: block.href || undefined };
+      }
+      return block;
+    }) as MarketingBlock[],
+  });
+
+  const formValid = computed(() => {
+    if (!form.value.subject.trim() || form.value.blocks.length === 0) return false;
+    return form.value.blocks.every((b) => {
+      if (b.type === 'heading') return !!b.text.trim();
+      if (b.type === 'text') return !!b.markdown.trim();
+      if (b.type === 'image') return !!b.url;
+      if (b.type === 'button') return !!b.label.trim() && /^https?:\/\//.test(b.href);
+      return true;
+    });
+  });
+
+  const resetForm = () => {
+    form.value = { subject: '', preheader: '', blocks: [] };
+    editingId.value = null;
+    previewHtml.value = '';
+  };
+
+  const loadDraft = (draft: MarketingEmailRecord) => {
+    editingId.value = draft.id;
+    form.value = {
+      subject: draft.subject,
+      preheader: draft.preheader || '',
+      blocks: (draft.blocks || []).map((b) => ({ ...b, key: nextKey() }) as EditorBlock),
+    };
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  // Debounced live preview — server-rendered so what you see is exactly what
+  // ships (same renderer as the send path).
+  let previewTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(
+    form,
+    () => {
+      if (previewTimer) clearTimeout(previewTimer);
+      previewTimer = setTimeout(() => {
+        if (formValid.value) fetchPreview(toPayload());
+      }, 600);
+    },
+    { deep: true }
+  );
+
+  const resizeIframe = () => {
+    const iframe = emailPreviewFrame.value;
+    if (iframe?.contentDocument?.body) {
+      iframe.style.height = iframe.contentDocument.body.scrollHeight + 32 + 'px';
+    }
+  };
+
+  const handleImageUpload = async (event: Event, index: number) => {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    uploadingIndex.value = index;
+    try {
+      // Client-side optimize (HEIC convert + resize to email-friendly width)
+      // before the admin upload route's magic-byte check.
+      const { file: optimized } = await optimizeImage(file, { maxWidthOrHeight: 1200, maxSizeMB: 1 });
+      const fd = new FormData();
+      fd.append('file', optimized, optimized.name);
+      const result = await $adminFetch<{ url: string }>('/api/admin/marketing/upload-image', {
+        method: 'POST',
+        body: fd,
+      });
+      const block = form.value.blocks[index];
+      if (block?.type === 'image') block.url = result.url;
+    } catch (error: any) {
+      toast.add({ title: 'Upload failed', description: error?.data?.message || error?.message, color: 'error' });
+    } finally {
+      uploadingIndex.value = null;
+      input.value = '';
+    }
+  };
+
+  const handleSaveDraft = async (): Promise<string | null> => {
+    const payload = toPayload();
+    if (editingId.value) {
+      const row = await updateDraft(editingId.value, payload);
+      return row ? row.id : null;
+    }
+    const row = await createDraft(payload);
+    if (row) editingId.value = row.id;
+    return row ? row.id : null;
+  };
+
+  const handleDeleteDraft = async (id: string) => {
+    if (!confirm('Delete this draft?')) return;
+    const ok = await deleteDraft(id);
+    if (ok && editingId.value === id) resetForm();
+  };
+
+  const openTestModal = () => {
+    testEmail.value = '';
+    testModal.value?.showModal();
+  };
+
+  const handleSendTest = async () => {
+    const ok = await sendTest(toPayload(), testEmail.value || undefined);
+    if (ok) testModal.value?.close();
+  };
+
+  const openSendModal = () => {
+    sendModal.value?.showModal();
+  };
+
+  const handleSend = async () => {
+    // Persist the latest edits first — the edge fn sends what the ROW contains.
+    const id = await handleSaveDraft();
+    if (!id) return;
+    sendModal.value?.close();
+    const ok = await sendMarketingEmail(id);
+    if (ok) {
+      capture('admin_marketing_email_sent', {
+        subject_length: form.value.subject.length,
+        block_count: form.value.blocks.length,
+        audience_total: audience.value?.total ?? null,
+      });
+      resetForm();
+    }
+  };
+
+  const statusBadgeClass = (status: string): string => {
+    switch (status) {
+      case 'sending':
+        return 'badge badge-info';
+      case 'sent':
+        return 'badge badge-success';
+      case 'partial':
+        return 'badge badge-warning';
+      case 'failed':
+        return 'badge badge-error';
+      default:
+        return 'badge';
+    }
+  };
+
+  onMounted(async () => {
+    await fetchEmails();
+    // Resume progress polling if a send is mid-flight (e.g. page reload).
+    if (activeSend.value) pollWhileSending(activeSend.value.id);
+  });
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -542,6 +542,14 @@ export default defineNuxtConfig({
       exchangeEnabled: process.env.NUXT_PUBLIC_EXCHANGE_ENABLED === 'true',
     },
     SUPABASE_SERVICE_KEY: process.env.SUPABASE_SERVICE_KEY || '',
+    // Marketing email composer (/admin/marketing). Allowlist is checked ON TOP
+    // of requireAdminAuth — only these admin emails may compose/send marketing
+    // mail. Comma-separated; defaults to the founder account.
+    MARKETING_ADMIN_EMAILS: process.env.MARKETING_ADMIN_EMAILS || 'classicminidiy@gmail.com',
+    // Shared HMAC secret with the send-marketing-email edge function: the edge
+    // fn signs per-recipient /email/unsubscribe links, this side verifies them.
+    // Unset = unsubscribe endpoints 503 (never silently accept unsigned links).
+    MARKETING_UNSUB_SECRET: process.env.MARKETING_UNSUB_SECRET || '',
     // 3D Model Library private S3 bucket (keystone §5/§10). Dedicated IAM user
     // scoped to `classicminidiy-models` ONLY — never the static-assets creds.
     // Used by server/utils/s3Models.ts for presigned upload POSTs and download

--- a/server/api/admin/marketing/audience.get.ts
+++ b/server/api/admin/marketing/audience.get.ts
@@ -1,0 +1,19 @@
+/**
+ * GET /api/admin/marketing/audience
+ *
+ * Marketing-admin only. Resolves the live marketing audience counts (digest
+ * opt-ins ∪ Shopify ∪ Ghost ∪ Patreon, minus suppressions) via the
+ * `marketing_audience` action. SLOW (~30-60s — four external API crawls);
+ * the composer calls it only from an explicit "Refresh audience" button.
+ * Returns counts only — recipient addresses never reach the browser.
+ *
+ *   returns: { counts: { profile, shopify, ghost, patreon, suppressed, total } }
+ */
+import { requireMarketingAdmin } from '../../../utils/marketingAuth';
+import { callMarketingEdge } from '../../../utils/marketingEdge';
+
+export default defineEventHandler(async (event) => {
+  await requireMarketingAdmin(event);
+  // Generous timeout — Ghost + Shopify + Patreon + SES suppression walks.
+  return callMarketingEdge({ action: 'marketing_audience' }, { timeout: 120_000 });
+});

--- a/server/api/admin/marketing/drafts.post.ts
+++ b/server/api/admin/marketing/drafts.post.ts
@@ -1,0 +1,38 @@
+/**
+ * POST /api/admin/marketing/drafts
+ *
+ * Marketing-admin only. Creates a marketing email draft. Writes are
+ * server-side only (marketing_emails has no client write policies) so the
+ * allowlist gate + validation live in one place; reads happen client-side via
+ * the is_admin() SELECT policy.
+ *
+ *   body: { subject, preheader?, blocks }
+ *   returns: the inserted row
+ */
+import { getServiceClient } from '../../../utils/supabase';
+import { requireMarketingAdmin } from '../../../utils/marketingAuth';
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireMarketingAdmin(event);
+  const body = await readBody<{ subject?: string; preheader?: string; blocks?: unknown[] }>(event);
+
+  const subject = typeof body?.subject === 'string' ? body.subject.trim().slice(0, 200) : '';
+  const preheader =
+    typeof body?.preheader === 'string' && body.preheader.trim() ? body.preheader.trim().slice(0, 200) : null;
+  const blocks = Array.isArray(body?.blocks) ? body.blocks : [];
+  if (!subject) throw createError({ statusCode: 400, statusMessage: 'subject is required' });
+
+  // marketing_emails postdates the generated Database types — cast until
+  // `bun run gen:types` runs against the migrated schema.
+  const db = getServiceClient() as any;
+  const { data: row, error } = await db
+    .from('marketing_emails')
+    .insert({ subject, preheader, blocks, created_by: user.id })
+    .select('*')
+    .single();
+  if (error || !row) {
+    console.error('[marketing/drafts] insert failed:', error?.message);
+    throw createError({ statusCode: 500, statusMessage: 'Could not create draft' });
+  }
+  return row;
+});

--- a/server/api/admin/marketing/drafts/[id].delete.ts
+++ b/server/api/admin/marketing/drafts/[id].delete.ts
@@ -1,0 +1,31 @@
+/**
+ * DELETE /api/admin/marketing/drafts/:id
+ *
+ * Marketing-admin only. Deletes a DRAFT (sent/sending rows are history and
+ * cannot be removed — the status-scoped delete refuses them).
+ */
+import { getServiceClient } from '../../../../utils/supabase';
+import { requireMarketingAdmin } from '../../../../utils/marketingAuth';
+
+export default defineEventHandler(async (event) => {
+  await requireMarketingAdmin(event);
+  const id = getRouterParam(event, 'id');
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id' });
+
+  // marketing_emails postdates the generated Database types — cast until
+  // `bun run gen:types` runs against the migrated schema.
+  const db = getServiceClient() as any;
+  const { data: row, error } = await db
+    .from('marketing_emails')
+    .delete()
+    .eq('id', id)
+    .eq('status', 'draft')
+    .select('id')
+    .maybeSingle();
+  if (error) {
+    console.error('[marketing/drafts] delete failed:', error.message);
+    throw createError({ statusCode: 500, statusMessage: 'Could not delete draft' });
+  }
+  if (!row) throw createError({ statusCode: 409, statusMessage: 'Draft not found or not deletable' });
+  return { success: true };
+});

--- a/server/api/admin/marketing/drafts/[id].put.ts
+++ b/server/api/admin/marketing/drafts/[id].put.ts
@@ -1,0 +1,46 @@
+/**
+ * PUT /api/admin/marketing/drafts/:id
+ *
+ * Marketing-admin only. Updates a draft's content. Refuses unless the row is
+ * still status='draft' (sent/sending emails are immutable history). The
+ * status-scoped UPDATE also loses gracefully to a concurrent send claim.
+ *
+ *   body: { subject?, preheader?, blocks? }
+ *   returns: the updated row
+ */
+import { getServiceClient } from '../../../../utils/supabase';
+import { requireMarketingAdmin } from '../../../../utils/marketingAuth';
+
+export default defineEventHandler(async (event) => {
+  await requireMarketingAdmin(event);
+  const id = getRouterParam(event, 'id');
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id' });
+  const body = await readBody<{ subject?: string; preheader?: string; blocks?: unknown[] }>(event);
+
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (typeof body?.subject === 'string') updates.subject = body.subject.trim().slice(0, 200);
+  if (body?.preheader !== undefined) {
+    updates.preheader =
+      typeof body.preheader === 'string' && body.preheader.trim() ? body.preheader.trim().slice(0, 200) : null;
+  }
+  if (Array.isArray(body?.blocks)) updates.blocks = body.blocks;
+
+  // marketing_emails postdates the generated Database types — cast until
+  // `bun run gen:types` runs against the migrated schema.
+  const db = getServiceClient() as any;
+  const { data: row, error } = await db
+    .from('marketing_emails')
+    .update(updates)
+    .eq('id', id)
+    .eq('status', 'draft')
+    .select('*')
+    .maybeSingle();
+  if (error) {
+    console.error('[marketing/drafts] update failed:', error.message);
+    throw createError({ statusCode: 500, statusMessage: 'Could not update draft' });
+  }
+  if (!row) {
+    throw createError({ statusCode: 409, statusMessage: 'Draft not found or no longer editable' });
+  }
+  return row;
+});

--- a/server/api/admin/marketing/preview.post.ts
+++ b/server/api/admin/marketing/preview.post.ts
@@ -1,0 +1,23 @@
+/**
+ * POST /api/admin/marketing/preview
+ *
+ * Marketing-admin only. Renders the block composition to branded email HTML
+ * via the send-marketing-email `marketing_preview` action. No audience
+ * resolution happens here (the composer calls this debounced per edit).
+ *
+ *   body: { subject, preheader?, blocks }
+ *   returns: { emailHtml, subject }
+ */
+import { requireMarketingAdmin } from '../../../utils/marketingAuth';
+import { callMarketingEdge } from '../../../utils/marketingEdge';
+
+export default defineEventHandler(async (event) => {
+  await requireMarketingAdmin(event);
+  const body = await readBody<{ subject?: string; preheader?: string; blocks?: unknown[] }>(event);
+  return callMarketingEdge({
+    action: 'marketing_preview',
+    subject: body?.subject,
+    preheader: body?.preheader,
+    blocks: body?.blocks,
+  });
+});

--- a/server/api/admin/marketing/send.post.ts
+++ b/server/api/admin/marketing/send.post.ts
@@ -1,0 +1,65 @@
+/**
+ * POST /api/admin/marketing/send
+ *
+ * Marketing-admin only. Triggers the full send for a draft via the
+ * `marketing_send` action. The edge fn atomically claims the row
+ * (draft→sending), resolves the live audience, and runs the SES loop to
+ * completion in Deno — which can outlive THIS request's window on Vercel. A
+ * proxy timeout therefore does NOT mean failure: the audit row is written
+ * before forwarding, and on timeout we return started:true so the composer
+ * polls the marketing_emails row for progress instead of erroring.
+ *
+ *   body: { id }
+ *   returns: edge result, or { started: true, polling: true } on proxy timeout
+ *   429 when the row was not in draft state (already sending/sent).
+ */
+import { getServiceClient } from '../../../utils/supabase';
+import { requireMarketingAdmin } from '../../../utils/marketingAuth';
+import { callMarketingEdge } from '../../../utils/marketingEdge';
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireMarketingAdmin(event);
+  const body = await readBody<{ id?: string }>(event);
+  const id = typeof body?.id === 'string' ? body.id : '';
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'id is required' });
+
+  // marketing_emails postdates the generated Database types — cast until
+  // `bun run gen:types` runs against the migrated schema.
+  const db = getServiceClient() as any;
+  const { data: draft } = await db.from('marketing_emails').select('id, subject, status').eq('id', id).maybeSingle();
+  if (!draft) throw createError({ statusCode: 404, statusMessage: 'Marketing email not found' });
+  if (draft.status !== 'draft') {
+    throw createError({ statusCode: 429, statusMessage: `Marketing email is ${draft.status}, not draft` });
+  }
+
+  // Audit intent BEFORE forwarding — the edge call may outlive this request.
+  await db.from('admin_audit_log').insert({
+    admin_id: user.id,
+    action: 'marketing_email_sent',
+    target_type: 'marketing_email',
+    target_id: id,
+    details: { subject: draft.subject },
+  });
+
+  let result: any;
+  try {
+    result = await callMarketingEdge({ action: 'marketing_send', marketingEmailId: id, sentBy: user.id });
+  } catch (error: any) {
+    // Distinguish "edge rejected it" from "proxy gave up waiting". On a
+    // timeout/abort the Deno loop keeps running — tell the client to poll.
+    const status = error?.statusCode;
+    if (!status || status === 502 || status === 504 || status === 408) {
+      console.warn('[marketing/send] proxy timed out awaiting edge fn; send continues edge-side');
+      return { started: true, polling: true, sendId: id };
+    }
+    throw error;
+  }
+
+  if (result && result.success === false && result.status === 'blocked') {
+    throw createError({ statusCode: 429, statusMessage: result.error || 'Marketing email is not in draft state' });
+  }
+  if (result && result.success === false) {
+    throw createError({ statusCode: 400, statusMessage: result.error || `Send failed (${result.status})` });
+  }
+  return result;
+});

--- a/server/api/admin/marketing/send.post.ts
+++ b/server/api/admin/marketing/send.post.ts
@@ -26,7 +26,15 @@ export default defineEventHandler(async (event) => {
   // marketing_emails postdates the generated Database types — cast until
   // `bun run gen:types` runs against the migrated schema.
   const db = getServiceClient() as any;
-  const { data: draft } = await db.from('marketing_emails').select('id, subject, status').eq('id', id).maybeSingle();
+  const { data: draft, error: lookupError } = await db
+    .from('marketing_emails')
+    .select('id, subject, status')
+    .eq('id', id)
+    .maybeSingle();
+  if (lookupError) {
+    console.error('[marketing/send] lookup failed:', lookupError.message);
+    throw createError({ statusCode: 500, statusMessage: 'Failed to look up marketing email' });
+  }
   if (!draft) throw createError({ statusCode: 404, statusMessage: 'Marketing email not found' });
   if (draft.status !== 'draft') {
     throw createError({ statusCode: 429, statusMessage: `Marketing email is ${draft.status}, not draft` });

--- a/server/api/admin/marketing/test.post.ts
+++ b/server/api/admin/marketing/test.post.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /api/admin/marketing/test
+ *
+ * Marketing-admin only. Sends the current composition as a [TEST]-prefixed
+ * email to a single address (defaults to the requesting admin) with a real
+ * signed unsubscribe link + RFC 8058 one-click headers, so header checks in
+ * "Show original" reflect exactly what a real send produces.
+ *
+ *   body: { subject, preheader?, blocks, email? }
+ *   returns: { success, sentTo }
+ */
+import { requireMarketingAdmin } from '../../../utils/marketingAuth';
+import { callMarketingEdge } from '../../../utils/marketingEdge';
+
+export default defineEventHandler(async (event) => {
+  const { user } = await requireMarketingAdmin(event);
+  const body = await readBody<{ subject?: string; preheader?: string; blocks?: unknown[]; email?: string }>(event);
+  const email = typeof body?.email === 'string' && body.email.trim() ? body.email.trim() : user.email;
+  if (!email) throw createError({ statusCode: 400, statusMessage: 'No test email address available' });
+  return callMarketingEdge({
+    action: 'marketing_test',
+    subject: body?.subject,
+    preheader: body?.preheader,
+    blocks: body?.blocks,
+    email,
+  });
+});

--- a/server/api/admin/marketing/upload-image.post.ts
+++ b/server/api/admin/marketing/upload-image.post.ts
@@ -1,0 +1,51 @@
+/**
+ * POST /api/admin/marketing/upload-image
+ *
+ * Marketing-admin only. Uploads an image for embedding in a marketing email
+ * to the PUBLIC marketing-images bucket (email clients fetch embedded images
+ * from the inbox, so they need stable public URLs). Mirrors the model-images
+ * pattern: magic-byte validated, random safe filename, service-role upload.
+ * The edge-fn renderer only accepts image URLs under this bucket's public
+ * prefix, so this route is the sole way images enter a marketing email.
+ *
+ *   multipart: file
+ *   returns: { url }
+ */
+import { getServiceClient } from '../../../utils/supabase';
+import { requireMarketingAdmin } from '../../../utils/marketingAuth';
+import { detectMimeFromMagic, generateSafeFilename, type DetectedMime } from '../../../utils/uploadValidation';
+
+const ALLOWED: DetectedMime[] = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MiB (matches the bucket limit)
+
+export default defineEventHandler(async (event) => {
+  await requireMarketingAdmin(event);
+
+  const form = await readMultipartFormData(event);
+  const file = form?.find((f) => f.data && f.filename);
+  if (!file?.data) throw createError({ statusCode: 400, statusMessage: 'No image uploaded' });
+  if (file.data.length > MAX_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Image exceeds the 5 MB limit' });
+  }
+
+  const mime = detectMimeFromMagic(file.data);
+  if (!mime || !ALLOWED.includes(mime)) {
+    throw createError({ statusCode: 400, statusMessage: 'File is not a JPG, PNG, or WebP image' });
+  }
+
+  const safeName = generateSafeFilename(mime);
+  const storagePath = `${new Date().getFullYear()}/${safeName}`;
+
+  const service = getServiceClient();
+  const { error: uploadError } = await service.storage
+    .from('marketing-images')
+    .upload(storagePath, file.data, { contentType: mime, upsert: false });
+  if (uploadError) {
+    console.error('[marketing/upload-image] storage upload failed:', uploadError.message);
+    throw createError({ statusCode: 500, statusMessage: 'Image upload failed' });
+  }
+
+  const config = useRuntimeConfig();
+  const supabaseUrl = (config.public.supabaseUrl as string)?.replace(/\/$/, '');
+  return { url: `${supabaseUrl}/storage/v1/object/public/marketing-images/${storagePath}` };
+});

--- a/server/routes/email/unsubscribe.get.ts
+++ b/server/routes/email/unsubscribe.get.ts
@@ -1,0 +1,49 @@
+/**
+ * GET /email/unsubscribe?e=<b64url email>&t=<b64url hmac>
+ *
+ * Marketing unsubscribe CONFIRM page. GET never performs the opt-out — mail
+ * scanners and link prefetchers (Outlook SafeLinks etc.) follow GETs, and an
+ * auto-unsubscribe on fetch would silently shred the audience. The page shows
+ * a masked address and a POST form to the same URL; the POST (also the RFC
+ * 8058 one-click target) does the actual suppression.
+ */
+import { maskEmail, unsubConfigured, unsubPage, verifyUnsubToken } from '../../utils/marketingUnsub';
+
+export default defineEventHandler((event) => {
+  setHeader(event, 'X-Robots-Tag', 'noindex');
+  setHeader(event, 'Content-Type', 'text/html; charset=utf-8');
+
+  if (!unsubConfigured()) {
+    setResponseStatus(event, 503);
+    return unsubPage(
+      'Unavailable',
+      `<h1>Temporarily unavailable</h1>
+       <p>Unsubscribe is not available right now. Please try again later or email
+       <a href="mailto:classicminidiy@gmail.com" style="color:#435231">classicminidiy@gmail.com</a>.</p>`
+    );
+  }
+
+  const query = getQuery(event);
+  const email = verifyUnsubToken(query.e, query.t);
+  if (!email) {
+    setResponseStatus(event, 400);
+    return unsubPage(
+      'Invalid link',
+      `<h1>This link isn't valid</h1>
+       <p>This unsubscribe link is invalid or was modified. Please use the link from a
+       recent Classic Mini DIY email, or contact
+       <a href="mailto:classicminidiy@gmail.com" style="color:#435231">classicminidiy@gmail.com</a>.</p>`
+    );
+  }
+
+  const e = encodeURIComponent(String(query.e));
+  const t = encodeURIComponent(String(query.t));
+  return unsubPage(
+    'Unsubscribe',
+    `<h1>Unsubscribe from marketing emails?</h1>
+     <p>Stop sending Classic Mini DIY marketing emails to <strong>${maskEmail(email)}</strong>?</p>
+     <form method="POST" action="/email/unsubscribe?e=${e}&t=${t}">
+       <button type="submit" class="btn">Unsubscribe</button>
+     </form>`
+  );
+});

--- a/server/routes/email/unsubscribe.get.ts
+++ b/server/routes/email/unsubscribe.get.ts
@@ -7,7 +7,7 @@
  * a masked address and a POST form to the same URL; the POST (also the RFC
  * 8058 one-click target) does the actual suppression.
  */
-import { maskEmail, unsubConfigured, unsubPage, verifyUnsubToken } from '../../utils/marketingUnsub';
+import { escapeUnsubHtml, maskEmail, unsubConfigured, unsubPage, verifyUnsubToken } from '../../utils/marketingUnsub';
 
 export default defineEventHandler((event) => {
   setHeader(event, 'X-Robots-Tag', 'noindex');
@@ -41,7 +41,7 @@ export default defineEventHandler((event) => {
   return unsubPage(
     'Unsubscribe',
     `<h1>Unsubscribe from marketing emails?</h1>
-     <p>Stop sending Classic Mini DIY marketing emails to <strong>${maskEmail(email)}</strong>?</p>
+     <p>Stop sending Classic Mini DIY marketing emails to <strong>${escapeUnsubHtml(maskEmail(email))}</strong>?</p>
      <form method="POST" action="/email/unsubscribe?e=${e}&t=${t}">
        <button type="submit" class="btn">Unsubscribe</button>
      </form>`

--- a/server/routes/email/unsubscribe.post.ts
+++ b/server/routes/email/unsubscribe.post.ts
@@ -1,0 +1,63 @@
+/**
+ * POST /email/unsubscribe?e=<b64url email>&t=<b64url hmac>
+ *
+ * Performs the marketing opt-out. Serves BOTH the confirm-page form and the
+ * RFC 8058 one-click POST that Gmail/Yahoo issue against the List-Unsubscribe
+ * URL (body `List-Unsubscribe=One-Click`; no CSRF token — the HMAC in the URL
+ * is the authorization). Upserts into email_suppressions, which every
+ * marketing + newsletter send subtracts, covering recipients from all sources
+ * (profiles, Shopify, Ghost, Patreon) uniformly. Duplicate opt-outs return
+ * the same success page.
+ */
+import { getServiceClient } from '../../utils/supabase';
+import { unsubConfigured, unsubPage, verifyUnsubToken } from '../../utils/marketingUnsub';
+
+export default defineEventHandler(async (event) => {
+  setHeader(event, 'X-Robots-Tag', 'noindex');
+  setHeader(event, 'Content-Type', 'text/html; charset=utf-8');
+
+  if (!unsubConfigured()) {
+    setResponseStatus(event, 503);
+    return unsubPage('Unavailable', `<h1>Temporarily unavailable</h1><p>Please try again later.</p>`);
+  }
+
+  const query = getQuery(event);
+  const email = verifyUnsubToken(query.e, query.t);
+  if (!email) {
+    setResponseStatus(event, 400);
+    return unsubPage(
+      'Invalid link',
+      `<h1>This link isn't valid</h1>
+       <p>This unsubscribe link is invalid or was modified. Please use the link from a
+       recent Classic Mini DIY email.</p>`
+    );
+  }
+
+  const db = getServiceClient();
+  const { error } = await db.from('email_suppressions').upsert(
+    {
+      email,
+      reason: 'unsubscribe',
+      source: 'marketing_unsub',
+      details: 'Marketing unsubscribe (one-click or confirm page)',
+    },
+    { onConflict: 'email', ignoreDuplicates: true }
+  );
+  if (error) {
+    console.error('[email/unsubscribe] suppression insert failed:', error.message);
+    setResponseStatus(event, 500);
+    return unsubPage(
+      'Something went wrong',
+      `<h1>Something went wrong</h1>
+       <p>We couldn't process the unsubscribe. Please try again, or email
+       <a href="mailto:classicminidiy@gmail.com" style="color:#435231">classicminidiy@gmail.com</a>.</p>`
+    );
+  }
+
+  return unsubPage(
+    'Unsubscribed',
+    `<h1>You're unsubscribed</h1>
+     <p>You won't receive marketing emails from Classic Mini DIY anymore.
+     Transactional emails (receipts, account notifications) are unaffected.</p>`
+  );
+});

--- a/server/utils/marketingAuth.ts
+++ b/server/utils/marketingAuth.ts
@@ -1,0 +1,22 @@
+import { requireAdminAuth } from './adminAuth';
+
+/**
+ * Marketing email composer gate: standard admin auth PLUS an email allowlist
+ * (MARKETING_ADMIN_EMAILS, comma-separated). Mass email is the one admin
+ * surface where "any admin" is too broad — only allowlisted accounts (default:
+ * the founder) may compose, upload images for, or send marketing mail. Reads
+ * of drafts/history stay plain-admin via the marketing_emails RLS SELECT.
+ */
+export async function requireMarketingAdmin(event: any) {
+  const auth = await requireAdminAuth(event);
+  const config = useRuntimeConfig();
+  const allowlist = ((config.MARKETING_ADMIN_EMAILS as string) || '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  const email = auth.user.email?.toLowerCase();
+  if (!email || !allowlist.includes(email)) {
+    throw createError({ statusCode: 403, statusMessage: 'Marketing admin access required' });
+  }
+  return auth;
+}

--- a/server/utils/marketingEdge.ts
+++ b/server/utils/marketingEdge.ts
@@ -1,0 +1,35 @@
+/**
+ * Thin caller for the send-marketing-email edge function. All marketing admin
+ * routes forward through here with the service-role bearer (the edge fn
+ * enforces service-grade auth itself; callers must gate on
+ * requireMarketingAdmin BEFORE invoking this).
+ */
+export async function callMarketingEdge<T = any>(
+  body: Record<string, unknown>,
+  opts: { timeout?: number } = {}
+): Promise<T> {
+  const config = useRuntimeConfig();
+  const supabaseUrl = (config.public.supabaseUrl as string)?.replace(/\/$/, '');
+  const serviceKey = config.SUPABASE_SERVICE_KEY as string;
+  if (!supabaseUrl || !serviceKey) {
+    throw createError({ statusCode: 500, statusMessage: 'Supabase not configured' });
+  }
+
+  try {
+    return await $fetch<T>(`${supabaseUrl}/functions/v1/send-marketing-email`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${serviceKey}`,
+        apikey: config.public.supabaseKey as string,
+        'content-type': 'application/json',
+      },
+      body,
+      timeout: opts.timeout,
+    });
+  } catch (error: any) {
+    const status = error?.statusCode || error?.response?.status || 502;
+    const message = error?.data?.error || error?.statusMessage || 'Marketing email service error';
+    console.error('[marketing] edge function error:', error?.data || error?.message || error);
+    throw createError({ statusCode: status, statusMessage: message });
+  }
+}

--- a/server/utils/marketingUnsub.ts
+++ b/server/utils/marketingUnsub.ts
@@ -42,11 +42,23 @@ export function unsubConfigured(): boolean {
   return Boolean(useRuntimeConfig().MARKETING_UNSUB_SECRET);
 }
 
-/** Mask an email for display: ab***@d***.com style, never the full address. */
+/** Escape a value for interpolation into the unsubscribe pages' HTML. */
+export function escapeUnsubHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/** Mask an email for display: ab…@d….com style — local AND domain masked. */
 export function maskEmail(email: string): string {
-  const [local, domain] = email.split('@');
-  const maskedLocal = local.length <= 2 ? `${local[0] ?? ''}…` : `${local.slice(0, 2)}…`;
-  return `${maskedLocal}@${domain ?? ''}`;
+  const [local = '', domain = ''] = email.split('@');
+  const maskedLocal = `${local.slice(0, Math.min(2, Math.max(1, local.length - 1)))}…`;
+  const lastDot = domain.lastIndexOf('.');
+  const maskedDomain = lastDot > 0 ? `${domain[0] ?? ''}…${domain.slice(lastDot)}` : `${domain[0] ?? ''}…`;
+  return `${maskedLocal}@${maskedDomain}`;
 }
 
 /** Minimal self-contained CMDIY-ish page (no app bundle, no external assets). */

--- a/server/utils/marketingUnsub.ts
+++ b/server/utils/marketingUnsub.ts
@@ -1,0 +1,78 @@
+/**
+ * Marketing unsubscribe link verification + shared page chrome for the public
+ * /email/unsubscribe routes. Links are minted by the send-marketing-email
+ * edge function: e = base64url(lowercased email), t = base64url(HMAC-SHA256(
+ * email, MARKETING_UNSUB_SECRET)). Same secret both sides — edge signs, web
+ * verifies. These are Nitro-rendered pages (no session, no client bundle):
+ * recipients from Ghost/Patreon/Shopify have no CMDIY account.
+ */
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function base64urlDecode(value: string): Buffer | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  try {
+    return Buffer.from(value, 'base64url');
+  } catch {
+    return null;
+  }
+}
+
+/** Verify e/t query params. Returns the lowercased email, or null. */
+export function verifyUnsubToken(e: unknown, t: unknown): string | null {
+  const config = useRuntimeConfig();
+  const secret = config.MARKETING_UNSUB_SECRET as string;
+  if (!secret) return null;
+  if (typeof e !== 'string' || typeof t !== 'string' || !e || !t) return null;
+
+  const emailBytes = base64urlDecode(e);
+  const sigBytes = base64urlDecode(t);
+  if (!emailBytes || !sigBytes) return null;
+
+  const email = emailBytes.toString('utf8').toLowerCase();
+  // Cheap shape check before HMAC — the token only ever wraps an email.
+  if (!email.includes('@') || email.length > 320) return null;
+
+  const expected = createHmac('sha256', secret).update(email).digest();
+  if (sigBytes.length !== expected.length || !timingSafeEqual(sigBytes, expected)) return null;
+  return email;
+}
+
+/** True when MARKETING_UNSUB_SECRET is configured (unset ⇒ routes 503). */
+export function unsubConfigured(): boolean {
+  return Boolean(useRuntimeConfig().MARKETING_UNSUB_SECRET);
+}
+
+/** Mask an email for display: ab***@d***.com style, never the full address. */
+export function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  const maskedLocal = local.length <= 2 ? `${local[0] ?? ''}…` : `${local.slice(0, 2)}…`;
+  return `${maskedLocal}@${domain ?? ''}`;
+}
+
+/** Minimal self-contained CMDIY-ish page (no app bundle, no external assets). */
+export function unsubPage(title: string, bodyHtml: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>${title} — Classic Mini DIY</title>
+  <style>
+    body { margin: 0; font-family: Arial, Helvetica, sans-serif; background: #f9fafb; color: #1f2937; }
+    .card { max-width: 480px; margin: 80px auto; background: #fff; border-radius: 16px; box-shadow: 0 4px 6px rgba(0,0,0,.07); padding: 40px 32px; text-align: center; }
+    h1 { font-size: 22px; margin: 0 0 16px; }
+    p { color: #4b5563; font-size: 15px; line-height: 1.6; margin: 0 0 20px; }
+    .btn { display: inline-block; padding: 12px 32px; background: #435231; color: #fff; border: none; border-radius: 24px; font-weight: 600; font-size: 15px; cursor: pointer; text-decoration: none; }
+    .brand { margin-top: 24px; font-size: 12px; color: #9ca3af; }
+    .brand a { color: #435231; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    ${bodyHtml}
+    <p class="brand"><a href="https://classicminidiy.com">Classic Mini DIY</a> &bull; Keeping Classic Minis on the road</p>
+  </div>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
Web half of the admin **marketing email composer** (paired backend PR: ClassicMiniDIY/classicminidiy-supabase#62 — merge/deploy that first).

- **`/admin/marketing`**: block-builder composer (heading / markdown text / uploaded image / CTA button / divider, drag-reorder via vuedraggable), debounced server-rendered preview iframe (same renderer as the send path), on-demand audience card (live counts per source, explicit refresh — the crawl takes ~30-60s), `[TEST]` send modal, confirm-modal send with live per-batch progress polling, drafts list + send history.
- **Gating**: `requireMarketingAdmin` = `requireAdminAuth` **+** `MARKETING_ADMIN_EMAILS` allowlist (default `classicminidiy@gmail.com`). Any admin can read drafts/history (RLS SELECT); only allowlisted admins can write/send.
- **Proxies** under `server/api/admin/marketing/` forward to the `send-marketing-email` edge fn with the service key. `send.post.ts` writes an `admin_audit_log` row before forwarding and treats a proxy timeout as "send started" — the Deno loop outlives the Vercel window by design; the composable polls the `marketing_emails` row for progress.
- **Image uploads**: admin-only route → public `marketing-images` bucket (magic-byte validated, 5 MB, random safe filename), client-side `optimizeImage` (HEIC convert + resize to 1200px) first. The edge renderer only accepts URLs under this bucket's prefix.
- **`/email/unsubscribe`** (Nitro-rendered, no session — Ghost/Patreon/Shopify recipients have no account): GET verifies the HMAC link and shows a confirm page (**never** suppresses on GET — prefetcher safety); POST serves both the confirm form and RFC 8058 one-click, upserting `email_suppressions` with `reason='unsubscribe'`.

## Env (Vercel, before first use)
- `MARKETING_UNSUB_SECRET` — same value as the Supabase edge secret
- `MARKETING_ADMIN_EMAILS` — optional, defaults to `classicminidiy@gmail.com`

## Testing
- `bun run build` passes; full vitest suite passes (4643 tests).
- Verified locally: unsubscribe confirm page renders with masked email on a valid HMAC link; tampered/missing tokens → 400; GET performs no suppression; `/admin/marketing` SSRs and the admin middleware gate redirects unauthenticated visitors.
- Not verifiable until the backend deploys: preview/test/audience/send round-trips (edge fn), image upload (bucket), one-click POST insert (migration).
- `marketing_emails` typed-client calls are `as any`-cast until `bun run gen:types` runs against the migrated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)