### PR TITLE
feat(marketing): admin dashboard card + regenerated marketing_emails types

### DIFF
--- a/app/components/admin/ExchangeShell.vue
+++ b/app/components/admin/ExchangeShell.vue
@@ -84,7 +84,7 @@
                 User Management
               </NuxtLink>
             </li>
-            <li>
+            <li v-if="marketingAllowed === true">
               <NuxtLink to="/admin/marketing" active-class="active">
                 <i class="fas fa-envelope-open-text w-4"></i>
                 Marketing Email
@@ -111,6 +111,10 @@
 
   const messageQueueCount = ref(0);
   const moderationCount = ref(0);
+
+  // Marketing Email is allowlist-gated (MARKETING_ADMIN_EMAILS) — only render
+  // the sidebar entry for admins the access probe approves.
+  const { allowed: marketingAllowed, check: checkMarketingAccess } = useMarketingAccess();
 
   const loadMessageQueueCount = async () => {
     try {
@@ -139,6 +143,7 @@
   onMounted(() => {
     loadMessageQueueCount();
     loadModerationCount();
+    checkMarketingAccess();
   });
 
   // Refresh badges when navigating between exchange admin sections.

--- a/app/composables/useMarketingEmail.ts
+++ b/app/composables/useMarketingEmail.ts
@@ -51,6 +51,27 @@ export interface MarketingDraftPayload {
   blocks: MarketingBlock[];
 }
 
+/**
+ * Whether the signed-in admin is on the MARKETING_ADMIN_EMAILS allowlist.
+ * Cached per session (useState); `allowed` is null until the first check
+ * resolves, so gate UI with `allowed === true`. Used by the admin dashboard
+ * card, the ExchangeShell sidebar entry, and the /admin/marketing page guard.
+ */
+export const useMarketingAccess = () => {
+  const allowed = useState<boolean | null>('marketing:access', () => null);
+  const check = async (): Promise<boolean> => {
+    if (allowed.value !== null) return allowed.value;
+    try {
+      await $adminFetch('/api/admin/marketing/access');
+      allowed.value = true;
+    } catch {
+      allowed.value = false;
+    }
+    return allowed.value;
+  };
+  return { allowed, check };
+};
+
 export const useMarketingEmail = () => {
   const supabase = useSupabase();
   const toast = useToast();

--- a/app/composables/useMarketingEmail.ts
+++ b/app/composables/useMarketingEmail.ts
@@ -93,14 +93,13 @@ export const useMarketingEmail = () => {
   const fetchEmails = async () => {
     emailsLoading.value = true;
     try {
-      // marketing_emails is newer than the generated Database types — cast
-      // until `bun run gen:types` runs against the migrated schema.
-      const { data, error } = await (supabase as any)
+      const { data, error } = await supabase
         .from('marketing_emails')
         .select('*')
         .order('created_at', { ascending: false });
       if (error) throw error;
-      emails.value = (data as MarketingEmailRecord[]) || [];
+      // Generated Row types blocks as Json; the app-level type narrows it.
+      emails.value = (data as unknown as MarketingEmailRecord[]) || [];
     } catch (error: any) {
       console.error('Failed to load marketing emails:', error);
       toast.add({ title: 'Error', description: 'Failed to load marketing emails', color: 'error' });
@@ -229,9 +228,10 @@ export const useMarketingEmail = () => {
     let draftPolls = 0;
     pollTimer = setInterval(async () => {
       try {
-        const { data } = await (supabase as any).from('marketing_emails').select('*').eq('id', id).maybeSingle();
-        if (!data) return;
-        emails.value = emails.value.map((e) => (e.id === id ? (data as MarketingEmailRecord) : e));
+        const { data: row } = await supabase.from('marketing_emails').select('*').eq('id', id).maybeSingle();
+        if (!row) return;
+        const data = row as unknown as MarketingEmailRecord;
+        emails.value = emails.value.map((e) => (e.id === id ? data : e));
         if (data.status === 'draft') {
           if (++draftPolls >= 3) {
             stopPolling();

--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -22,6 +22,13 @@
   // Marketplace admin is only surfaced when the Exchange section is enabled
   const exchangeEnabled = useRuntimeConfig().public.exchangeEnabled;
 
+  // Marketing Email is allowlist-gated (MARKETING_ADMIN_EMAILS, server-side) —
+  // the card only renders for admins the probe approves.
+  const { allowed: marketingAllowed, check: checkMarketingAccess } = useMarketingAccess();
+  onMounted(() => {
+    checkMarketingAccess();
+  });
+
   // Fetch pending count — uses useAdminFetch to inject auth header and skip SSR
   const { data: totalPendingCount } = await useAdminFetch<{ count: number }>('/api/admin/queue/count');
 
@@ -163,6 +170,33 @@
               <NuxtLink to="/admin/users" class="btn btn-warning">
                 <i class="fad fa-arrow-right mr-2"></i>
                 Manage Users
+              </NuxtLink>
+            </div>
+          </div>
+        </div>
+
+        <!-- Marketing Email Card (allowlisted marketing admins only) -->
+        <div
+          v-if="marketingAllowed === true"
+          class="card bg-base-100 shadow-md border border-base-300 hover:shadow-2xl transition-shadow"
+        >
+          <div class="card-body">
+            <div class="flex items-center gap-3 mb-4">
+              <div class="w-12 h-12 bg-success/10 rounded-lg flex items-center justify-center">
+                <i class="fad fa-envelope-open-text text-2xl text-success"></i>
+              </div>
+              <h2 class="text-xl font-bold">Marketing Email</h2>
+            </div>
+
+            <p class="opacity-70 mb-6">
+              Compose and send one-off marketing emails to newsletter subscribers, Shopify, Ghost, and Patreon
+              supporters.
+            </p>
+
+            <div class="card-actions justify-end">
+              <NuxtLink to="/admin/marketing" class="btn btn-success">
+                <i class="fad fa-arrow-right mr-2"></i>
+                Open Composer
               </NuxtLink>
             </div>
           </div>

--- a/app/pages/admin/marketing.vue
+++ b/app/pages/admin/marketing.vue
@@ -662,6 +662,14 @@
   };
 
   onMounted(async () => {
+    // Allowlist guard: a non-allowlisted admin can reach this route (the
+    // global middleware only checks is_admin) but every action would 403 —
+    // bounce them back to the dashboard instead of showing a dead page.
+    const { check: checkMarketingAccess } = useMarketingAccess();
+    if (!(await checkMarketingAccess())) {
+      toast.add({ title: 'Not available', description: 'Marketing email access is restricted', color: 'warning' });
+      return navigateTo('/admin');
+    }
     await fetchEmails();
     // Resume progress polling if a send is mid-flight (e.g. page reload).
     if (activeSend.value) pollWhileSending(activeSend.value.id);

--- a/server/api/admin/marketing/access.get.ts
+++ b/server/api/admin/marketing/access.get.ts
@@ -1,0 +1,15 @@
+/**
+ * GET /api/admin/marketing/access
+ *
+ * Cheap allowlist probe: 200 { allowed: true } iff the caller passes
+ * requireMarketingAdmin (admin + MARKETING_ADMIN_EMAILS). The allowlist is
+ * server-only config, so the admin dashboard / sidebar call this to decide
+ * whether to surface the Marketing Email entry points at all — non-allowlisted
+ * admins simply never see them (and would 403 on every action anyway).
+ */
+import { requireMarketingAdmin } from '../../../utils/marketingAuth';
+
+export default defineEventHandler(async (event) => {
+  await requireMarketingAdmin(event);
+  return { allowed: true };
+});

--- a/server/api/admin/marketing/drafts.post.ts
+++ b/server/api/admin/marketing/drafts.post.ts
@@ -22,9 +22,7 @@ export default defineEventHandler(async (event) => {
   const blocks = Array.isArray(body?.blocks) ? body.blocks : [];
   if (!subject) throw createError({ statusCode: 400, statusMessage: 'subject is required' });
 
-  // marketing_emails postdates the generated Database types — cast until
-  // `bun run gen:types` runs against the migrated schema.
-  const db = getServiceClient() as any;
+  const db = getServiceClient();
   const { data: row, error } = await db
     .from('marketing_emails')
     .insert({ subject, preheader, blocks, created_by: user.id })

--- a/server/api/admin/marketing/drafts/[id].delete.ts
+++ b/server/api/admin/marketing/drafts/[id].delete.ts
@@ -12,9 +12,7 @@ export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id');
   if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing id' });
 
-  // marketing_emails postdates the generated Database types — cast until
-  // `bun run gen:types` runs against the migrated schema.
-  const db = getServiceClient() as any;
+  const db = getServiceClient();
   const { data: row, error } = await db
     .from('marketing_emails')
     .delete()

--- a/server/api/admin/marketing/drafts/[id].put.ts
+++ b/server/api/admin/marketing/drafts/[id].put.ts
@@ -25,9 +25,7 @@ export default defineEventHandler(async (event) => {
   }
   if (Array.isArray(body?.blocks)) updates.blocks = body.blocks;
 
-  // marketing_emails postdates the generated Database types — cast until
-  // `bun run gen:types` runs against the migrated schema.
-  const db = getServiceClient() as any;
+  const db = getServiceClient();
   const { data: row, error } = await db
     .from('marketing_emails')
     .update(updates)

--- a/server/api/admin/marketing/send.post.ts
+++ b/server/api/admin/marketing/send.post.ts
@@ -23,9 +23,7 @@ export default defineEventHandler(async (event) => {
   const id = typeof body?.id === 'string' ? body.id : '';
   if (!id) throw createError({ statusCode: 400, statusMessage: 'id is required' });
 
-  // marketing_emails postdates the generated Database types — cast until
-  // `bun run gen:types` runs against the migrated schema.
-  const db = getServiceClient() as any;
+  const db = getServiceClient();
   const { data: draft, error: lookupError } = await db
     .from('marketing_emails')
     .select('id, subject, status')

--- a/types/database.ts
+++ b/types/database.ts
@@ -1785,6 +1785,86 @@ export type Database = {
           },
         ]
       }
+      marketing_emails: {
+        Row: {
+          audience_counts: Json | null
+          blocks: Json
+          created_at: string
+          created_by: string | null
+          error_message: string | null
+          id: string
+          preheader: string | null
+          recipient_count: number
+          sent_at: string | null
+          sent_by: string | null
+          status: string
+          subject: string
+          total_recipients: number | null
+          updated_at: string
+        }
+        Insert: {
+          audience_counts?: Json | null
+          blocks?: Json
+          created_at?: string
+          created_by?: string | null
+          error_message?: string | null
+          id?: string
+          preheader?: string | null
+          recipient_count?: number
+          sent_at?: string | null
+          sent_by?: string | null
+          status?: string
+          subject?: string
+          total_recipients?: number | null
+          updated_at?: string
+        }
+        Update: {
+          audience_counts?: Json | null
+          blocks?: Json
+          created_at?: string
+          created_by?: string | null
+          error_message?: string | null
+          id?: string
+          preheader?: string | null
+          recipient_count?: number
+          sent_at?: string | null
+          sent_by?: string | null
+          status?: string
+          subject?: string
+          total_recipients?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "marketing_emails_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "marketing_emails_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "marketing_emails_sent_by_fkey"
+            columns: ["sent_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "marketing_emails_sent_by_fkey"
+            columns: ["sent_by"]
+            isOneToOne: false
+            referencedRelation: "public_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       marketplace_config: {
         Row: {
           key: string


### PR DESCRIPTION
## Summary
Two follow-ups that missed the #680 merge window:

1. **Allowlist-gated Marketing Email card on /admin** (cherry-picked — it was pushed to the #680 branch minutes after the merge, so it never landed on main): new `/api/admin/marketing/access` probe (`requireMarketingAdmin`) drives `useMarketingAccess()`; the dashboard card and the ExchangeShell sidebar entry only render for allowlisted admins, and `/admin/marketing` bounces non-allowlisted admins back to `/admin` instead of a page whose every action 403s.
2. **`bun run gen:types` against the migrated schema** — `marketing_emails` is now in `types/database.ts`, so the temporary `as any` casts in the four marketing server routes and `useMarketingEmail` are removed.

## Testing
- Full vitest suite passes (4643 tests); `bun run build` completes.
- Deployed-backend verification already done against prod: audience resolves (2 site + 2737 Shopify + 532 Ghost + 11 Patreon − 64 suppressed = 3218), `[TEST]` send delivered, newsletter preview regression clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)