### PR TITLE
feat(registry): claim prompt, owner edits, and a review surface for legacy pending rows

### DIFF
--- a/app/components/RegistryClaimPrompt.vue
+++ b/app/components/RegistryClaimPrompt.vue
@@ -1,0 +1,255 @@
+<script lang="ts" setup>
+  import type { ClaimableRegistryEntry } from '../../data/models/registry';
+
+  /**
+   * "Is this your Mini?" prompt.
+   *
+   * Register entries migrated from DynamoDB carry only a free-text submitter name
+   * and email — no account. classicminidiy-supabase #65 linked the ones whose
+   * email matched a CONFIRMED account; everyone else claims theirs here once they
+   * sign up and confirm.
+   *
+   * Deliberately a prompt, not a silent auto-link: attaching someone's car to a
+   * newly created account without asking is worth a confirmation, and the entry
+   * shown is the proof the user needs to recognise it as theirs.
+   *
+   * The RPC returns nothing for an unauthenticated or unconfirmed caller, so this
+   * renders nothing rather than nagging logged-out visitors.
+   */
+  const { t } = useI18n();
+  const { isAuthenticated } = useAuth();
+  const { listClaimable, claimEntry } = useRegistry();
+  const toast = useToast();
+  const { track } = useAnalytics();
+
+  const emit = defineEmits<{ claimed: [] }>();
+
+  const entries = ref<ClaimableRegistryEntry[]>([]);
+  const claiming = ref<string | null>(null);
+  const dismissed = ref(false);
+
+  const refresh = async () => {
+    if (!isAuthenticated.value) {
+      entries.value = [];
+      return;
+    }
+    entries.value = await listClaimable();
+  };
+
+  // Client-only: depends on the auth session, and re-runs when the user signs in
+  // or out without a page change.
+  onMounted(refresh);
+  watch(isAuthenticated, refresh);
+
+  const claim = async (entry: ClaimableRegistryEntry) => {
+    claiming.value = entry.id;
+    try {
+      await claimEntry(entry.id);
+      entries.value = entries.value.filter((e) => e.id !== entry.id);
+      toast.add({
+        title: t('claimed_title'),
+        description: t('claimed_description', { year: entry.year, model: entry.model }),
+        color: 'success',
+        icon: 'i-fa6-solid-circle-check',
+      });
+      track?.('registry_entry_claimed', { entry_id: entry.id });
+      emit('claimed');
+    } catch (e: any) {
+      // The RPC refuses a mismatched or already-claimed entry; surface its message
+      // rather than a generic failure, since "already claimed" is actionable.
+      toast.add({
+        title: t('claim_failed_title'),
+        description: e?.message || t('claim_failed_description'),
+        color: 'error',
+        icon: 'i-fa6-solid-triangle-exclamation',
+      });
+    } finally {
+      claiming.value = null;
+    }
+  };
+</script>
+
+<template>
+  <div v-if="entries.length > 0 && !dismissed" class="card bg-base-100 shadow-sm border border-primary/40 mb-6">
+    <div class="card-body">
+      <div class="flex items-start justify-between gap-4">
+        <h3 class="card-title text-lg">
+          <i class="fas fa-car-side text-primary mr-2" aria-hidden="true"></i>
+          {{ t('heading', entries.length) }}
+        </h3>
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm btn-circle"
+          :aria-label="t('dismiss')"
+          @click="dismissed = true"
+        >
+          <i class="fas fa-xmark" aria-hidden="true"></i>
+        </button>
+      </div>
+
+      <p class="text-sm text-base-content/70">{{ t('description') }}</p>
+
+      <ul class="mt-2 divide-y divide-base-300">
+        <li v-for="entry in entries" :key="entry.id" class="flex flex-wrap items-center justify-between gap-3 py-3">
+          <div>
+            <div class="font-semibold">{{ entry.year }} {{ entry.model || t('unknown_model') }}</div>
+            <div class="text-sm text-base-content/70">
+              <span v-if="entry.bodyNum">{{ t('body_number', { value: entry.bodyNum }) }}</span>
+              <span v-if="entry.bodyNum && entry.submittedBy"> &middot; </span>
+              <span v-if="entry.submittedBy">{{ t('submitted_by', { value: entry.submittedBy }) }}</span>
+            </div>
+          </div>
+          <button type="button" class="btn btn-primary btn-sm" :disabled="claiming === entry.id" @click="claim(entry)">
+            <span v-if="claiming === entry.id" class="loading loading-spinner loading-xs" aria-hidden="true"></span>
+            {{ claiming === entry.id ? t('claiming') : t('claim') }}
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "heading": "This might be your Mini | We found {count} entries that might be yours",
+    "description": "A register entry was submitted using your email address before you had an account. Claim it to have it listed as yours.",
+    "claim": "This is mine",
+    "claiming": "Claiming...",
+    "dismiss": "Dismiss",
+    "body_number": "Body no. {value}",
+    "submitted_by": "Submitted by {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "Entry claimed",
+    "claimed_description": "Your {year} {model} is now linked to your account.",
+    "claim_failed_title": "Could not claim entry",
+    "claim_failed_description": "Please try again later."
+  },
+  "de": {
+    "heading": "Das könnte Ihr Mini sein | Wir haben {count} Einträge gefunden, die Ihnen gehören könnten",
+    "description": "Ein Registereintrag wurde mit Ihrer E-Mail-Adresse eingereicht, bevor Sie ein Konto hatten. Beanspruchen Sie ihn, damit er Ihnen zugeordnet wird.",
+    "claim": "Das gehört mir",
+    "claiming": "Wird beansprucht...",
+    "dismiss": "Schließen",
+    "body_number": "Karosserie-Nr. {value}",
+    "submitted_by": "Eingereicht von {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "Eintrag beansprucht",
+    "claimed_description": "Ihr {year} {model} ist jetzt mit Ihrem Konto verknüpft.",
+    "claim_failed_title": "Eintrag konnte nicht beansprucht werden",
+    "claim_failed_description": "Bitte versuchen Sie es später erneut."
+  },
+  "es": {
+    "heading": "Este podría ser su Mini | Encontramos {count} entradas que podrían ser suyas",
+    "description": "Se envió una entrada al registro con su dirección de correo antes de que tuviera una cuenta. Reclámela para que aparezca como suya.",
+    "claim": "Esta es mía",
+    "claiming": "Reclamando...",
+    "dismiss": "Descartar",
+    "body_number": "N.º de carrocería {value}",
+    "submitted_by": "Enviado por {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "Entrada reclamada",
+    "claimed_description": "Su {year} {model} ya está vinculado a su cuenta.",
+    "claim_failed_title": "No se pudo reclamar la entrada",
+    "claim_failed_description": "Inténtelo de nuevo más tarde."
+  },
+  "fr": {
+    "heading": "Ceci est peut-être votre Mini | Nous avons trouvé {count} entrées qui pourraient être les vôtres",
+    "description": "Une entrée du registre a été soumise avec votre adresse e-mail avant que vous n'ayez un compte. Réclamez-la pour qu'elle vous soit attribuée.",
+    "claim": "C'est la mienne",
+    "claiming": "Réclamation...",
+    "dismiss": "Fermer",
+    "body_number": "N° de caisse {value}",
+    "submitted_by": "Soumis par {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "Entrée réclamée",
+    "claimed_description": "Votre {year} {model} est maintenant liée à votre compte.",
+    "claim_failed_title": "Impossible de réclamer l'entrée",
+    "claim_failed_description": "Veuillez réessayer plus tard."
+  },
+  "it": {
+    "heading": "Questa potrebbe essere la tua Mini | Abbiamo trovato {count} voci che potrebbero essere tue",
+    "description": "Una voce del registro è stata inviata con il tuo indirizzo email prima che avessi un account. Rivendicala per averla assegnata a te.",
+    "claim": "Questa è mia",
+    "claiming": "Rivendicazione...",
+    "dismiss": "Chiudi",
+    "body_number": "N. scocca {value}",
+    "submitted_by": "Inviato da {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "Voce rivendicata",
+    "claimed_description": "La tua {year} {model} è ora collegata al tuo account.",
+    "claim_failed_title": "Impossibile rivendicare la voce",
+    "claim_failed_description": "Riprova più tardi."
+  },
+  "pt": {
+    "heading": "Este pode ser o seu Mini | Encontramos {count} entradas que podem ser suas",
+    "description": "Uma entrada no registro foi enviada com o seu endereço de e-mail antes de você ter uma conta. Reivindique-a para que fique listada como sua.",
+    "claim": "Esta é minha",
+    "claiming": "Reivindicando...",
+    "dismiss": "Dispensar",
+    "body_number": "N.º de carroceria {value}",
+    "submitted_by": "Enviado por {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "Entrada reivindicada",
+    "claimed_description": "Seu {year} {model} agora está vinculado à sua conta.",
+    "claim_failed_title": "Não foi possível reivindicar a entrada",
+    "claim_failed_description": "Tente novamente mais tarde."
+  },
+  "ru": {
+    "heading": "Возможно, это ваш Mini | Мы нашли {count} записей, которые могут быть вашими",
+    "description": "Запись в реестре была отправлена с вашего адреса электронной почты до того, как у вас появился аккаунт. Заявите права, чтобы она числилась за вами.",
+    "claim": "Это моя",
+    "claiming": "Оформление...",
+    "dismiss": "Закрыть",
+    "body_number": "Номер кузова {value}",
+    "submitted_by": "Отправил {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "Запись закреплена",
+    "claimed_description": "Ваш {year} {model} теперь привязан к вашему аккаунту.",
+    "claim_failed_title": "Не удалось закрепить запись",
+    "claim_failed_description": "Повторите попытку позже."
+  },
+  "ja": {
+    "heading": "あなたのMiniかもしれません | あなたのものと思われる登録が{count}件見つかりました",
+    "description": "アカウント作成前に、あなたのメールアドレスで登録が申請されていました。申請するとあなたの車両として表示されます。",
+    "claim": "これは私の車です",
+    "claiming": "申請中...",
+    "dismiss": "閉じる",
+    "body_number": "ボディ番号 {value}",
+    "submitted_by": "申請者 {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "登録を紐付けました",
+    "claimed_description": "{year} {model} がアカウントに紐付けられました。",
+    "claim_failed_title": "登録を紐付けできませんでした",
+    "claim_failed_description": "後でもう一度お試しください。"
+  },
+  "zh": {
+    "heading": "这可能是您的 Mini | 我们找到了 {count} 条可能属于您的记录",
+    "description": "在您注册账户之前，有人使用您的邮箱提交了一条登记记录。认领后即可显示为您的车辆。",
+    "claim": "这是我的",
+    "claiming": "认领中...",
+    "dismiss": "关闭",
+    "body_number": "车身编号 {value}",
+    "submitted_by": "提交者 {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "已认领记录",
+    "claimed_description": "您的 {year} {model} 已关联到您的账户。",
+    "claim_failed_title": "无法认领该记录",
+    "claim_failed_description": "请稍后再试。"
+  },
+  "ko": {
+    "heading": "회원님의 Mini일 수 있습니다 | 회원님의 것으로 보이는 항목 {count}건을 찾았습니다",
+    "description": "계정을 만들기 전에 회원님의 이메일 주소로 등록이 제출되었습니다. 인증하면 회원님의 차량으로 표시됩니다.",
+    "claim": "제 차량입니다",
+    "claiming": "처리 중...",
+    "dismiss": "닫기",
+    "body_number": "차체 번호 {value}",
+    "submitted_by": "제출자 {value}",
+    "unknown_model": "Mini",
+    "claimed_title": "항목이 연결되었습니다",
+    "claimed_description": "{year} {model} 차량이 계정에 연결되었습니다.",
+    "claim_failed_title": "항목을 연결할 수 없습니다",
+    "claim_failed_description": "나중에 다시 시도해 주세요."
+  }
+}
+</i18n>

