### PR TITLE
fix(marketing): resumable sends — stalled-send detection, resume, start toast

### DIFF
--- a/app/composables/useMarketingEmail.ts
+++ b/app/composables/useMarketingEmail.ts
@@ -40,6 +40,7 @@ export interface MarketingEmailRecord {
   sent_by: string | null;
   sent_at: string | null;
   error_message: string | null;
+  send_lease_expires_at: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -89,6 +90,13 @@ export const useMarketingEmail = () => {
   const drafts = computed(() => emails.value.filter((e) => e.status === 'draft'));
   const history = computed(() => emails.value.filter((e) => e.status !== 'draft'));
   const activeSend = computed(() => emails.value.find((e) => e.status === 'sending') ?? null);
+  /** A send whose isolate died: still 'sending' but its lease has lapsed
+   *  (with a minute of grace for the auto-handoff to re-claim). */
+  const isStalled = (e: MarketingEmailRecord | null): boolean =>
+    !!e &&
+    e.status === 'sending' &&
+    !!e.send_lease_expires_at &&
+    Date.now() - new Date(e.send_lease_expires_at).getTime() > 60_000;
 
   const fetchEmails = async () => {
     emailsLoading.value = true;
@@ -255,13 +263,23 @@ export const useMarketingEmail = () => {
     }, 5000);
   };
 
-  const sendMarketingEmail = async (id: string): Promise<boolean> => {
+  const sendMarketingEmail = async (id: string, opts: { resume?: boolean } = {}): Promise<boolean> => {
     sending.value = true;
+    // Immediate feedback — the actual send can run for minutes edge-side.
+    toast.add({
+      title: opts.resume ? 'Resuming send' : 'Send started',
+      description: 'Delivery runs in the background — progress updates below.',
+      color: 'info',
+    });
     try {
-      const result = await $adminFetch<any>('/api/admin/marketing/send', { method: 'POST', body: { id } });
+      const result = await $adminFetch<any>('/api/admin/marketing/send', {
+        method: 'POST',
+        body: { id, resume: !!opts.resume },
+      });
       await fetchEmails();
-      if (result?.polling || emails.value.find((e) => e.id === id)?.status === 'sending') {
-        // Proxy timed out (or send still running) — the edge loop continues.
+      if (result?.polling || result?.handedOff || emails.value.find((e) => e.id === id)?.status === 'sending') {
+        // Proxy timed out, or the edge fn handed off to a fresh isolate —
+        // either way the send continues server-side; watch the row.
         pollWhileSending(id);
         return true;
       }
@@ -278,7 +296,7 @@ export const useMarketingEmail = () => {
       sending.value = false;
       const status = error?.statusCode || error?.response?.status;
       toast.add({
-        title: status === 429 ? 'Already sent' : 'Send failed',
+        title: status === 429 ? 'Already sent' : status === 409 ? 'Nothing to resume' : 'Send failed',
         description: error?.data?.message || 'Failed to send marketing email',
         color: 'error',
       });
@@ -295,6 +313,7 @@ export const useMarketingEmail = () => {
     drafts,
     history,
     activeSend,
+    isStalled,
     previewHtml,
     previewLoading,
     audience,

--- a/app/pages/admin/marketing.vue
+++ b/app/pages/admin/marketing.vue
@@ -8,12 +8,31 @@
     </div>
 
     <!-- Active send progress -->
-    <div v-if="activeSend" class="alert alert-info mb-6">
-      <span class="loading loading-spinner loading-sm"></span>
+    <div v-if="activeSend" class="alert mb-6" :class="stalledSend ? 'alert-warning' : 'alert-info'">
+      <span v-if="!stalledSend" class="loading loading-spinner loading-sm"></span>
+      <i v-else class="fas fa-triangle-exclamation"></i>
       <span>
-        Sending "{{ activeSend.subject }}" — {{ activeSend.recipient_count }}/{{ activeSend.total_recipients ?? '?' }}
-        delivered
+        <template v-if="stalledSend">
+          Send of "{{ activeSend.subject }}" stalled at {{ activeSend.recipient_count }}/{{
+            activeSend.total_recipients ?? '?'
+          }}
+          — resume to deliver the rest (no one gets it twice).
+        </template>
+        <template v-else>
+          Sending "{{ activeSend.subject }}" — {{ activeSend.recipient_count }}/{{ activeSend.total_recipients ?? '?' }}
+          delivered
+        </template>
       </span>
+      <button
+        v-if="stalledSend"
+        class="btn btn-sm btn-warning"
+        :disabled="sending"
+        @click="handleResume(activeSend.id)"
+      >
+        <span v-if="sending" class="loading loading-spinner loading-xs"></span>
+        <i v-else class="fas fa-rotate-right"></i>
+        Resume send
+      </button>
     </div>
 
     <div class="grid lg:grid-cols-2 gap-6 mb-8 items-start">
@@ -455,7 +474,21 @@
     sendTest,
     sendMarketingEmail,
     pollWhileSending,
+    isStalled,
   } = useMarketingEmail();
+
+  // Stalled-send detection re-evaluates on a slow tick (isStalled compares
+  // the lease against wall-clock time, which isn't reactive by itself).
+  const stalledTick = ref(0);
+  let stalledTimer: ReturnType<typeof setInterval> | null = null;
+  const stalledSend = computed(() => {
+    void stalledTick.value;
+    return isStalled(activeSend.value) ? activeSend.value : null;
+  });
+
+  const handleResume = async (id: string) => {
+    await sendMarketingEmail(id, { resume: true });
+  };
 
   // Editor state. Blocks carry a local `key` for draggable identity — stripped
   // before anything is sent to the server.
@@ -673,5 +706,10 @@
     await fetchEmails();
     // Resume progress polling if a send is mid-flight (e.g. page reload).
     if (activeSend.value) pollWhileSending(activeSend.value.id);
+    stalledTimer = setInterval(() => stalledTick.value++, 30_000);
+  });
+
+  onBeforeUnmount(() => {
+    if (stalledTimer) clearInterval(stalledTimer);
   });
 </script>

--- a/server/api/admin/marketing/send.post.ts
+++ b/server/api/admin/marketing/send.post.ts
@@ -19,8 +19,9 @@ import { callMarketingEdge } from '../../../utils/marketingEdge';
 
 export default defineEventHandler(async (event) => {
   const { user } = await requireMarketingAdmin(event);
-  const body = await readBody<{ id?: string }>(event);
+  const body = await readBody<{ id?: string; resume?: boolean }>(event);
   const id = typeof body?.id === 'string' ? body.id : '';
+  const resume = body?.resume === true;
   if (!id) throw createError({ statusCode: 400, statusMessage: 'id is required' });
 
   const db = getServiceClient();
@@ -34,14 +35,23 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 500, statusMessage: 'Failed to look up marketing email' });
   }
   if (!draft) throw createError({ statusCode: 404, statusMessage: 'Marketing email not found' });
-  if (draft.status !== 'draft') {
+  // A resume targets a stalled 'sending' row; a fresh send targets a draft.
+  // The edge fn enforces both transitions atomically (lease-guarded) — this
+  // is just the fast, friendly rejection.
+  if (!resume && draft.status !== 'draft') {
     throw createError({ statusCode: 429, statusMessage: `Marketing email is ${draft.status}, not draft` });
+  }
+  if (resume && draft.status !== 'sending') {
+    throw createError({
+      statusCode: 409,
+      statusMessage: `Only a stalled sending email can be resumed (status: ${draft.status})`,
+    });
   }
 
   // Audit intent BEFORE forwarding — the edge call may outlive this request.
   await db.from('admin_audit_log').insert({
     admin_id: user.id,
-    action: 'marketing_email_sent',
+    action: resume ? 'marketing_email_send_resumed' : 'marketing_email_sent',
     target_type: 'marketing_email',
     target_id: id,
     details: { subject: draft.subject },
@@ -49,7 +59,7 @@ export default defineEventHandler(async (event) => {
 
   let result: any;
   try {
-    result = await callMarketingEdge({ action: 'marketing_send', marketingEmailId: id, sentBy: user.id });
+    result = await callMarketingEdge({ action: 'marketing_send', marketingEmailId: id, sentBy: user.id, resume });
   } catch (error: any) {
     // Distinguish "edge rejected it" from "proxy gave up waiting". On a
     // timeout/abort the Deno loop keeps running — tell the client to poll.


### PR DESCRIPTION
## Summary
Web half of the send-resumability fix (pairs with classicminidiy-supabase#72; deploy that first — already deployed).

Addresses two of today's incident symptoms:
- **No feedback after hitting Send**: an immediate "Send started — delivery runs in the background" toast, and the progress alert + polling now reach closure because the edge fn finalizes reliably (handoff) instead of dying mid-run.
- **Stalled sends were dead ends**: when a `sending` row's lease lapses (isolate died), the alert flips to a warning with a **Resume send** button — `resume:true` continues from the recipient ledger with no double-sends. The send proxy 409s a resume on anything that isn't a stalled sending row.

## Testing
Full vitest suite passes (4664); `bun run build` completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)