### PR TITLE
test(needles): pin canonical hash of needles.json to catch ordering drift

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,34 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Not --frozen-lockfile: the repo is mid-transition from bun.lockb to the
+      # text bun.lock, and a frozen install fails while both states are in play.
+      - name: Install dependencies
+        run: bun install
+
+      # Includes tests/unit/data/needles-data-integrity.test.ts, which pins the
+      # canonical hash of data/needles.json. The Android and iOS repos pin the
+      # same hash, so a drifted copy fails CI in whichever repo drifted.
+      - name: Run tests
+        run: bun run test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # Required: tsconfig.json extends ./.nuxt/tsconfig.json, which is
+      # generated rather than committed (.nuxt is gitignored). The repo's
+      # postinstall is overridden for a better-sqlite3 rebuild, so the usual
+      # Nuxt `postinstall: nuxt prepare` never runs and .nuxt is absent on a
+      # fresh checkout. Without this step every test file fails to load with
+      # `Cannot find module './.nuxt/tsconfig.json'` — 147 files, 0 tests run.
+      # It passes locally only because .nuxt lingers from `bun run dev`.
+      - name: Prepare Nuxt types
+        run: bunx nuxi prepare
+
       # Includes tests/unit/data/needles-data-integrity.test.ts, which pins the
       # canonical hash of data/needles.json. The Android and iOS repos pin the
       # same hash, so a drifted copy fails CI in whichever repo drifted.