--- a/app/components/RegistryTable.vue
+++ b/app/components/RegistryTable.vue
@@ -23,6 +23,28 @@
     defaultPageSize: 10,
   });
 
+  const { user } = useAuth();
+
+  /**
+   * Owner edits go through the moderation queue rather than writing to
+   * registry_entries directly — the RLS UPDATE policy permits nothing on an
+   * approved entry by design, so an approved register entry can't be silently
+   * rewritten. SuggestEditModal already speaks `target_type: 'registry'`, and
+   * the admin approve handler applies the change to the target row.
+   *
+   * Only the owner sees this; ownership comes from the `submitted_by` column,
+   * set by the #65 backfill or by claiming.
+   */
+  const isOwner = (item: RegistryItem) => !!user.value && !!item.ownerId && item.ownerId === user.value.id;
+
+  const editingItem = ref<RegistryItem | null>(null);
+  const showSuggestEdit = ref(false);
+
+  const openSuggestEdit = (item: RegistryItem) => {
+    editingItem.value = item;
+    showSuggestEdit.value = true;
+  };
+
   // State
   const searchValue = ref('');
   const expanded = ref<string[]>([]);
@@ -281,6 +303,16 @@
                         <strong>{{ t('expanded_details.notes') }}</strong>
                         <div>{{ item.notes || t('no_data') }}</div>
                       </div>
