### PR TITLE
fix(archive): stop fetching submitter emails on the public archive reads

### DIFF
--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -2,6 +2,33 @@ import type { Color, PrettyColor } from '../../data/models/colors';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * Columns read from `colors` for the public archive.
+ *
+ * Deliberately NOT `select('*')`. The table uses column-level SELECT grants
+ * since classicminidiy-supabase migration 20260727000002: submitter contact
+ * details (`legacy_submitted_by_email`) are revoked from anon/authenticated
+ * because they were world-readable, and Postgres expands `*` to every column
+ * and rejects the whole query with 42501 when one of them is not granted.
+ *
+ * Adding a column here means checking it is granted to anon in that repo.
+ */
+const COLOR_COLUMNS = [
+  'id',
+  'name',
+  'code',
+  'short_code',
+  'ditzler_ppg_code',
+  'dulux_code',
+  'year_start',
+  'year_end',
+  'hex_value',
+  'swatch_path',
+  'has_swatch',
+  'contributor_images',
+  'status',
+].join(', ');
+
 export const useColors = () => {
   const supabase = useSupabase();
   const config = useRuntimeConfig();
@@ -27,7 +54,7 @@ export const useColors = () => {
   });
 
   const listColors = async (): Promise<Color[]> => {
-    const { data, error } = await supabase.from('colors').select('*').eq('status', 'approved').order('name');
+    const { data, error } = await supabase.from('colors').select(COLOR_COLUMNS).eq('status', 'approved').order('name');
 
     if (error) throw error;
     return (data || []).map(mapToColor);
@@ -42,7 +69,7 @@ export const useColors = () => {
     // a 406 API error.
     const { data, error } = await supabase
       .from('colors')
-      .select('*')
+      .select(COLOR_COLUMNS)
       .eq('id', id)
       .eq('status', 'approved')
       .maybeSingle();

--- a/app/composables/useRegistry.ts
+++ b/app/composables/useRegistry.ts
@@ -1,5 +1,32 @@
 import type { RegistryItem } from '../../data/models/registry';
 
+/**
+ * Columns read from `registry_entries` for the public register.
+ *
+ * Deliberately NOT `select('*')`. The table uses column-level SELECT grants
+ * since classicminidiy-supabase migration 20260727000002: submitter contact
+ * details (`legacy_submitted_by_email`) are revoked from anon/authenticated
+ * because they were world-readable, and Postgres expands `*` to every column
+ * and rejects the whole query with 42501 when one of them is not granted.
+ *
+ * Adding a column here means checking it is granted to anon in that repo.
+ */
+const REGISTRY_COLUMNS = [
+  'id',
+  'year',
+  'model',
+  'body_number',
+  'engine_number',
+  'engine_size',
+  'body_type',
+  'color',
+  'trim',
+  'build_date',
+  'notes',
+  'legacy_submitted_by',
+  'status',
+].join(', ');
+
 export const useRegistry = () => {
   const supabase = useSupabase();
 
@@ -16,14 +43,16 @@ export const useRegistry = () => {
     buildDate: row.build_date,
     notes: row.notes || '',
     submittedBy: row.legacy_submitted_by || '',
-    submittedByEmail: row.legacy_submitted_by_email || '',
+    // No submittedByEmail: the register never rendered it, and the column is no
+    // longer readable by anon/authenticated. Admin surfaces read submitter
+    // contact details from submission_queue via the service client instead.
     status: row.status === 'pending' ? 'P' : row.status === 'approved' ? 'A' : ('R' as any),
   });
 
   const listApproved = async (): Promise<RegistryItem[]> => {
     const { data, error } = await supabase
       .from('registry_entries')
-      .select('*')
+      .select(REGISTRY_COLUMNS)
       .eq('status', 'approved')
       .order('year', { ascending: false });
 

--- a/app/composables/useWheels.ts
+++ b/app/composables/useWheels.ts
@@ -2,6 +2,34 @@ import type { IWheelsData } from '../../data/models/wheels';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * Columns read from `wheels` for the public archive.
+ *
+ * Deliberately NOT `select('*')`. The table uses column-level SELECT grants
+ * since classicminidiy-supabase migration 20260727000002: submitter contact
+ * details (`legacy_submitted_by_email`) are revoked from anon/authenticated
+ * because they were world-readable, and Postgres expands `*` to every column
+ * and rejects the whole query with 42501 when one of them is not granted.
+ *
+ * Adding a column here means checking it is granted to anon in that repo.
+ */
+const WHEEL_COLUMNS = [
+  'id',
+  'name',
+  'wheel_type',
+  'size',
+  'width',
+  'offset_value',
+  'bolt_pattern',
+  'center_bore',
+  'manufacturer',
+  'weight',
+  'notes',
+  'photos',
+  'legacy_submitted_by',
+  'status',
+].join(', ');
+
 export const useWheels = () => {
   const supabase = useSupabase();
   const config = useRuntimeConfig();
@@ -21,7 +49,9 @@ export const useWheels = () => {
     offset: row.offset_value || '',
     notes: row.notes || '',
     userName: row.legacy_submitted_by || '',
-    emailAddress: row.legacy_submitted_by_email || '',
+    // No emailAddress: the archive never rendered it, and the column is no
+    // longer readable by anon/authenticated. The admin review screen gets it
+    // from submission_queue via the service client instead.
     referral: '',
     images: (row.photos || []).map((p: string) => ({ src: getPhotoUrl(p) })),
     manufacturer: row.manufacturer || '',
@@ -31,7 +61,7 @@ export const useWheels = () => {
   });
 
   const listAll = async (): Promise<IWheelsData[]> => {
-    const { data, error } = await supabase.from('wheels').select('*').eq('status', 'approved').order('name');
+    const { data, error } = await supabase.from('wheels').select(WHEEL_COLUMNS).eq('status', 'approved').order('name');
 
     if (error) throw error;
     return (data || []).map(mapToWheel);
@@ -52,7 +82,7 @@ export const useWheels = () => {
   const listFeaturedCandidates = async (poolSize = 100): Promise<IWheelsData[]> => {
     const { data, error } = await supabase
       .from('wheels')
-      .select('*')
+      .select(WHEEL_COLUMNS)
       .eq('status', 'approved')
       .not('name', 'is', null)
       .not('photos', 'is', null)
@@ -66,7 +96,7 @@ export const useWheels = () => {
   const listBySize = async (wheelSize: number): Promise<IWheelsData[]> => {
     const { data, error } = await supabase
       .from('wheels')
-      .select('*')
+      .select(WHEEL_COLUMNS)
       .eq('status', 'approved')
       .eq('size', wheelSize)
       .order('name');
@@ -93,7 +123,7 @@ export const useWheels = () => {
     // returns null data and no error, which is what a miss actually is.
     const { data, error } = await supabase
       .from('wheels')
-      .select('*')
+      .select(WHEEL_COLUMNS)
       .eq('id', id)
       .eq('status', 'approved')
       .maybeSingle();

--- a/data/models/registry.ts
+++ b/data/models/registry.ts
@@ -3,7 +3,13 @@ export interface RegistryItem extends Record<string, any> {
   bodyNum: string;
   trim: string;
   submittedBy: string;
-  submittedByEmail: string;
+  /**
+   * Optional: only the submission form and the admin queue view (service
+   * client, reads submission_queue) carry this. The public register no longer
+   * fetches it — `registry_entries.legacy_submitted_by_email` is revoked from
+   * anon/authenticated as PII.
+   */
+  submittedByEmail?: string;
   engineNum: string;
   notes: string;
   year: number;

--- a/data/models/wheels.ts
+++ b/data/models/wheels.ts
@@ -13,7 +13,13 @@ export interface IWheelsData {
   offset: string;
   notes: string;
   userName: string;
-  emailAddress: string;
+  /**
+   * Optional: only the submission form and the admin review view (service
+   * client, reads submission_queue) carry this. The public archive no longer
+   * fetches it — `wheels.legacy_submitted_by_email` is revoked from
+   * anon/authenticated as PII.
+   */
+  emailAddress?: string;
   referral: string;
   images?: any[];
   newWheel?: boolean;

--- a/tests/unit/composables/useColors.test.ts
+++ b/tests/unit/composables/useColors.test.ts
@@ -112,7 +112,12 @@ describe('useColors', () => {
       const result = await listColors();
 
       expect(mockSupabase.from).toHaveBeenCalledWith('colors');
-      expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
+      // NOT select('*'): colors uses column-level SELECT grants, so `*` fails
+      // with 42501 for anon/authenticated, and the submitter email must never
+      // be requested (PII — revoked in supabase 20260727000002).
+      const selected = mockSupabase._queryBuilder.select.mock.calls[0]![0] as string;
+      expect(selected).not.toBe('*');
+      expect(selected).not.toContain('legacy_submitted_by_email');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('status', 'approved');
       expect(mockSupabase._queryBuilder.order).toHaveBeenCalledWith('name');
       expect(result).toHaveLength(2);
@@ -238,7 +243,12 @@ describe('useColors', () => {
       await getColor('11111111-2222-4333-8444-555555555555');
 
       expect(mockSupabase.from).toHaveBeenCalledWith('colors');
-      expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
+      // NOT select('*'): colors uses column-level SELECT grants, so `*` fails
+      // with 42501 for anon/authenticated, and the submitter email must never
+      // be requested (PII — revoked in supabase 20260727000002).
+      const selected = mockSupabase._queryBuilder.select.mock.calls[0]![0] as string;
+      expect(selected).not.toBe('*');
+      expect(selected).not.toContain('legacy_submitted_by_email');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', '11111111-2222-4333-8444-555555555555');
       expect(mockSupabase._queryBuilder.maybeSingle).toHaveBeenCalled();
     });

--- a/tests/unit/composables/useRegistry.test.ts
+++ b/tests/unit/composables/useRegistry.test.ts
@@ -48,8 +48,13 @@ describe('useRegistry', () => {
 
       // Verify correct table
       expect(mockSupabase.from).toHaveBeenCalledWith('registry_entries');
-      // Verify select all
-      expect(mockSupabase._mockSelect).toHaveBeenCalledWith('*');
+      // NOT select('*'): registry_entries uses column-level SELECT grants, so
+      // `*` fails with 42501 for anon/authenticated, and the submitter email
+      // must never be requested (PII — revoked in supabase 20260727000002).
+      const selected = mockSupabase._mockSelect.mock.calls[0]![0] as string;
+      expect(selected).not.toBe('*');
+      expect(selected).not.toContain('legacy_submitted_by_email');
+      expect(selected).toContain('legacy_submitted_by');
       // Verify filtering for approved
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('status', 'approved');
       // Verify ordering
@@ -100,7 +105,6 @@ describe('useRegistry', () => {
         buildDate: '1967-03-15',
         notes: 'Numbers matching',
         submittedBy: 'John Doe',
-        submittedByEmail: 'john@example.com',
         status: 'A',
       });
     });
@@ -141,7 +145,6 @@ describe('useRegistry', () => {
         buildDate: null,
         notes: '',
         submittedBy: '',
-        submittedByEmail: '',
         status: 'A',
       });
     });

--- a/tests/unit/composables/useWheels.test.ts
+++ b/tests/unit/composables/useWheels.test.ts
@@ -75,7 +75,13 @@ describe('useWheels', () => {
       const result = await listAll();
 
       expect(mockSupabase.from).toHaveBeenCalledWith('wheels');
-      expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
+      // NOT select('*'): wheels uses column-level SELECT grants, so `*` fails
+      // with 42501 for anon/authenticated, and the submitter email must never
+      // be requested (PII — revoked in supabase 20260727000002).
+      const selected = mockSupabase._queryBuilder.select.mock.calls[0]![0] as string;
+      expect(selected).not.toBe('*');
+      expect(selected).not.toContain('legacy_submitted_by_email');
+      expect(selected).toContain('legacy_submitted_by');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('status', 'approved');
       expect(mockSupabase._queryBuilder.order).toHaveBeenCalledWith('name');
       expect(result).toHaveLength(2);
@@ -101,7 +107,8 @@ describe('useWheels', () => {
       expect(wheel.offset).toBe('ET0');
       expect(wheel.notes).toBe('Classic look');
       expect(wheel.userName).toBe('TestUser');
-      expect(wheel.emailAddress).toBe('test@example.com');
+      // Never mapped from the public archive read — see WHEEL_COLUMNS.
+      expect(wheel.emailAddress).toBeUndefined();
       expect(wheel.referral).toBe('');
       expect(wheel.manufacturer).toBe('Minilite');
       expect(wheel.boltPattern).toBe('4x101.6');
@@ -168,7 +175,7 @@ describe('useWheels', () => {
       expect(wheel.offset).toBe('');
       expect(wheel.notes).toBe('');
       expect(wheel.userName).toBe('');
-      expect(wheel.emailAddress).toBe('');
+      expect(wheel.emailAddress).toBeUndefined();
       expect(wheel.manufacturer).toBe('');
       expect(wheel.boltPattern).toBe('');
       expect(wheel.centerBore).toBe('');
@@ -303,7 +310,13 @@ describe('useWheels', () => {
       const result = await getWheel('11111111-2222-4333-8444-555555555555');
 
       expect(mockSupabase.from).toHaveBeenCalledWith('wheels');
-      expect(mockSupabase._queryBuilder.select).toHaveBeenCalledWith('*');
+      // NOT select('*'): wheels uses column-level SELECT grants, so `*` fails
+      // with 42501 for anon/authenticated, and the submitter email must never
+      // be requested (PII — revoked in supabase 20260727000002).
+      const selected = mockSupabase._queryBuilder.select.mock.calls[0]![0] as string;
+      expect(selected).not.toBe('*');
+      expect(selected).not.toContain('legacy_submitted_by_email');
+      expect(selected).toContain('legacy_submitted_by');
       expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('id', '11111111-2222-4333-8444-555555555555');
       expect(mockSupabase._mockMaybeSingle).toHaveBeenCalled();
       expect(result).not.toBeNull();


### PR DESCRIPTION
Client half of the fix for [classicminidiy-supabase#65](https://github.com/ClassicMiniDIY/classicminidiy-supabase/issues/65) phase 1. **This must be deployed before** the paired migration in [classicminidiy-supabase#67](https://github.com/ClassicMiniDIY/classicminidiy-supabase/pull/67), or the register, wheel and colour archives all break.

## Why

`registry_entries`, `wheels` and `colors` each pair a `TO public` SELECT policy on approved rows with a table-wide `GRANT ALL` from `20260316000001`, so the `legacy_submitted_by_email` values copied out of DynamoDB are readable by any anonymous caller. Verified against production as the `anon` role: **35 distinct addresses on `registry_entries`, 15 on `wheels`**.

The supabase-side fix revokes SELECT on that column. Postgres expands `*` to every column and checks each one, so `select('*')` starts returning `42501 permission denied` for `anon`/`authenticated` the moment it lands — and all three composables used `select('*')`.

## What changed

- `useRegistry`, `useWheels`, `useColors` name the columns they actually map, in a documented `*_COLUMNS` constant per composable.
- The mappers stop reading the email entirely. Nothing rendered it — `RegistryTable` shows the submitter *name* only.
- `submittedByEmail` / `emailAddress` become optional on the shared models: only the submission forms and the admin queue view carry them now.
- Tests assert the invariant (never `*`, never `legacy_submitted_by_email`) instead of pinning the old shape, so this can't silently regress.

## Not affected

The admin review and queue screens read submitter contact details from `submission_queue` via the service client (`/api/wheels/review/list`, `/api/registry/queue/list`), not from these tables. Sitemap sources are service-client too. No mobile client reads these tables.

## Verification

`bun run test` — 147 files, 4654 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)