### PR TITLE
fix(archive): return real 404s for dead wheel and colour deep links

### DIFF
--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -37,9 +37,17 @@ export const useColors = () => {
     // colors.id is a uuid; the catch-all route param can be anything (e.g. /archive/colors/review),
     // and passing a non-uuid straight through throws 22P02 in Postgres.
     if (!UUID_RE.test(id)) return null;
-    const { data, error } = await supabase.from('colors').select('*').eq('id', id).eq('status', 'approved').single();
+    // maybeSingle, not single — see the equivalent note in useWheels.getWheel: a
+    // uuid-shaped miss is expected for pre-migration links and shouldn't surface as
+    // a 406 API error.
+    const { data, error } = await supabase
+      .from('colors')
+      .select('*')
+      .eq('id', id)
+      .eq('status', 'approved')
+      .maybeSingle();
 
-    if (error) return null;
+    if (error || !data) return null;
     const color = mapToColor(data);
     return {
       raw: color,

--- a/app/composables/useWheels.ts
+++ b/app/composables/useWheels.ts
@@ -87,9 +87,18 @@ export const useWheels = () => {
     // wheels.id is a uuid; the catch-all route param can be anything (including the 'noWheel'
     // fallback), and passing a non-uuid straight through throws 22P02 in Postgres.
     if (!UUID_RE.test(id)) return null;
-    const { data, error } = await supabase.from('wheels').select('*').eq('id', id).eq('status', 'approved').single();
+    // maybeSingle, not single: a well-formed uuid that matches no row is the COMMON
+    // case here — pre-migration deep links use ids the DynamoDB import never carried
+    // over. single() answers that with a 406 logged as an API error; maybeSingle()
+    // returns null data and no error, which is what a miss actually is.
+    const { data, error } = await supabase
+      .from('wheels')
+      .select('*')
+      .eq('id', id)
+      .eq('status', 'approved')
+      .maybeSingle();
 
-    if (error) return null;
+    if (error || !data) return null;
     return mapToWheel(data);
   };
 

--- a/app/pages/archive/colors/[...color].vue
+++ b/app/pages/archive/colors/[...color].vue
@@ -9,6 +9,13 @@
   const { getColor } = useColors();
   const { data: color, status } = await useAsyncData(`color-${colorId}`, () => getColor(colorId as string));
 
+  // Same soft-404 as the wheel detail page: the template has no v-else after
+  // `v-else-if="color"`, so an unresolvable id rendered an empty shell with a 200.
+  // Every id the colors re-seed regenerated lands here, so answer with a real 404.
+  if (!color.value) {
+    throw createError({ statusCode: 404, statusMessage: 'Color not found', fatal: true });
+  }
+
   const copied = ref(false);
   // Computed (not ref + watch) so the value is populated during SSR — a lazy
   // watch never fires server-side, which left og:image/twitter:image as '' and

--- a/app/pages/archive/wheels/[...wheel].vue
+++ b/app/pages/archive/wheels/[...wheel].vue
@@ -19,6 +19,14 @@
     default: () => ({}) as IWheelsData,
   });
 
+  // An unresolvable id still rendered this page: `default` supplies an empty object,
+  // so the response was 200 with a blank body and an "undefined" SEO title — a soft
+  // 404. Crawlers read that as a live page and keep re-requesting dead pre-migration
+  // deep links indefinitely. Answer with a real 404 instead.
+  if (!wheel.value?.uuid) {
+    throw createError({ statusCode: 404, statusMessage: 'Wheel not found', fatal: true });
+  }
+
   const copied = ref<boolean>(false);
   const showSuggestEdit = ref(false);
   // Legacy notes may contain embedded HTML; strip tags so they render as plain text rather than escaped markup.