+                      <div v-if="isOwner(item)" class="mt-2">
+                        <span class="badge badge-success badge-sm mr-2">
+                          <i class="fas fa-circle-check mr-1" aria-hidden="true"></i>
+                          {{ t('owner.yours') }}
+                        </span>
+                        <button type="button" class="btn btn-outline btn-xs" @click="openSuggestEdit(item)">
+                          <i class="fas fa-pen-to-square mr-1" aria-hidden="true"></i>
+                          {{ t('owner.suggest_edit') }}
+                        </button>
+                      </div>
                     </div>
                   </td>
                 </tr>
@@ -339,6 +371,29 @@
         </div>
       </div>
     </div>
+
+    <SuggestEditModal
+      v-if="editingItem"
+      v-model="showSuggestEdit"
+      target-type="registry"
+      :target-id="editingItem.uniqueId"
+      :current-data="{
+        model: editingItem.model,
+        trim: editingItem.trim,
+        color: editingItem.color,
+        body_number: editingItem.bodyNum,
+        engine_number: editingItem.engineNum,
+        notes: editingItem.notes,
+      }"
+      :editable-fields="[
+        { key: 'model', label: t('owner.field_model'), type: 'text' },
+        { key: 'trim', label: t('owner.field_trim'), type: 'text' },
+        { key: 'color', label: t('owner.field_color'), type: 'text' },
+        { key: 'body_number', label: t('owner.field_body_number'), type: 'text' },
+        { key: 'engine_number', label: t('owner.field_engine_number'), type: 'text' },
+        { key: 'notes', label: t('owner.field_notes'), type: 'textarea' },
+      ]"
+    />
   </div>
 </template>
 
@@ -366,6 +421,16 @@
       "submitted_by": "Submitted by:",
       "notes": "Notes:"
     },
+    "owner": {
+      "yours": "Your entry",
+      "suggest_edit": "Suggest an edit",
+      "field_model": "Model",
+      "field_trim": "Trim",
+      "field_color": "Color",
+      "field_body_number": "Body number",
+      "field_engine_number": "Engine number",
+      "field_notes": "Notes"
+    },
     "no_items_found": "No items found",
     "no_data": "---"
   },
@@ -390,6 +455,16 @@
       "engine_number": "Motor-Nr.:",
       "submitted_by": "Eingereicht von:",
       "notes": "Notizen:"
+    },
+    "owner": {
+      "yours": "Ihr Eintrag",
+      "suggest_edit": "Änderung vorschlagen",
+      "field_model": "Modell",
+      "field_trim": "Ausstattung",
+      "field_color": "Farbe",
+      "field_body_number": "Karosserienummer",
+      "field_engine_number": "Motornummer",
+      "field_notes": "Notizen"
     },
     "no_items_found": "Keine Elemente gefunden",
     "no_data": "---"
@@ -416,6 +491,16 @@
       "submitted_by": "Enviado por:",
       "notes": "Notas:"
     },
+    "owner": {
+      "yours": "Su entrada",
+      "suggest_edit": "Sugerir un cambio",
+      "field_model": "Modelo",
+      "field_trim": "Acabado",
+      "field_color": "Color",
+      "field_body_number": "Número de carrocería",
+      "field_engine_number": "Número de motor",
+      "field_notes": "Notas"
+    },
     "no_items_found": "No se encontraron elementos",
     "no_data": "---"
   },
@@ -440,6 +525,16 @@
       "engine_number": "N° de moteur :",
       "submitted_by": "Soumis par :",
       "notes": "Notes :"
+    },
+    "owner": {
+      "yours": "Votre entrée",
+      "suggest_edit": "Suggérer une modification",
+      "field_model": "Modèle",
+      "field_trim": "Finition",
+      "field_color": "Couleur",
+      "field_body_number": "Numéro de caisse",
+      "field_engine_number": "Numéro de moteur",
+      "field_notes": "Notes"
     },
     "no_items_found": "Aucun élément trouvé",
     "no_data": "---"
@@ -466,6 +561,16 @@
       "submitted_by": "Inviato da:",
       "notes": "Note:"
     },
+    "owner": {
+      "yours": "La tua voce",
+      "suggest_edit": "Suggerisci una modifica",
+      "field_model": "Modello",
+      "field_trim": "Allestimento",
+      "field_color": "Colore",
+      "field_body_number": "Numero scocca",
+      "field_engine_number": "Numero motore",
+      "field_notes": "Note"
+    },
     "no_items_found": "Nessun elemento trovato",
     "no_data": "---"
   },
@@ -490,6 +595,16 @@
       "engine_number": "Nº do Motor:",
       "submitted_by": "Enviado por:",
       "notes": "Observações:"
+    },
+    "owner": {
+      "yours": "Sua entrada",
+      "suggest_edit": "Sugerir uma alteração",
+      "field_model": "Modelo",
+      "field_trim": "Acabamento",
+      "field_color": "Cor",
+      "field_body_number": "Número de carroceria",
+      "field_engine_number": "Número do motor",
+      "field_notes": "Notas"
     },
     "no_items_found": "Nenhum item encontrado",
     "no_data": "---"
@@ -516,6 +631,16 @@
       "submitted_by": "Отправлено:",
       "notes": "Примечания:"
     },
+    "owner": {
+      "yours": "Ваша запись",
+      "suggest_edit": "Предложить изменение",
+      "field_model": "Модель",
+      "field_trim": "Комплектация",
+      "field_color": "Цвет",
+      "field_body_number": "Номер кузова",
+      "field_engine_number": "Номер двигателя",
+      "field_notes": "Примечания"
+    },
     "no_items_found": "Элементы не найдены",
     "no_data": "---"
   },
@@ -540,6 +665,16 @@
       "engine_number": "エンジン番号:",
       "submitted_by": "投稿者:",
       "notes": "備考:"