--- a/tests/unit/data/needles-data-integrity.test.ts
+++ b/tests/unit/data/needles-data-integrity.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+import Needles from '~/data/needles.json';
+import DefaultNeedles from '~/data/default-needles.json';
+
+// ---------------------------------------------------------------------------
+// Why this file exists
+//
+// `data/needles.json` is the canonical SU needle dataset. Each `data` array is
+// a POSITIONAL series — 16 stations down the needle — so the ordering IS the
+// data. A reordered array is not a formatting difference, it is a different
+// needle, and every number in it still looks plausible.
+//
+// This was not hypothetical. A DynamoDB `needles` table stored `data` as a
+// Number Set (`NS`), which is unordered and deduplicating. All 54 of its rows
+// came back scrambled, and because 410 of the 709 needles legitimately repeat a
+// value (usually trailing zeros), an `NS` round-trip also silently DROPPED
+// entries — 16 values in, 14 out. That table was deleted in July 2026 and was
+// never used as a migration source. See ClassicMiniDIY/classicminidiy-supabase#64.
+//
+// Three byte-identical copies of this file ship today:
+//   classicminidiy/data/needles.json                                (canonical)
+//   ClassicMiniToolbox-android/app/src/main/assets/needles.json
+//   Classic Mini DIY Toolbox/Data/needles.json                      (iOS)
+//
+// Each repo pins the SAME canonical hash below, so drift in any one copy fails
+// that repo's CI. If you legitimately change needle data, update the hash in
+// ALL THREE repos in the same change, and re-run the copy scripts in
+// `Native CMDIY Apps/shared-data/`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Whitespace-stripped SHA-256 of `data/needles.json`.
+ *
+ * Whitespace is stripped so that a prettier reformat (which has happened three
+ * times in this file's history) does not fail CI, while any change to a value,
+ * to array ordering, or to record ordering does. Safe to do byte-wise here
+ * because no needle name contains whitespace and the file is pure ASCII.
+ *
+ * Deliberately duplicated as a literal in the Android and iOS test suites —
+ * the whole point is that three independent repos agree on one value.
+ */
+const CANONICAL_NEEDLES_SHA256 = 'fa1769214755f4bc0a78d35880e48795f1c1846d05abecf07685c7e962355273';
+
+const EXPECTED_NEEDLE_COUNT = 709;
+const STATIONS_PER_NEEDLE = 16;
+
+type NeedleRecord = { name: string; size: number; data: number[] };
+
+const needles = Needles as NeedleRecord[];
+
+function canonicalHash(filePath: string): string {
+  const raw = readFileSync(resolve(process.cwd(), filePath), 'utf8');
+  return createHash('sha256').update(raw.replace(/\s+/g, '')).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Ordering integrity — the checks that would have caught the DynamoDB bug
+// ---------------------------------------------------------------------------
+describe('needles.json ordering integrity', () => {
+  it('matches the canonical whitespace-stripped hash', () => {
+    // If this fails, needle data changed. That is allowed — but it must be
+    // deliberate, and the Android and iOS copies must change with it.
+    expect(canonicalHash('data/needles.json')).toBe(CANONICAL_NEEDLES_SHA256);
+  });
+
+  it('has not been sorted — arrays are in taper order, not numeric order', () => {
+    // A Number Set round-trip returns values in set order. The single loudest
+    // symptom is that arrays come back sorted. Real taper data is not.
+    const sortedAscending = needles.filter((n) => {
+      const values = n.data.map(Number);
+      return values.every((v, i) => i === 0 || values[i - 1] <= v);
+    });
+
+    // 407 needles end in one or more zeros, so an ascending run is only
+    // suspicious when it covers a needle with genuine variation.
+    const suspicious = sortedAscending.filter((n) => new Set(n.data.map(Number)).size > 2);
+    expect(suspicious.map((n) => n.name)).toEqual([]);
+  });
+
+  it('preserves repeated values rather than deduplicating them', () => {
+    // 410 of 709 needles repeat at least one value. A set-backed store loses
+    // those entries entirely, so assert every needle still carries a full
+    // 16 stations even where values collide.
+    const withRepeats = needles.filter((n) => new Set(n.data.map(Number)).size < n.data.length);
+
+    expect(withRepeats.length).toBeGreaterThan(0);
+    for (const needle of withRepeats) {
+      expect(needle.data).toHaveLength(STATIONS_PER_NEEDLE);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shape invariants
+// ---------------------------------------------------------------------------
+describe('needles.json shape', () => {
+  it(`contains exactly ${EXPECTED_NEEDLE_COUNT} needles`, () => {
+    expect(needles).toHaveLength(EXPECTED_NEEDLE_COUNT);
+  });
+
+  it(`gives every needle exactly ${STATIONS_PER_NEEDLE} stations`, () => {
+    const wrongLength = needles
+      .filter((n) => n.data.length !== STATIONS_PER_NEEDLE)
+      .map((n) => `${n.name} (${n.data.length})`);
+    expect(wrongLength).toEqual([]);
+  });
+
+  it('has finite, non-negative numeric values throughout', () => {
+    const bad = needles
+      .filter((n) => n.data.some((v) => !Number.isFinite(Number(v)) || Number(v) < 0))
+      .map((n) => n.name);
+    expect(bad).toEqual([]);
+  });
+
+  it('has unique needle names', () => {
+    const names = needles.map((n) => n.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('uses only the three known needle sizes', () => {
+    const sizes = [...new Set(needles.map((n) => String(n.size)))].sort();
+    expect(sizes).toEqual(['0.09', '0.1', '0.125']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Starter set consistency
+// ---------------------------------------------------------------------------
+describe('default-needles.json', () => {
+  it('references needles that exist in the canonical set', () => {
+    const canonical = new Map(needles.map((n) => [n.name, n]));
+    const missing = (DefaultNeedles as NeedleRecord[]).filter((n) => !canonical.has(n.name)).map((n) => n.name);
+    expect(missing).toEqual([]);
+  });
+
+  it('carries data identical to the canonical record, in order', () => {
+    const canonical = new Map(needles.map((n) => [n.name, n]));
+    for (const starter of DefaultNeedles as NeedleRecord[]) {
+      expect(starter.data).toEqual(canonical.get(starter.name)?.data);
+    }
+  });
+});


### PR DESCRIPTION
Guards `data/needles.json` — the **canonical** copy of the SU needle dataset — against silent ordering drift. Test-only; no production code touched.

## Why

Needle taper data is a **positional 16-station series**, so the ordering *is* the data. A reordered array isn't a formatting difference, it's a different needle — and every number in it still looks plausible, so nothing catches it downstream. It would just quietly produce wrong tuning advice.

This isn't hypothetical. A DynamoDB `needles` table stored `data` as a **Number Set** (unordered, deduplicating):

```
canonical  3.15, 2.992, 2.913, 2.832, 2.753, 2.675, 2.596, 2.517, ...
dynamodb   2.083, 2.753, 2.913, 2.21,  1.981, 3.15,  2.362, 2.134, ...
```

All 54 rows came back scrambled. Worse, **410 of the 709 needles legitimately repeat a value** (usually trailing zeros), so an `NS` round-trip also dropped entries outright — 16 values in, 14 out. That table was never used as a migration source and has been deleted: ClassicMiniDIY/classicminidiy-supabase#64.

## What this adds

**`tests/unit/data/needles-data-integrity.test.ts`** — 10 checks:

- pins the whitespace-stripped SHA-256 of `data/needles.json`
- asserts arrays are in taper order, not numeric order (the loudest `NS` symptom)
- asserts repeated values are preserved rather than deduplicated
- shape: 709 needles, 16 stations each, finite non-negative values, unique names, only the three known sizes
- `default-needles.json` references real needles and carries data identical **in order** to the canonical record

**`.github/workflows/pr-check.yml`** — the repo had **4654 passing tests and nothing running them in CI**. This adds a lean Bun + `bun run test` job on PRs so the guard actually gates.

> Uses plain `bun install` rather than `--frozen-lockfile`: the repo is mid-transition from `bun.lockb` to the text `bun.lock`, and a frozen install fails while both states are in play. Worth switching once that settles.

## The cross-repo part

Three byte-identical copies of this file ship today and **nothing enforced that they stay in sync** — drift would have been silent:

```
data/needles.json                                              (canonical, this repo)
ClassicMiniToolbox-android/app/src/main/assets/needles.json
Classic Mini DIY Toolbox/Data/needles.json                     (iOS)
```

All three repos now pin the *same* hash, so a drifted copy fails CI in whichever repo drifted. Whitespace is stripped before hashing so a prettier reformat — which has happened three times in this file's history — doesn't false-positive, while any value or ordering change does.

> **If you legitimately change needle data**, update the hash in all three repos in the same change and re-run the `shared-data/` copy scripts.

## Verification

Green as-is (10/10; full suite 4654/4654). Then mutation-tested against the real file:

| mutation | result |
|---|---|
| simulated `NS` round-trip (dedupe + sort) | **5 checks fail** |
| one needle's array reversed (still 16 values) | **2 checks fail** |
| prettier-style reformat (whitespace only) | **passes**, as intended |

File restored after each.

Companion PRs: ClassicMiniDIY/toolbox-android#66 and ClassicMiniDIY/toolbox-ios#63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)