--- a/tests/unit/composables/useColors.test.ts
+++ b/tests/unit/composables/useColors.test.ts
@@ -227,8 +227,8 @@ describe('useColors', () => {
   });
 
   describe('getColor', () => {
-    it('queries colors table by id with .single()', async () => {
-      mockSupabase._queryBuilder.single.mockResolvedValue({
+    it('queries colors table by id with .maybeSingle()', async () => {
+      mockSupabase._queryBuilder.maybeSingle.mockResolvedValue({
         data: mockColorRow,
         error: null,
       });
@@ -240,11 +240,11 @@ describe('useColors', () => {
       expect(mockSupabase.from).toHaveBeenCalledWith('colors');
       expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', '11111111-2222-4333-8444-555555555555');
-      expect(mockSupabase._queryBuilder.single).toHaveBeenCalled();
+      expect(mockSupabase._queryBuilder.maybeSingle).toHaveBeenCalled();
     });
 
     it('returns a PrettyColor object with raw and pretty fields', async () => {
-      mockSupabase._queryBuilder.single.mockResolvedValue({
+      mockSupabase._queryBuilder.maybeSingle.mockResolvedValue({
         data: mockColorRow,
         error: null,
       });
@@ -281,7 +281,7 @@ describe('useColors', () => {
     });
 
     it('returns null when Supabase returns an error', async () => {
-      mockSupabase._queryBuilder.single.mockResolvedValue({
+      mockSupabase._queryBuilder.maybeSingle.mockResolvedValue({
         data: null,
         error: { message: 'Not found', code: 'PGRST116' },
       });
@@ -294,9 +294,11 @@ describe('useColors', () => {
     });
 
     it('returns null when the color does not exist', async () => {
-      mockSupabase._queryBuilder.single.mockResolvedValue({
+      // maybeSingle reports a miss as {data: null, error: null} — the shape every
+      // stale pre-re-seed colour link produces. single() would 406 instead.
+      mockSupabase._queryBuilder.maybeSingle.mockResolvedValue({
         data: null,
-        error: { message: 'Row not found', code: 'PGRST116' },
+        error: null,
       });
 
       const { useColors } = await import('~/app/composables/useColors');
@@ -304,6 +306,7 @@ describe('useColors', () => {
       const result = await getColor('11111111-2222-4333-8444-555555555555');
 
       expect(result).toBeNull();
+      expect(mockSupabase._queryBuilder.single).not.toHaveBeenCalled();
     });
 
     it('returns null for a non-uuid id without querying Supabase', async () => {

--- a/tests/unit/composables/useWheels.test.ts
+++ b/tests/unit/composables/useWheels.test.ts
@@ -296,7 +296,7 @@ describe('useWheels', () => {
   describe('getWheel', () => {
     it('fetches a single wheel by id', async () => {
       const row = makeWheelRow({ id: 'wheel-42' });
-      mockSupabase._mockSingle.mockResolvedValue({ data: row, error: null });
+      mockSupabase._mockMaybeSingle.mockResolvedValue({ data: row, error: null });
 
       const { useWheels } = await import('~/app/composables/useWheels');
       const { getWheel } = useWheels();
@@ -305,7 +305,7 @@ describe('useWheels', () => {
       expect(mockSupabase.from).toHaveBeenCalledWith('wheels');
       expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', '11111111-2222-4333-8444-555555555555');
-      expect(mockSupabase._mockSingle).toHaveBeenCalled();
+      expect(mockSupabase._mockMaybeSingle).toHaveBeenCalled();
       expect(result).not.toBeNull();
       expect(result!.uuid).toBe('wheel-42');
       expect(result!.name).toBe('Minilite');
@@ -313,7 +313,7 @@ describe('useWheels', () => {
 
     it('filters by id and approved status', async () => {
       const row = makeWheelRow({ id: 'wheel-42' });
-      mockSupabase._mockSingle.mockResolvedValue({ data: row, error: null });
+      mockSupabase._mockMaybeSingle.mockResolvedValue({ data: row, error: null });
 
       const { useWheels } = await import('~/app/composables/useWheels');
       const { getWheel } = useWheels();
@@ -325,7 +325,7 @@ describe('useWheels', () => {
     });
 
     it('returns null when Supabase returns an error', async () => {
-      mockSupabase._mockSingle.mockResolvedValue({
+      mockSupabase._mockMaybeSingle.mockResolvedValue({
         data: null,
         error: { message: 'Row not found', code: 'PGRST116' },
       });
@@ -334,6 +334,21 @@ describe('useWheels', () => {
       const { getWheel } = useWheels();
       const result = await getWheel('11111111-2222-4333-8444-555555555555');
 
+      expect(result).toBeNull();
+    });
+
+    it('uses maybeSingle so a uuid-shaped miss is null rather than a 406', async () => {
+      // Pre-migration deep links carry uuids the DynamoDB import never brought
+      // across, so "well-formed id, no row" is the common case — not an error.
+      // maybeSingle returns {data: null, error: null}; single() would 406.
+      mockSupabase._mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+
+      const { useWheels } = await import('~/app/composables/useWheels');
+      const { getWheel } = useWheels();
+      const result = await getWheel('1ce3638a-7754-5a43-ad6f-cddffe477235');
+
+      expect(mockSupabase._mockMaybeSingle).toHaveBeenCalled();
+      expect(mockSupabase._mockSingle).not.toHaveBeenCalled();
       expect(result).toBeNull();
     });
 
@@ -360,7 +375,7 @@ describe('useWheels', () => {
         offset_value: 'ET+10',
         photos: ['cosmic/front.jpg'],
       });
-      mockSupabase._mockSingle.mockResolvedValue({ data: row, error: null });
+      mockSupabase._mockMaybeSingle.mockResolvedValue({ data: row, error: null });
 
       const { useWheels } = await import('~/app/composables/useWheels');
       const { getWheel } = useWheels();


### PR DESCRIPTION
## What

Found while triaging a week of Supabase edge logs (Jul 20-26): a steady 406 trickle on `/rest/v1/wheels` and `/rest/v1/colors` — 27 hits, with one wheel id accounting for 13 on its own, all from SSR crawls.

## Root cause

Two separate problems stacked.

**1. `.single()` treats a miss as an error.** `getWheel`/`getColor` used `.single()`, so a well-formed uuid matching no row returned a PostgREST 406 instead of an empty result.

That's the common case here, not an exception. Every wheel id requested in the logs is a **UUIDv5**, while all 627 stored wheels are **v4** — [`scripts/migrate/migrate-wheels.ts`](https://github.com/ClassicMiniDIY/classicminidiy/blob/main/scripts/migrate/migrate-wheels.ts) maps the DynamoDB fields but never carries the source id across, so Postgres minted fresh ones on insert. Every previously-indexed `/archive/wheels/<old-id>` URL has been dead since the migration. Colours have the same break from a later re-seed: 0 of the 7 requested ids exist among 299 rows.

**2. The pages rendered anyway.** The wheel page has `default: () => ({}) as IWheelsData` and the colour page has no `v-else` after `v-else-if="color"`. A dead link returned **200 with a blank body and an "undefined" SEO title** — a textbook soft 404. Crawlers read that as a live page and keep re-requesting indefinitely, which is why the same handful of ids recur across all six days of logs.

## Changes

- `useWheels.getWheel` / `useColors.getColor` → `.maybeSingle()`, so a uuid-shaped miss is `{data: null, error: null}` rather than a logged API error. The `.single()` calls in `submitWheel`/`submitColor` are untouched — a failed insert *should* error.
- Both detail pages now `throw createError({ statusCode: 404 })` when the id doesn't resolve.
- Tests updated to the new mock path, plus new coverage asserting the miss case goes through `maybeSingle` and never `single`.

## What this does not fix

It stops the noise and the soft-404 SEO damage, but it **does not restore the dead links**. The legacy ids exist nowhere in Supabase — there's no `legacy_id` column and `metadata` is empty on all 627 wheels and 299 colours. Recovering them needs a `legacy_id` column added in `classicminidiy-supabase` plus a backfill from the DynamoDB source, then a redirect here. Worth tracking separately if the old tables are still around.

## Verification

- `bun run test` — 4,644 passed / 146 files
- `bun run build` — clean (client + server + prerender)

🤖 Generated with [Claude Code](https://claude.com/claude-code)