+    },
+    "owner": {
+      "yours": "あなたの登録",
+      "suggest_edit": "修正を提案",
+      "field_model": "モデル",
+      "field_trim": "トリム",
+      "field_color": "カラー",
+      "field_body_number": "ボディ番号",
+      "field_engine_number": "エンジン番号",
+      "field_notes": "備考"
     },
     "no_items_found": "項目が見つかりません",
     "no_data": "---"
@@ -566,6 +701,16 @@
       "submitted_by": "提交者：",
       "notes": "备注："
     },
+    "owner": {
+      "yours": "您的记录",
+      "suggest_edit": "建议修改",
+      "field_model": "车型",
+      "field_trim": "内饰",
+      "field_color": "颜色",
+      "field_body_number": "车身编号",
+      "field_engine_number": "发动机编号",
+      "field_notes": "备注"
+    },
     "no_items_found": "未找到项目",
     "no_data": "---"
   },
@@ -590,6 +735,16 @@
       "engine_number": "엔진 번호:",
       "submitted_by": "제출자:",
       "notes": "참고사항:"
+    },
+    "owner": {
+      "yours": "내 항목",
+      "suggest_edit": "수정 제안",
+      "field_model": "모델",
+      "field_trim": "트림",
+      "field_color": "색상",
+      "field_body_number": "차체 번호",
+      "field_engine_number": "엔진 번호",
+      "field_notes": "메모"
     },
     "no_items_found": "항목을 찾을 수 없습니다",
     "no_data": "---"

--- a/app/composables/useRegistry.ts
+++ b/app/composables/useRegistry.ts
@@ -1,4 +1,4 @@
-import type { RegistryItem } from '../../data/models/registry';
+import type { ClaimableRegistryEntry, RegistryItem } from '../../data/models/registry';
 
 /**
  * Columns read from `registry_entries` for the public register.
@@ -24,6 +24,11 @@ const REGISTRY_COLUMNS = [
   'build_date',
   'notes',
   'legacy_submitted_by',
+  // Ownership, not contact details: this is a profiles id, and it drives the
+  // "this entry is yours" affordance. Populated by the #65 phase-3 backfill for
+  // submitters whose email matched a confirmed account, and by claim_registry_entry
+  // for everyone who claims later.
+  'submitted_by',
   'status',
 ].join(', ');
 
@@ -43,6 +48,7 @@ export const useRegistry = () => {
     buildDate: row.build_date,
     notes: row.notes || '',
     submittedBy: row.legacy_submitted_by || '',
+    ownerId: row.submitted_by ?? null,
     // No submittedByEmail: the register never rendered it, and the column is no
     // longer readable by anon/authenticated. Admin surfaces read submitter
     // contact details from submission_queue via the service client instead.
@@ -80,5 +86,36 @@ export const useRegistry = () => {
     return data;
   };
 
-  return { listApproved, submitRegistryEntry };
+  /**
+   * Register entries this user can claim: ones whose recorded submitter email
+   * equals their CONFIRMED account email and that nobody owns yet.
+   *
+   * The RPC does the matching server-side and never returns the stored email —
+   * that column is service_role-only. It returns nothing for an unauthenticated
+   * or unconfirmed caller, so this is safe to call unconditionally after auth.
+   */
+  const listClaimable = async (): Promise<ClaimableRegistryEntry[]> => {
+    const { data, error } = await supabase.rpc('get_my_claimable_registry_entries');
+
+    // A logged-out visitor is the common case, not an error worth surfacing.
+    if (error) return [];
+    return (data || []).map((row: any) => ({
+      id: row.id,
+      year: row.year,
+      model: row.model || '',
+      bodyNum: row.body_number || '',
+      submittedBy: row.submitted_by_name || '',
+    }));
+  };
+
+  /**
+   * Take ownership of an entry submitted from this user's confirmed address.
+   * The server re-checks the match; this cannot claim someone else's entry.
+   */
+  const claimEntry = async (entryId: string): Promise<void> => {
+    const { error } = await supabase.rpc('claim_registry_entry', { p_entry_id: entryId });
+    if (error) throw error;
+  };
+
+  return { listApproved, submitRegistryEntry, listClaimable, claimEntry };
 };

--- a/app/pages/archive/registry/index.vue
+++ b/app/pages/archive/registry/index.vue
@@ -13,7 +13,9 @@
     { title: t('table_headers.color'), key: 'color' },
   ];
 
-  const { data: registryItems, status } = await useAsyncData('registry-list', () => listApproved());
+  // `refresh` re-pulls the list after a claim so the entry immediately shows as
+  // owned (and its "suggest an edit" affordance appears) without a reload.
+  const { data: registryItems, status, refresh } = await useAsyncData('registry-list', () => listApproved());
 
   useHead({
     title: t('title'),
@@ -137,7 +139,9 @@
               class="block"
               @click="track('contribute_cta_clicked', { type: 'registry', location: 'archive_registry' })"
             >
-              <div class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-2xl transition-shadow duration-300">
+              <div
+                class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-2xl transition-shadow duration-300"
+              >
                 <div class="card-body">
                   <div class="flex items-start space-x-4">
                     <div class="flex-shrink-0">
@@ -174,6 +178,10 @@
         </div>
       </div>
       <div class="col-span-12">
+        <!-- Renders nothing unless the signed-in user has an unclaimed entry
+             submitted from their confirmed email address. -->
+        <RegistryClaimPrompt @claimed="refresh()" />
+
         <RegistryTable
           :items="registryItems || []"
           :loading="status === 'pending'"

--- a/app/pages/archive/registry/pending.vue
+++ b/app/pages/archive/registry/pending.vue
@@ -17,6 +17,51 @@
   // Fetch pending registry items
   const { data: pendingItemsRaw, status } = await useAdminFetch<RegistryItem[]>('/api/registry/queue/list');
 
+  /**
+   * Pending rows that sit on `registry_entries` itself rather than in
+   * submission_queue — the DynamoDB MiniRegisterQueue submissions that were never
+   * approved and whose submitters never had accounts (classicminidiy-supabase
+   * 20260727000004). The table above reads submission_queue, so without this they
+   * are reachable only by SQL.
+   */
+  interface LegacyPendingEntry {
+    id: string;
+    year: number;
+    model: string;
+    bodyNum: string;
+    submittedBy: string;
+    submittedByEmail: string;
+  }
+
+  const { data: legacyPendingRaw, refresh: refreshLegacy } = await useAdminFetch<LegacyPendingEntry[]>(
+    '/api/registry/pending-entries/list'
+  );
+
+  const legacyPending = computed(() => legacyPendingRaw.value ?? []);
+  const moderating = ref<string | null>(null);
+  const legacyError = ref('');
+
+  // $adminFetch, not useAdminFetch: this runs from a click handler, and
+  // useAdminFetch wraps useFetch, which belongs in setup rather than an event
+  // callback. $adminFetch is the $fetch-based mutation wrapper.
+  const moderate = async (entry: LegacyPendingEntry, action: 'approve' | 'reject') => {
+    moderating.value = entry.id;
+    legacyError.value = '';
+    try {
+      await $adminFetch('/api/registry/pending-entries/moderate', {
+        method: 'POST',
+        body: { id: entry.id, action },
+      });
+      await refreshLegacy();
+    } catch (e: any) {
+      // The endpoint refuses an entry that already has a submitter account, so
+      // its message is worth showing verbatim rather than a generic failure.
+      legacyError.value = e?.data?.message || e?.statusMessage || e?.message || 'Failed to moderate entry';
+    } finally {
+      moderating.value = null;
+    }
+  };
+
   // Computed property to filter only pending items
   const pendingItems = computed(() => {
     if (!pendingItemsRaw.value) return [];
@@ -62,7 +107,13 @@
         </breadcrumb>
         <div class="grid grid-cols-1 md:grid-cols-12 gap-6">
           <div class="col-span-12 md:col-span-8">
-            <PageIntro :eyebrow="t('eyebrow')" :title="t('main_heading')" :description="t('description_text')" class="mb-6" as="h2" />
+            <PageIntro
+              :eyebrow="t('eyebrow')"
+              :title="t('main_heading')"
+              :description="t('description_text')"
+              class="mb-6"
+              as="h2"
+            />
             <h2 class="text-xl mt-4">
               <strong>{{ pendingItems?.length || '0' }}</strong>
               {{ t('subtitle') }}
@@ -111,6 +162,65 @@
           :defaultPageSize="10"
         />
       </div>
+      <!-- Legacy imports: pending rows that live on registry_entries rather than
+           submission_queue, so they don't appear in the table above. -->
+      <div v-if="legacyPending.length > 0" class="col-span-12">
+        <div class="card bg-base-100 shadow-sm border border-warning/40">
+          <div class="card-body">
+            <h2 class="card-title text-lg">
+              <i class="fas fa-box-archive text-warning mr-2" aria-hidden="true"></i>
+              {{ t('legacy.title', legacyPending.length) }}
+            </h2>
+            <p class="text-sm text-base-content/70">{{ t('legacy.description') }}</p>
+
+            <p v-if="legacyError" class="text-error text-sm mt-2">{{ legacyError }}</p>
+
+            <div class="overflow-x-auto mt-3">
+              <table class="table table-zebra">
+                <thead>
+                  <tr>
+                    <th>{{ t('table_headers.year') }}</th>
+                    <th>{{ t('table_headers.model') }}</th>
+                    <th>{{ t('table_headers.body_number') }}</th>
+                    <th>{{ t('table_headers.submitted_by') }}</th>
+                    <th class="text-right">{{ t('legacy.actions') }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="entry in legacyPending" :key="entry.id">
+                    <td>{{ entry.year }}</td>
+                    <td>{{ entry.model || '---' }}</td>
+                    <td>{{ entry.bodyNum || '---' }}</td>
+                    <td>
+                      <div>{{ entry.submittedBy || '---' }}</div>
+                      <div class="text-xs text-base-content/60">{{ entry.submittedByEmail || '---' }}</div>
+                    </td>
+                    <td class="text-right whitespace-nowrap">
+                      <button
+                        type="button"
+                        class="btn btn-success btn-xs mr-2"
+                        :disabled="moderating === entry.id"
+                        @click="moderate(entry, 'approve')"
+                      >
+                        {{ t('legacy.approve') }}
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-error btn-outline btn-xs"
+                        :disabled="moderating === entry.id"
+                        @click="moderate(entry, 'reject')"
+                      >
+                        {{ t('legacy.reject') }}
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="col-span-12 md:col-span-10 md:col-start-2">
         <div class="divider">{{ t('submit_divider') }}</div>
       </div>
@@ -135,6 +245,13 @@
     "description_text": "Below you can see all pending registry submissions that are currently being reviewed. Submissions are typically processed within 7-14 days.",
     "contact_text": "If you have questions about your submission, please",
     "contact_link": "contact us",
+    "legacy": {
+      "title": "1 legacy submission needs review | {count} legacy submissions need review",
+      "description": "These were submitted before the site moved to Supabase and were never approved. Their submitters have no account, so they are not in the queue above. Approving publishes the entry to the register; rejecting hides it.",
+      "approve": "Approve",
+      "reject": "Reject",
+      "actions": "Actions"
+    },
     "table_headers": {
       "year": "Year",
       "model": "Model",
@@ -171,6 +288,13 @@
     "description_text": "Unten können Sie alle ausstehenden Registry-Einreichungen sehen, die derzeit überprüft werden. Einreichungen werden normalerweise innerhalb von 7-14 Tagen bearbeitet.",
     "contact_text": "Wenn Sie Fragen zu Ihrer Einreichung haben, bitte",
     "contact_link": "kontaktieren Sie uns",
+    "legacy": {
+      "title": "1 Alteinreichung wartet auf Prüfung | {count} Alteinreichungen warten auf Prüfung",
+      "description": "Diese wurden vor dem Wechsel zu Supabase eingereicht und nie genehmigt. Ihre Einreicher haben kein Konto, daher stehen sie nicht in der Liste oben. Genehmigen veröffentlicht den Eintrag im Register, Ablehnen blendet ihn aus.",
+      "approve": "Genehmigen",
+      "reject": "Ablehnen",
+      "actions": "Aktionen"
+    },
     "table_headers": {
       "year": "Jahr",
       "model": "Modell",
@@ -207,6 +331,13 @@
     "description_text": "A continuación puedes ver todos los envíos de registro pendientes que están siendo revisados actualmente. Los envíos se procesan típicamente dentro de 7-14 días.",
     "contact_text": "Si tienes preguntas sobre tu envío, por favor",
     "contact_link": "contáctanos",
+    "legacy": {
+      "title": "1 envío heredado requiere revisión | {count} envíos heredados requieren revisión",
+      "description": "Se enviaron antes de la migración a Supabase y nunca se aprobaron. Sus autores no tienen cuenta, por lo que no aparecen en la cola anterior. Aprobar publica la entrada en el registro; rechazar la oculta.",
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "actions": "Acciones"
+    },
     "table_headers": {
       "year": "Año",
       "model": "Modelo",
@@ -243,6 +374,13 @@
     "description_text": "Ci-dessous, vous pouvez voir toutes les soumissions de registre en attente qui sont actuellement en cours de révision. Les soumissions sont généralement traitées dans les 7-14 jours.",
     "contact_text": "Si vous avez des questions sur votre soumission, veuillez",
     "contact_link": "nous contacter",
+    "legacy": {
+      "title": "1 soumission héritée à examiner | {count} soumissions héritées à examiner",
+      "description": "Elles ont été soumises avant le passage à Supabase et n'ont jamais été approuvées. Leurs auteurs n'ont pas de compte, elles n'apparaissent donc pas dans la file ci-dessus. Approuver publie l'entrée au registre ; rejeter la masque.",
+      "approve": "Approuver",
+      "reject": "Rejeter",
+      "actions": "Actions"
+    },
     "table_headers": {
       "year": "Année",
       "model": "Modèle",
@@ -279,6 +417,13 @@
     "description_text": "Di seguito puoi vedere tutti gli invii di registro in sospeso che sono attualmente in fase di revisione. Gli invii vengono generalmente elaborati entro 7-14 giorni.",
     "contact_text": "Se hai domande sul tuo invio, per favore",
     "contact_link": "contattaci",
+    "legacy": {
+      "title": "1 invio legacy da revisionare | {count} invii legacy da revisionare",
+      "description": "Sono stati inviati prima del passaggio a Supabase e mai approvati. Chi li ha inviati non ha un account, quindi non compaiono nella coda sopra. Approvare pubblica la voce nel registro; rifiutare la nasconde.",
+      "approve": "Approva",
+      "reject": "Rifiuta",
+      "actions": "Azioni"
+    },
     "table_headers": {
       "year": "Anno",
       "model": "Modello",
@@ -315,6 +460,13 @@
     "description_text": "Abaixo você pode ver todas as submissões de registro pendentes que estão sendo revisadas atualmente. As submissões são normalmente processadas dentro de 7-14 dias.",
     "contact_text": "Se você tem perguntas sobre sua submissão, por favor",
     "contact_link": "entre em contato conosco",
+    "legacy": {
+      "title": "1 envio antigo precisa de revisão | {count} envios antigos precisam de revisão",
+      "description": "Foram enviados antes da migração para o Supabase e nunca aprovados. Os autores não têm conta, por isso não aparecem na fila acima. Aprovar publica a entrada no registro; rejeitar a oculta.",
+      "approve": "Aprovar",
+      "reject": "Rejeitar",
+      "actions": "Ações"
+    },
     "table_headers": {
       "year": "Ano",
       "model": "Modelo",
@@ -351,6 +503,13 @@
     "description_text": "Ниже вы можете видеть все ожидающие заявки в реестр, которые в данный момент проходят проверку. Заявки обычно обрабатываются в течение 7-14 дней.",
     "contact_text": "Если у вас есть вопросы по вашей заявке, пожалуйста",
     "contact_link": "свяжитесь с нами",
+    "legacy": {
+      "title": "1 старая заявка ожидает проверки | {count} старых заявок ожидают проверки",
+      "description": "Они были отправлены до перехода на Supabase и никогда не одобрялись. У их авторов нет аккаунта, поэтому они не попадают в очередь выше. Одобрение публикует запись в реестре, отклонение скрывает её.",
+      "approve": "Одобрить",
+      "reject": "Отклонить",
+      "actions": "Действия"
+    },
     "table_headers": {
       "year": "Год",
       "model": "Модель",
@@ -387,6 +546,13 @@
     "description_text": "現在審査中のすべてのレジストリ申請を以下でご確認いただけます。申請は通常7〜14日以内に処理されます。",
     "contact_text": "申請についてご質問がある場合は、",
     "contact_link": "お問い合わせください",
+    "legacy": {
+      "title": "確認待ちの旧申請が1件あります | 確認待ちの旧申請が{count}件あります",
+      "description": "Supabase移行前に申請され、承認されないままだったものです。申請者にアカウントがないため、上のキューには表示されません。承認すると登録簿に公開され、却下すると非表示になります。",
+      "approve": "承認",
+      "reject": "却下",
+      "actions": "操作"
+    },
     "table_headers": {
       "year": "年式",
       "model": "モデル",
@@ -423,6 +589,13 @@
     "description_text": "以下您可以查看所有正在审核中的待处理注册表提交。提交通常在7-14天内处理完成。",
     "contact_text": "如果您对提交有疑问，请",
     "contact_link": "联系我们",
+    "legacy": {
+      "title": "有 1 条旧提交待审核 | 有 {count} 条旧提交待审核",
+      "description": "这些是在迁移到 Supabase 之前提交且从未审核通过的记录。提交者没有账户，因此不会出现在上面的队列中。通过后将公开显示在登记簿中，拒绝则会隐藏。",
+      "approve": "通过",
+      "reject": "拒绝",
+      "actions": "操作"
+    },
     "table_headers": {
       "year": "年份",
       "model": "型号",
@@ -459,6 +632,13 @@
     "description_text": "아래에서 현재 검토 중인 모든 대기 중인 레지스트리 제출을 확인할 수 있습니다. 제출은 보통 7-14일 이내에 처리됩니다.",
     "contact_text": "제출에 대한 질문이 있으시면",
     "contact_link": "문의하세요",
+    "legacy": {
+      "title": "검토가 필요한 이전 제출 1건 | 검토가 필요한 이전 제출 {count}건",
+      "description": "Supabase로 이전하기 전에 제출되어 승인되지 않은 항목입니다. 제출자에게 계정이 없어 위 대기열에 표시되지 않습니다. 승인하면 등록부에 공개되고, 거부하면 숨겨집니다.",
+      "approve": "승인",
+      "reject": "거부",
+      "actions": "작업"
+    },
     "table_headers": {
       "year": "연도",
       "model": "모델",

--- a/data/models/registry.ts
+++ b/data/models/registry.ts
@@ -19,6 +19,22 @@ export interface RegistryItem extends Record<string, any> {
   engineSize: number;
   color: string;
   status?: RegistryItemStatus;
+  /**
+   * profiles id of the account that owns this entry, or null while unowned.
+   * Set by the #65 phase-3 backfill for submitters whose email matched a
+   * confirmed account, and by `claim_registry_entry` for anyone claiming later.
+   * Drives the owner-only "suggest an edit" affordance.
+   */
+  ownerId?: string | null;
+}
+
+/** A register entry the signed-in user is entitled to claim. */
+export interface ClaimableRegistryEntry {
+  id: string;
+  year: number;
+  model: string;
+  bodyNum: string;
+  submittedBy: string;
 }
 
 export interface RegistryQueueSubmissionResponse {

--- a/server/api/registry/pending-entries/list.ts
+++ b/server/api/registry/pending-entries/list.ts
@@ -1,0 +1,58 @@
+import { getServiceClient } from '../../../utils/supabase';
+import { requireAdminAuth } from '../../../utils/adminAuth';
+
+/**
+ * Pending rows that live directly on `registry_entries`, as opposed to the
+ * submissions in `submission_queue` that /api/registry/queue/list returns.
+ *
+ * These exist because the DynamoDB MiniRegisterQueue held submissions that were
+ * never approved and never migrated. They could not be replayed through
+ * submission_queue — `submitted_by` there is NOT NULL and references profiles,
+ * and none of those submitters ever had an account (see
+ * classicminidiy-supabase migration 20260727000004). So they were imported
+ * straight onto registry_entries with status 'pending', where the RLS policy
+ * keeps them invisible to the public until reviewed.
+ *
+ * Service client: `legacy_submitted_by_email` is revoked from anon and
+ * authenticated, so the submitter's contact details are only reachable here.
+ */
+export default defineEventHandler(async (event) => {
+  await requireAdminAuth(event);
+
+  // No caching: this is a moderation queue, and a stale list means double-review.
+  setResponseHeaders(event, { 'Cache-Control': 'no-store' });
+
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from('registry_entries')
+    .select(
+      'id, year, model, body_number, engine_number, engine_size, body_type, color, trim, notes, legacy_submitted_by, legacy_submitted_by_email, legacy_id, submitted_by, created_at'
+    )
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: error.message });
+  }
+
+  return (data ?? []).map((row: any) => ({
+    id: row.id,
+    year: row.year,
+    model: row.model || '',
+    bodyNum: row.body_number || '',
+    engineNum: row.engine_number || '',
+    engineSize: row.engine_size || 0,
+    bodyType: row.body_type || '',
+    color: row.color || '',
+    trim: row.trim || '',
+    notes: row.notes || '',
+    submittedBy: row.legacy_submitted_by || '',
+    submittedByEmail: row.legacy_submitted_by_email || '',
+    legacyId: row.legacy_id || null,
+    // Non-null means a real account submitted it, which the moderate endpoint
+    // refuses to act on — those belong in the trust-tracked queue flow.
+    ownerId: row.submitted_by || null,
+    createdAt: row.created_at,
+  }));
+});

--- a/server/api/registry/pending-entries/moderate.post.ts
+++ b/server/api/registry/pending-entries/moderate.post.ts
@@ -1,0 +1,72 @@
+import { getServiceClient } from '../../../utils/supabase';
+import { requireAdminAuth } from '../../../utils/adminAuth';
+
+/**
+ * Approve or reject a pending row that lives directly on `registry_entries`.
+ *
+ * Scope is deliberately narrow: this only handles the legacy imports that have
+ * no submitter account (`submitted_by IS NULL`). See list.ts for why those rows
+ * exist outside submission_queue.
+ *
+ * A pending row WITH a submitter is refused rather than approved here. Every
+ * human-reviewed approval surface owes the trust pipeline three things —
+ * increment the profiles counters, write a `contributions` ledger row, and call
+ * `recalculate_trust_level()` — which the submission_queue trigger does and this
+ * endpoint does not. Approving a real user's entry here would silently deny them
+ * contribution credit and recreate the "everyone stuck at `new`" bug. Those must
+ * go through the queue flow. (Contract:
+ * classicminidiy-supabase/docs/plans/2026-07-13-unified-trust-pipeline.md.)
+ */
+export default defineEventHandler(async (event) => {
+  await requireAdminAuth(event);
+
+  const body = await readBody(event);
+  const { id, action } = body ?? {};
+
+  if (!id || typeof id !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'Missing entry id' });
+  }
+  if (action !== 'approve' && action !== 'reject') {
+    throw createError({ statusCode: 400, statusMessage: "action must be 'approve' or 'reject'" });
+  }
+
+  const supabase = getServiceClient();
+
+  const { data: entry, error: fetchError } = await supabase
+    .from('registry_entries')
+    .select('id, status, submitted_by')
+    .eq('id', id)
+    .single();
+
+  if (fetchError || !entry) {
+    throw createError({ statusCode: 404, statusMessage: 'Register entry not found' });
+  }
+
+  if (entry.status !== 'pending') {
+    throw createError({ statusCode: 409, statusMessage: `Entry is already ${entry.status}` });
+  }
+
+  if (entry.submitted_by) {
+    throw createError({
+      statusCode: 409,
+      statusMessage:
+        'This entry has a submitter account. Approve it through the submission queue so the contributor gets trust credit.',
+    });
+  }
+
+  const { error: updateError } = await supabase
+    .from('registry_entries')
+    .update({ status: action === 'approve' ? 'approved' : 'rejected' })
+    .eq('id', id)
+    // Re-assert both guards in the write itself: without this, two admins acting
+    // at once could both pass the checks above and the second would silently
+    // re-decide an entry the first already resolved.
+    .eq('status', 'pending')
+    .is('submitted_by', null);
+
+  if (updateError) {
+    throw createError({ statusCode: 500, statusMessage: updateError.message });
+  }
+
+  return { success: true, id, status: action === 'approve' ? 'approved' : 'rejected' };
+});

--- a/tests/unit/composables/useRegistry.test.ts
+++ b/tests/unit/composables/useRegistry.test.ts
@@ -105,6 +105,7 @@ describe('useRegistry', () => {
         buildDate: '1967-03-15',
         notes: 'Numbers matching',
         submittedBy: 'John Doe',
+        ownerId: null,
         status: 'A',
       });
     });
@@ -145,6 +146,7 @@ describe('useRegistry', () => {
         buildDate: null,
         notes: '',
         submittedBy: '',
+        ownerId: null,
         status: 'A',
       });
     });
@@ -305,6 +307,71 @@ describe('useRegistry', () => {
       const result = await submitRegistryEntry({ model: 'Cooper' });
 
       expect(result).toEqual(responseData);
+    });
+  });
+
+  describe('ownership', () => {
+    it('maps submitted_by to ownerId so the owner-only edit affordance can key off it', async () => {
+      const rows = [makeRow({ submitted_by: 'user-42' }), makeRow({ id: 'row-2', submitted_by: null })];
+      mockSupabase._queryBuilder.then = vi.fn((resolve: any) => resolve({ data: rows, error: null }));
+
+      const { useRegistry } = await import('~/app/composables/useRegistry');
+      const result = await useRegistry().listApproved();
+
+      expect(result[0]!.ownerId).toBe('user-42');
+      expect(result[1]!.ownerId).toBeNull();
+    });
+
+    it('requests submitted_by but never the submitter email', async () => {
+      mockSupabase._queryBuilder.then = vi.fn((resolve: any) => resolve({ data: [], error: null }));
+
+      const { useRegistry } = await import('~/app/composables/useRegistry');
+      await useRegistry().listApproved();
+
+      const selected = mockSupabase._mockSelect.mock.calls[0]![0] as string;
+      expect(selected).toContain('submitted_by');
+      expect(selected).not.toContain('legacy_submitted_by_email');
+    });
+  });
+
+  describe('claim flow', () => {
+    it('maps claimable entries returned by the RPC', async () => {
+      mockSupabase.rpc = vi.fn().mockResolvedValue({
+        data: [{ id: 'e1', year: 1967, model: 'Cooper S', body_number: 'B-1', submitted_by_name: 'Jane' }],
+        error: null,
+      });
+
+      const { useRegistry } = await import('~/app/composables/useRegistry');
+      const result = await useRegistry().listClaimable();
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('get_my_claimable_registry_entries');
+      expect(result).toEqual([{ id: 'e1', year: 1967, model: 'Cooper S', bodyNum: 'B-1', submittedBy: 'Jane' }]);
+    });
+
+    it('returns an empty list rather than throwing when the caller is not signed in', async () => {
+      // The RPC is granted to `authenticated` only, so an anonymous visitor gets
+      // an error back. The prompt should stay invisible, not break the page.
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'permission denied' } });
+
+      const { useRegistry } = await import('~/app/composables/useRegistry');
+      await expect(useRegistry().listClaimable()).resolves.toEqual([]);
+    });
+
+    it('passes the entry id to claim_registry_entry', async () => {
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+
+      const { useRegistry } = await import('~/app/composables/useRegistry');
+      await useRegistry().claimEntry('entry-9');
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('claim_registry_entry', { p_entry_id: 'entry-9' });
+    });
+
+    it('throws when the claim is refused, so the UI can surface the reason', async () => {
+      const refusal = { message: 'That register entry was not submitted from your email address' };
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: null, error: refusal });
+
+      const { useRegistry } = await import('~/app/composables/useRegistry');
+      await expect(useRegistry().claimEntry('entry-9')).rejects.toEqual(refusal);
     });
   });
 });


### PR DESCRIPTION
The app-side half of [classicminidiy-supabase#65](https://github.com/ClassicMiniDIY/classicminidiy-supabase/issues/65). The database side (phases 1–4) is already live; this is what makes it reachable in the UI and closes the last acceptance criterion.

## 1. Claim prompt

`RegistryClaimPrompt` calls `get_my_claimable_registry_entries()` after auth and offers each match. Register entries migrated from DynamoDB carry only a free-text submitter name and email; phase 3 linked the 7 whose address matched a **confirmed** account, and the other 28 claim theirs here once they sign up and confirm.

- The RPC returns nothing for an unauthenticated or unconfirmed caller, so the component renders nothing rather than nagging logged-out visitors.
- It never receives the stored submitter email — that column is `service_role`-only since `20260727000002`.
- Deliberately a prompt, not a silent auto-link: attaching someone's car to a newly created account is worth a confirmation, and the entry shown is how they recognise it as theirs.

## 2. Owner edits

`registry_entries` now exposes `submitted_by`, so the table can show a "suggest an edit" affordance to the owner alone. It reuses the existing `SuggestEditModal`, which already speaks `target_type: 'registry'`, so edits land in `submission_queue` and the existing approve handler applies them.

Nothing writes to the entry directly. The RLS `UPDATE` policy permits nothing on an approved row by design — that's what stops an approved register entry being silently rewritten — so the queue is the only path, which was the decision on the issue.

⚠️ **Field keys here are DB column names** (`body_number`, `engine_number`), not the camelCase client names. `applyEditSuggestion` maps `changes.{field}.to` straight onto columns with no translation layer, so a camelCase key produces an `UPDATE` against a column that doesn't exist. Worth knowing: `app/pages/archive/wheels/[...wheel].vue` currently passes `offset`, but the column is `offset_value` — approving a wheel offset edit would 500 today. Flagged separately, not fixed here.

## 3. Review surface for the legacy pending rows

The 2 `MiniRegisterQueue` submissions imported by `20260727000004` sit on `registry_entries`, not `submission_queue`, so `/archive/registry/pending` could not see them — they were reachable only by SQL. Adds `list` + `moderate` endpoints and a section on that page.

`moderate` **refuses any row that has a submitter account** and re-asserts both guards inside the `UPDATE` (so two admins acting at once can't double-decide). Approving a real user's entry here would bypass the trust pipeline — no counter increment, no `contributions` row, no `recalculate_trust_level()` — and silently deny them contribution credit, recreating the "everyone stuck at `new`" bug. Those belong in the queue flow.

## Verification

- `bun run test` — 147 files, **4660 tests**, all passing (+6 new covering the claim RPCs, the `ownerId` mapping, and that the select still never requests the submitter email).
- `bun run build` — full production build, 141 routes prerendered.

Note the default-heap `bun run build` OOMs on this machine during the prerender step, before and after this change; `NODE_OPTIONS=--max-old-space-size=8192` completes cleanly. Unrelated to this PR, but it'll bite anyone building locally.

New strings are translated across all 10 locales in the existing per-component `<i18n>` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)