### PR TITLE
feat(exchange): capture sold prices and open the sold archive to search

### DIFF
--- a/app/components/exchange/listings/MarkSoldDialog.vue
+++ b/app/components/exchange/listings/MarkSoldDialog.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+  /**
+   * Mark-as-sold confirmation, with sale-price capture.
+   *
+   * Why this exists rather than the generic ExchangeConfirmDialog: marking a listing
+   * sold used to write only `status` and `sold_date`, so `final_price` was never
+   * populated by any code path in the app. That left /exchange/sold unable to be what
+   * a sold archive is actually good for — a pricing reference other owners search for
+   * ("what did a Cooper S go for") — and is why that page is still noindex.
+   *
+   * The price is OPTIONAL on purpose. Forcing a number on a seller who doesn't want to
+   * disclose one produces junk (1, 99999) and quietly poisons the archive; fewer honest
+   * figures are worth more than a complete column of guesses. The public-visibility
+   * warning is deliberately unmissable — this is a private individual publishing what
+   * they got for their car, and they must not discover that after the fact.
+   */
+  interface Props {
+    /** ISO currency of the listing, used for the input prefix. */
+    currency?: string;
+    /** Asking price, offered as a starting point so the common case is one tap. */
+    askingPrice?: number | null;
+  }
+
+  const props = withDefaults(defineProps<Props>(), {
+    currency: 'USD',
+    askingPrice: null,
+  });
+
+  const emit = defineEmits<{
+    /** Emitted with the sale price, or null when the seller declines to give one. */
+    confirm: [finalPrice: number | null];
+    cancel: [];
+  }>();
+
+  const { t } = useI18n();
+
+  const dialogRef = ref<HTMLDialogElement | null>(null);
+  const priceInput = ref<string>('');
+  const touched = ref(false);
+
+  const currencySymbol = computed(() => {
+    try {
+      // Extract just the symbol so the input can show it as a prefix.
+      return (
+        new Intl.NumberFormat('en-US', { style: 'currency', currency: props.currency })
+          .formatToParts(0)
+          .find((p) => p.type === 'currency')?.value ?? '$'
+      );
+    } catch {
+      return '$';
+    }
+  });
+
+  /** null = intentionally blank; NaN = present but unparseable. */
+  const parsedPrice = computed(() => {
+    const raw = priceInput.value.replace(/[^0-9.]/g, '').trim();
+    if (!raw) return null;
+    return Number(raw);
+  });
+
+  const error = computed(() => {
+    if (!touched.value) return '';
+    const value = parsedPrice.value;
+    if (value === null) return '';
+    if (!Number.isFinite(value) || value <= 0) return t('error.invalid');
+    if (value > 10_000_000) return t('error.tooLarge');
+    return '';
+  });
+
+  const canConfirm = computed(() => !error.value);
+
+  const show = () => {
+    priceInput.value = props.askingPrice != null ? String(props.askingPrice) : '';
+    touched.value = false;
+    dialogRef.value?.showModal();
+  };
+
+  const hide = () => dialogRef.value?.close();
+
+  const handleConfirm = () => {
+    touched.value = true;
+    if (!canConfirm.value) return;
+    const value = parsedPrice.value;
+    hide();
+    emit('confirm', value !== null && Number.isFinite(value) ? value : null);
+  };
+
+  const handleCancel = () => {
+    hide();
+    emit('cancel');
+  };
+
+  defineExpose({ show, hide });
+</script>
+
+<template>
+  <dialog ref="dialogRef" class="modal">
+    <div class="modal-box">
+      <h3 class="font-bold text-lg">{{ t('title') }}</h3>
+      <p class="pt-3 pb-1 text-base-content/80">{{ t('intro') }}</p>
+
+      <fieldset class="fieldset mt-3">
+        <label class="label" for="mark-sold-price">
+          <span class="label-text font-medium">{{ t('priceLabel') }}</span>
+        </label>
+        <label class="input input-bordered flex items-center gap-2 w-full">
+          <span class="text-base-content/60">{{ currencySymbol }}</span>
+          <input
+            id="mark-sold-price"
+            v-model="priceInput"
+            type="text"
+            inputmode="decimal"
+            class="grow"
+            :placeholder="t('pricePlaceholder')"
+            :aria-invalid="!!error"
+            aria-describedby="mark-sold-price-help"
+            @blur="touched = true"
+          />
+          <span class="text-base-content/60 text-sm">{{ currency }}</span>
+        </label>
+        <p v-if="error" class="text-error text-sm mt-1" role="alert">{{ error }}</p>
+        <p id="mark-sold-price-help" class="text-base-content/60 text-sm mt-1">
+          {{ t('priceHelp') }}
+        </p>
+      </fieldset>
+
+      <div role="note" class="alert alert-warning mt-4 text-sm">
+        <i class="fas fa-eye" aria-hidden="true"></i>
+        <span>{{ t('publicWarning') }}</span>
+      </div>
+
+      <div class="modal-action">
+        <button class="btn btn-ghost" @click="handleCancel">{{ t('cancel') }}</button>
+        <button class="btn btn-success" :disabled="!canConfirm" @click="handleConfirm">
+          {{ t('confirm') }}
+        </button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button @click="handleCancel">close</button>
+    </form>
+  </dialog>
+</template>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Mark as Sold",
+    "intro": "Congratulations on your sale. Adding what it sold for helps other Classic Mini owners judge what their car is worth.",
+    "priceLabel": "Sold price",
+    "pricePlaceholder": "Leave blank to skip",
+    "priceHelp": "Optional. Enter the amount it actually sold for, not the asking price.",
+    "publicWarning": "The sold price is shown publicly in the sold archive.",
+    "confirm": "Mark Sold",
+    "cancel": "Cancel",
+    "error": { "invalid": "Enter an amount greater than zero.", "tooLarge": "That amount looks too large." }
+  },
+  "es": {
+    "title": "Marcar como vendido",
+    "intro": "Enhorabuena por tu venta. Indicar el precio de venta ayuda a otros propietarios de Mini clásicos a valorar su coche.",
+    "priceLabel": "Precio de venta",
+    "pricePlaceholder": "Déjalo vacío para omitir",
+    "priceHelp": "Opcional. Indica el importe por el que se vendió realmente, no el precio pedido.",
+    "publicWarning": "El precio de venta se muestra públicamente en el archivo de vendidos.",
+    "confirm": "Marcar como vendido",
+    "cancel": "Cancelar",
+    "error": { "invalid": "Introduce un importe mayor que cero.", "tooLarge": "Ese importe parece demasiado alto." }
+  },
+  "fr": {
+    "title": "Marquer comme vendu",
+    "intro": "Félicitations pour votre vente. Indiquer le prix de vente aide les autres propriétaires de Mini classiques à estimer leur voiture.",
+    "priceLabel": "Prix de vente",
+    "pricePlaceholder": "Laisser vide pour ignorer",
+    "priceHelp": "Facultatif. Indiquez le montant réellement obtenu, pas le prix demandé.",
+    "publicWarning": "Le prix de vente est affiché publiquement dans les archives des ventes.",
+    "confirm": "Marquer comme vendu",
+    "cancel": "Annuler",
+    "error": { "invalid": "Saisissez un montant supérieur à zéro.", "tooLarge": "Ce montant semble trop élevé." }
+  },
+  "de": {
+    "title": "Als verkauft markieren",
+    "intro": "Glückwunsch zum Verkauf. Der Verkaufspreis hilft anderen Classic-Mini-Besitzern, den Wert ihres Autos einzuschätzen.",
+    "priceLabel": "Verkaufspreis",
+    "pricePlaceholder": "Leer lassen zum Überspringen",
+    "priceHelp": "Optional. Gib den tatsächlich erzielten Betrag an, nicht den geforderten Preis.",
+    "publicWarning": "Der Verkaufspreis wird im Verkaufsarchiv öffentlich angezeigt.",
+    "confirm": "Als verkauft markieren",
+    "cancel": "Abbrechen",
+    "error": { "invalid": "Gib einen Betrag größer als null ein.", "tooLarge": "Dieser Betrag scheint zu hoch." }
+  },
+  "it": {
+    "title": "Segna come venduto",
+    "intro": "Congratulazioni per la vendita. Indicare il prezzo di vendita aiuta altri proprietari di Mini classiche a valutare la propria auto.",
+    "priceLabel": "Prezzo di vendita",
+    "pricePlaceholder": "Lascia vuoto per saltare",
+    "priceHelp": "Facoltativo. Inserisci l'importo effettivamente realizzato, non il prezzo richiesto.",
+    "publicWarning": "Il prezzo di vendita è mostrato pubblicamente nell'archivio dei venduti.",
+    "confirm": "Segna come venduto",
+    "cancel": "Annulla",
+    "error": { "invalid": "Inserisci un importo maggiore di zero.", "tooLarge": "Questo importo sembra troppo alto." }
+  },
+  "pt": {
+    "title": "Marcar como vendido",
+    "intro": "Parabéns pela venda. Indicar o preço de venda ajuda outros proprietários de Mini clássicos a avaliar o seu carro.",
+    "priceLabel": "Preço de venda",
+    "pricePlaceholder": "Deixe em branco para ignorar",
+    "priceHelp": "Opcional. Indique o valor pelo qual foi realmente vendido, não o preço pedido.",
+    "publicWarning": "O preço de venda é apresentado publicamente no arquivo de vendidos.",
+    "confirm": "Marcar como vendido",
+    "cancel": "Cancelar",
+    "error": { "invalid": "Introduza um valor maior que zero.", "tooLarge": "Esse valor parece demasiado alto." }
+  },
+  "ru": {
+    "title": "Отметить как проданное",
+    "intro": "Поздравляем с продажей. Указание цены продажи помогает другим владельцам классического Mini оценить свою машину.",
+    "priceLabel": "Цена продажи",
+    "pricePlaceholder": "Оставьте пустым, чтобы пропустить",
+    "priceHelp": "Необязательно. Укажите сумму, за которую автомобиль действительно продан, а не запрашиваемую цену.",
+    "publicWarning": "Цена продажи публично отображается в архиве проданных.",
+    "confirm": "Отметить как проданное",
+    "cancel": "Отмена",
+    "error": { "invalid": "Введите сумму больше нуля.", "tooLarge": "Эта сумма выглядит слишком большой." }
+  },
+  "ja": {
+    "title": "売却済みにする",
+    "intro": "ご成約おめでとうございます。売却価格を入力すると、他のクラシック・ミニのオーナーが自分の車の価値を判断する助けになります。",
+    "priceLabel": "売却価格",
+    "pricePlaceholder": "空欄のままでスキップ",
+    "priceHelp": "任意です。希望価格ではなく、実際に売れた金額を入力してください。",
+    "publicWarning": "売却価格は売却済みアーカイブで公開されます。",
+    "confirm": "売却済みにする",
+    "cancel": "キャンセル",
+    "error": { "invalid": "0 より大きい金額を入力してください。", "tooLarge": "金額が大きすぎるようです。" }
+  },
+  "zh": {
+    "title": "标记为已售出",
+    "intro": "恭喜成交。填写成交价可以帮助其他经典 Mini 车主判断自己车辆的价值。",
+    "priceLabel": "成交价",
+    "pricePlaceholder": "留空则跳过",
+    "priceHelp": "选填。请填写实际成交金额，而非要价。",
+    "publicWarning": "成交价会在已售出档案中公开显示。",
+    "confirm": "标记为已售出",
+    "cancel": "取消",
+    "error": { "invalid": "请输入大于零的金额。", "tooLarge": "该金额看起来过大。" }
+  },
+  "ko": {
+    "title": "판매 완료로 표시",
+    "intro": "판매를 축하합니다. 판매 가격을 입력하면 다른 클래식 미니 오너들이 자기 차의 가치를 판단하는 데 도움이 됩니다.",
+    "priceLabel": "판매 가격",
+    "pricePlaceholder": "비워 두면 건너뜁니다",
+    "priceHelp": "선택 사항입니다. 희망 가격이 아니라 실제로 판매된 금액을 입력하세요.",
+    "publicWarning": "판매 가격은 판매 완료 아카이브에 공개적으로 표시됩니다.",
+    "confirm": "판매 완료로 표시",
+    "cancel": "취소",
+    "error": { "invalid": "0보다 큰 금액을 입력하세요.", "tooLarge": "금액이 너무 큰 것 같습니다." }
+  }
+}
+</i18n>

--- a/app/pages/exchange/listings/[slug]/index.vue
+++ b/app/pages/exchange/listings/[slug]/index.vue
@@ -45,11 +45,7 @@
 
       <!-- Back to Listings -->
       <div class="container pt-6">
-        <NuxtLink
-          :to="backToListingsUrl"
-          class="btn btn-ghost btn-sm -ml-2"
-          data-test="back-to-listings"
-        >
+        <NuxtLink :to="backToListingsUrl" class="btn btn-ghost btn-sm -ml-2" data-test="back-to-listings">
           <i class="fas fa-arrow-left"></i>
           {{ t('backToListings') }}
         </NuxtLink>
@@ -103,7 +99,9 @@
                       <i class="fas fa-chart-column text-2xl text-base-content/60"></i>
                       <div>
                         <div class="text-sm text-base-content/60">{{ t('specs.mileage') }}</div>
-                        <div class="font-medium">{{ t('specs.milesValue', { miles: formatMileage(listing.mileage) }) }}</div>
+                        <div class="font-medium">
+                          {{ t('specs.milesValue', { miles: formatMileage(listing.mileage) }) }}
+                        </div>
                       </div>
                     </div>
 
@@ -209,8 +207,12 @@
                         <i class="fas fa-truck text-primary"></i>
                         {{ t('shipping.title') }}
                       </h3>
-                      <span v-if="!listing.shipping_available" class="badge badge-ghost">{{ t('shipping.pickupOnly') }}</span>
-                      <span v-else-if="listing.shipping_cost === 0" class="badge badge-success"> {{ t('shipping.freeShipping') }} </span>
+                      <span v-if="!listing.shipping_available" class="badge badge-ghost">{{
+                        t('shipping.pickupOnly')
+                      }}</span>
+                      <span v-else-if="listing.shipping_cost === 0" class="badge badge-success">
+                        {{ t('shipping.freeShipping') }}
+                      </span>
                     </div>
 
                     <template v-if="listing.shipping_available">
@@ -263,12 +265,19 @@
                           <span class="text-base-content/60">{{ t('shipping.delivery') }}</span>
                           <span class="font-medium ml-1">
                             <template v-if="listing.estimated_delivery_days_min && listing.estimated_delivery_days_max">
-                              {{ t('shipping.businessDaysRange', { min: listing.estimated_delivery_days_min, max: listing.estimated_delivery_days_max }) }}
+                              {{
+                                t('shipping.businessDaysRange', {
+                                  min: listing.estimated_delivery_days_min,
+                                  max: listing.estimated_delivery_days_max,
+                                })
+                              }}
                             </template>
                             <template v-else-if="listing.estimated_delivery_days_min">
                               {{ t('shipping.businessDaysMin', { min: listing.estimated_delivery_days_min }) }}
                             </template>
-                            <template v-else> {{ t('shipping.businessDaysMax', { max: listing.estimated_delivery_days_max }) }} </template>
+                            <template v-else>
+                              {{ t('shipping.businessDaysMax', { max: listing.estimated_delivery_days_max }) }}
+                            </template>
                           </span>
                         </div>
                       </div>
@@ -386,15 +395,14 @@
                               <span v-if="change.old_value" class="line-through opacity-60">{{
                                 change.old_value
                               }}</span>
-                              <i
-                                v-if="change.old_value"
-                                class="fas fa-arrow-right inline mx-1"
-                              ></i>
+                              <i v-if="change.old_value" class="fas fa-arrow-right inline mx-1"></i>
                               <span class="font-medium">{{ change.new_value }}</span>
                             </div>
                           </div>
                           <div class="text-xs text-base-content/60 text-right shrink-0">
-                            <div>{{ change.profiles?.display_name || change.profiles?.username || t('anonymous') }}</div>
+                            <div>
+                              {{ change.profiles?.display_name || change.profiles?.username || t('anonymous') }}
+                            </div>
                             <div>{{ formatDate(change.created_at) }}</div>
                           </div>
                         </div>
@@ -405,11 +413,10 @@
                   <!-- Show More / Show Less Button -->
                   <div v-if="history.length > 3" class="text-center">
                     <button @click="showAllHistory = !showAllHistory" class="btn btn-ghost btn-sm">
-                      {{ showAllHistory ? t('history.showLess') : t('history.showMore', { count: history.length - 3 }) }}
-                      <i
-                        :class="showAllHistory ? 'fas fa-chevron-up' : 'fas fa-chevron-down'"
-                        class="ml-1"
-                      ></i>
+                      {{
+                        showAllHistory ? t('history.showLess') : t('history.showMore', { count: history.length - 3 })
+                      }}
+                      <i :class="showAllHistory ? 'fas fa-chevron-up' : 'fas fa-chevron-down'" class="ml-1"></i>
                     </button>
                   </div>
                 </div>
@@ -429,22 +436,36 @@
                             <i class="fas fa-circle-check text-3xl text-success shrink-0"></i>
                             <div class="text-lg font-bold text-success">{{ t('sold.badge') }}</div>
                           </div>
-                          <div v-if="soldPrice !== 0" class="text-sm text-base-content/60 mb-2">{{ t('sold.soldFor') }}</div>
+                          <div v-if="soldPrice !== 0" class="text-sm text-base-content/60 mb-2">
+                            {{ t('sold.soldFor') }}
+                          </div>
                           <div class="text-3xl font-bold text-success">
                             {{ formatListingPrice(soldPrice, formatCurrency(soldPrice, listingCurrency)) }}
                           </div>
                           <div v-if="soldConvertedPrice && soldPrice !== 0" class="text-sm text-base-content/60 mt-1">
-                            {{ t('aboutInCurrency', { amount: formatCurrency(soldConvertedPrice, userCurrency), currency: userCurrency }) }}
+                            {{
+                              t('aboutInCurrency', {
+                                amount: formatCurrency(soldConvertedPrice, userCurrency),
+                                currency: userCurrency,
+                              })
+                            }}
                           </div>
                         </div>
                       </template>
                       <template v-else>
-                        <div v-if="listing.price !== 0" class="text-sm text-base-content/60 mb-1">{{ t('price.askingPrice') }}</div>
+                        <div v-if="listing.price !== 0" class="text-sm text-base-content/60 mb-1">
+                          {{ t('price.askingPrice') }}
+                        </div>
                         <div class="text-4xl font-bold" :class="listing.price === 0 ? 'text-success' : 'text-primary'">
                           {{ formatListingPrice(listing.price, formatCurrency(listing.price, listingCurrency)) }}
                         </div>
                         <div v-if="convertedPrice && listing.price !== 0" class="text-sm text-base-content/60 mt-1">
-                          {{ t('aboutInCurrency', { amount: formatCurrency(convertedPrice, userCurrency), currency: userCurrency }) }}
+                          {{
+                            t('aboutInCurrency', {
+                              amount: formatCurrency(convertedPrice, userCurrency),
+                              currency: userCurrency,
+                            })
+                          }}
                         </div>
                         <!-- Price Drop Indicator -->
                         <div
@@ -534,12 +555,12 @@
                     </div>
 
                     <!-- Seller Info -->
-                    <div
-                      v-if="listing.profiles"
-                      class="mb-6 pb-6 border-b border-base-300"
-                    >
+                    <div v-if="listing.profiles" class="mb-6 pb-6 border-b border-base-300">
                       <div class="text-sm font-medium text-base-content/60 mb-3">{{ t('seller.label') }}</div>
-                      <NuxtLink :to="`/users/${listing.user_id}`" class="flex items-center gap-3 hover:opacity-80 transition-opacity">
+                      <NuxtLink
+                        :to="`/users/${listing.user_id}`"
+                        class="flex items-center gap-3 hover:opacity-80 transition-opacity"
+                      >
                         <div class="avatar shrink-0">
                           <div class="w-12 h-12 rounded-full bg-base-300">
                             <img
@@ -552,7 +573,11 @@
                               v-else
                               class="flex items-center justify-center h-full text-lg font-semibold text-base-content/70"
                             >
-                              {{ getInitials(listing.profiles.display_name || listing.profiles.username || t('anonymous')) }}
+                              {{
+                                getInitials(
+                                  listing.profiles.display_name || listing.profiles.username || t('anonymous')
+                                )
+                              }}
                             </div>
                           </div>
                         </div>
@@ -653,11 +678,10 @@
                           class="btn btn-block"
                           :class="isWatchlisted(listing.id) ? 'btn-error' : 'btn-outline'"
                         >
-                          <i
-                            :class="isWatchlisted(listing.id) ? 'fas fa-heart' : 'far fa-heart'"
-                            class="text-2xl"
-                          ></i>
-                          {{ isWatchlisted(listing.id) ? t('actions.removeFromWatchlist') : t('actions.addToWatchlist') }}
+                          <i :class="isWatchlisted(listing.id) ? 'fas fa-heart' : 'far fa-heart'" class="text-2xl"></i>
+                          {{
+                            isWatchlisted(listing.id) ? t('actions.removeFromWatchlist') : t('actions.addToWatchlist')
+                          }}
                         </button>
                       </template>
                     </div>
@@ -701,12 +725,10 @@
       </section>
 
       <!-- Confirm Dialogs -->
-      <ExchangeConfirmDialog
+      <ExchangeListingsMarkSoldDialog
         ref="soldDialogRef"
-        :title="t('confirm.markSold.title')"
-        :message="t('confirm.markSold.message')"
-        :confirm-text="t('confirm.markSold.confirm')"
-        confirm-color="success"
+        :currency="(listing as any).currency || 'USD'"
+        :asking-price="listing.price"
         @confirm="confirmMarkSold"
       />
       <ExchangeConfirmDialog
@@ -995,8 +1017,14 @@
     soldDialogRef.value?.show();
   };
 
-  // Confirm mark as sold
-  const confirmMarkSold = async () => {
+  // Confirm mark as sold.
+  //
+  // `finalPrice` comes from ExchangeListingsMarkSoldDialog and may be null — the seller
+  // can decline to disclose. Until 2026-07-30 this wrote only status + sold_date, so
+  // `final_price` was never populated by ANY code path and the sold archive had no
+  // prices to show; that is what kept /exchange/sold worth noindex-ing. Persist it only
+  // when given, so declining leaves the column null rather than writing a bogus 0.
+  const confirmMarkSold = async (finalPrice: number | null) => {
     if (!listing.value) return;
 
     markingSold.value = true;
@@ -1004,7 +1032,11 @@
       const soldDate = new Date().toISOString();
       const { error } = await supabase
         .from('listings')
-        .update({ status: 'sold', sold_date: soldDate })
+        .update({
+          status: 'sold',
+          sold_date: soldDate,
+          ...(finalPrice != null ? { final_price: finalPrice } : {}),
+        })
         .eq('id', listing.value.id)
         .eq('user_id', user.value?.id);
 
@@ -1013,6 +1045,7 @@
       // Update local state
       listing.value.status = 'sold';
       listing.value.sold_date = soldDate;
+      if (finalPrice != null) (listing.value as any).final_price = finalPrice;
 
       toast.add({
         title: t('toast.markedSold.title'),
@@ -1196,8 +1229,17 @@
         category: 'Classic Mini Cooper',
         offers: {
           '@type': 'Offer',
-          price: listing.value.price || 0,
-          priceCurrency: currency,
+          // For a SOLD listing the only honest figure is what it actually went for. The
+          // asking price is not the transaction price, and asserting it as one on an
+          // OutOfStock item would misrepresent the archive that this schema feeds — so
+          // when the seller declined to disclose (final_price null), emit no price at
+          // all rather than a number we'd be inventing. Active listings are unaffected:
+          // their asking price IS the offer.
+          ...(listing.value.status === 'sold'
+            ? (listing.value as any).final_price != null
+              ? { price: (listing.value as any).final_price, priceCurrency: currency }
+              : {}
+            : { price: listing.value.price || 0, priceCurrency: currency }),
           availability:
             listing.value.status === 'active' ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
           itemCondition: `https://schema.org/${listing.value.condition === 'new' ? 'NewCondition' : 'UsedCondition'}`,
@@ -1253,13 +1295,48 @@
 <i18n lang="json">
 {
   "en": {
-    "adminPreview": { "intro": "Admin Preview — This listing is", "outro": "and not visible to the public.", "approve": "Approve" },
+    "adminPreview": {
+      "intro": "Admin Preview — This listing is",
+      "outro": "and not visible to the public.",
+      "approve": "Approve"
+    },
     "exampleDisclaimer": "This is an example listing for demonstration purposes and is not for sale.",
     "backToListings": "Back to Listings",
     "anonymous": "Anonymous",
     "sections": { "description": "Description", "specifications": "Specifications", "location": "Location" },
-    "specs": { "mileage": "Mileage", "milesValue": "{miles} miles", "engineSize": "Engine Size", "transmission": "Transmission", "color": "Color", "enginePlateDetails": "Engine Plate Details", "partNumber": "Part Number", "type": "Type", "oem": "OEM", "oemAftermarketMix": "OEM & Aftermarket Mix", "aftermarket": "Aftermarket", "quantityAvailable": "Quantity Available", "fitsModels": "Fits Models" },
-    "shipping": { "title": "Shipping", "pickupOnly": "Pickup Only", "freeShipping": "Free Shipping", "domestic": "Domestic:", "international": "International:", "free": "Free", "shipsTo": "Ships to:", "delivery": "Delivery:", "businessDaysRange": "{min}-{max} business days", "businessDaysMin": "{min}+ business days", "businessDaysMax": "Up to {max} business days", "weightKg": "{weight} kg", "estimateCost": "Estimate shipping cost", "tracking": "Tracking", "trackPackage": "Track Package", "via": "via {carrier}" },
+    "specs": {
+      "mileage": "Mileage",
+      "milesValue": "{miles} miles",
+      "engineSize": "Engine Size",
+      "transmission": "Transmission",
+      "color": "Color",
+      "enginePlateDetails": "Engine Plate Details",
+      "partNumber": "Part Number",
+      "type": "Type",
+      "oem": "OEM",
+      "oemAftermarketMix": "OEM & Aftermarket Mix",
+      "aftermarket": "Aftermarket",
+      "quantityAvailable": "Quantity Available",
+      "fitsModels": "Fits Models"
+    },
+    "shipping": {
+      "title": "Shipping",
+      "pickupOnly": "Pickup Only",
+      "freeShipping": "Free Shipping",
+      "domestic": "Domestic:",
+      "international": "International:",
+      "free": "Free",
+      "shipsTo": "Ships to:",
+      "delivery": "Delivery:",
+      "businessDaysRange": "{min}-{max} business days",
+      "businessDaysMin": "{min}+ business days",
+      "businessDaysMax": "Up to {max} business days",
+      "weightKg": "{weight} kg",
+      "estimateCost": "Estimate shipping cost",
+      "tracking": "Tracking",
+      "trackPackage": "Track Package",
+      "via": "via {carrier}"
+    },
     "history": { "title": "Change History", "showLess": "Show Less", "showMore": "Show {count} More" },
     "sold": { "badge": "SOLD", "soldFor": "Sold for" },
     "aboutInCurrency": "About {amount} in {currency}",
@@ -1267,20 +1344,89 @@
     "details": { "views": "{count} views", "listingLocationFallback": "Listing location" },
     "heritage": { "certified": "Heritage Certified" },
     "seller": { "label": "Seller", "altFallback": "Seller" },
-    "actions": { "markSold": "Mark Sold", "delete": "Delete", "editListing": "Edit Listing", "manageListings": "Manage Listings", "messageSeller": "Message Seller", "removeFromWatchlist": "Remove from Watchlist", "addToWatchlist": "Add to Watchlist" },
+    "actions": {
+      "markSold": "Mark Sold",
+      "delete": "Delete",
+      "editListing": "Edit Listing",
+      "manageListings": "Manage Listings",
+      "messageSeller": "Message Seller",
+      "removeFromWatchlist": "Remove from Watchlist",
+      "addToWatchlist": "Add to Watchlist"
+    },
     "dates": { "listed": "Listed {date}", "updated": "· Updated {date}" },
-    "confirm": { "markSold": { "title": "Mark as Sold", "message": "Mark this listing as sold? Congratulations on your sale!", "confirm": "Mark Sold" }, "delete": { "title": "Delete Listing", "message": "Are you sure you want to delete this listing? This action cannot be undone.", "confirm": "Delete" } },
-    "notFound": { "title": "Listing Not Found", "message": "The listing you're looking for doesn't exist or has been removed.", "browseAll": "Browse All Listings" },
-    "toast": { "approved": { "title": "Listing Approved", "description": "This listing is now active and visible to all users." }, "approveError": "Failed to approve listing. Please try again.", "markedSold": { "title": "Listing Marked as Sold", "description": "Congratulations on your sale!" }, "markSoldError": "Failed to mark listing as sold. Please try again.", "deleted": { "title": "Listing Deleted", "description": "Your listing has been permanently deleted." }, "deleteError": "Failed to delete listing. Please try again.", "error": { "title": "Error" } }
+    "confirm": {
+      "markSold": {
+        "title": "Mark as Sold",
+        "message": "Mark this listing as sold? Congratulations on your sale!",
+        "confirm": "Mark Sold"
+      },
+      "delete": {
+        "title": "Delete Listing",
+        "message": "Are you sure you want to delete this listing? This action cannot be undone.",
+        "confirm": "Delete"
+      }
+    },
+    "notFound": {
+      "title": "Listing Not Found",
+      "message": "The listing you're looking for doesn't exist or has been removed.",
+      "browseAll": "Browse All Listings"
+    },
+    "toast": {
+      "approved": {
+        "title": "Listing Approved",
+        "description": "This listing is now active and visible to all users."
+      },
+      "approveError": "Failed to approve listing. Please try again.",
+      "markedSold": { "title": "Listing Marked as Sold", "description": "Congratulations on your sale!" },
+      "markSoldError": "Failed to mark listing as sold. Please try again.",
+      "deleted": { "title": "Listing Deleted", "description": "Your listing has been permanently deleted." },
+      "deleteError": "Failed to delete listing. Please try again.",
+      "error": { "title": "Error" }
+    }
   },
   "es": {
-    "adminPreview": { "intro": "Vista previa de administrador — Este anuncio está", "outro": "y no es visible para el público.", "approve": "Aprobar" },
+    "adminPreview": {
+      "intro": "Vista previa de administrador — Este anuncio está",
+      "outro": "y no es visible para el público.",
+      "approve": "Aprobar"
+    },
     "exampleDisclaimer": "Este es un anuncio de ejemplo con fines de demostración y no está en venta.",
     "backToListings": "Volver a los anuncios",
     "anonymous": "Anónimo",
     "sections": { "description": "Descripción", "specifications": "Especificaciones", "location": "Ubicación" },
-    "specs": { "mileage": "Kilometraje", "milesValue": "{miles} millas", "engineSize": "Cilindrada", "transmission": "Transmisión", "color": "Color", "enginePlateDetails": "Detalles de la placa del motor", "partNumber": "Número de pieza", "type": "Tipo", "oem": "OEM", "oemAftermarketMix": "Mezcla OEM y posventa", "aftermarket": "Posventa", "quantityAvailable": "Cantidad disponible", "fitsModels": "Modelos compatibles" },
-    "shipping": { "title": "Envío", "pickupOnly": "Solo recogida", "freeShipping": "Envío gratis", "domestic": "Nacional:", "international": "Internacional:", "free": "Gratis", "shipsTo": "Envía a:", "delivery": "Entrega:", "businessDaysRange": "{min}-{max} días hábiles", "businessDaysMin": "{min}+ días hábiles", "businessDaysMax": "Hasta {max} días hábiles", "weightKg": "{weight} kg", "estimateCost": "Estimar costo de envío", "tracking": "Seguimiento", "trackPackage": "Rastrear paquete", "via": "vía {carrier}" },
+    "specs": {
+      "mileage": "Kilometraje",
+      "milesValue": "{miles} millas",
+      "engineSize": "Cilindrada",
+      "transmission": "Transmisión",
+      "color": "Color",
+      "enginePlateDetails": "Detalles de la placa del motor",
+      "partNumber": "Número de pieza",
+      "type": "Tipo",
+      "oem": "OEM",
+      "oemAftermarketMix": "Mezcla OEM y posventa",
+      "aftermarket": "Posventa",
+      "quantityAvailable": "Cantidad disponible",
+      "fitsModels": "Modelos compatibles"
+    },
+    "shipping": {
+      "title": "Envío",
+      "pickupOnly": "Solo recogida",
+      "freeShipping": "Envío gratis",
+      "domestic": "Nacional:",
+      "international": "Internacional:",
+      "free": "Gratis",
+      "shipsTo": "Envía a:",
+      "delivery": "Entrega:",
+      "businessDaysRange": "{min}-{max} días hábiles",
+      "businessDaysMin": "{min}+ días hábiles",
+      "businessDaysMax": "Hasta {max} días hábiles",
+      "weightKg": "{weight} kg",
+      "estimateCost": "Estimar costo de envío",
+      "tracking": "Seguimiento",
+      "trackPackage": "Rastrear paquete",
+      "via": "vía {carrier}"
+    },
     "history": { "title": "Historial de cambios", "showLess": "Mostrar menos", "showMore": "Mostrar {count} más" },
     "sold": { "badge": "VENDIDO", "soldFor": "Vendido por" },
     "aboutInCurrency": "Aproximadamente {amount} en {currency}",
@@ -1288,41 +1434,183 @@
     "details": { "views": "{count} vistas", "listingLocationFallback": "Ubicación del anuncio" },
     "heritage": { "certified": "Certificado de patrimonio" },
     "seller": { "label": "Vendedor", "altFallback": "Vendedor" },
-    "actions": { "markSold": "Marcar como vendido", "delete": "Eliminar", "editListing": "Editar anuncio", "manageListings": "Gestionar anuncios", "messageSeller": "Enviar mensaje al vendedor", "removeFromWatchlist": "Quitar de la lista de seguimiento", "addToWatchlist": "Añadir a la lista de seguimiento" },
+    "actions": {
+      "markSold": "Marcar como vendido",
+      "delete": "Eliminar",
+      "editListing": "Editar anuncio",
+      "manageListings": "Gestionar anuncios",
+      "messageSeller": "Enviar mensaje al vendedor",
+      "removeFromWatchlist": "Quitar de la lista de seguimiento",
+      "addToWatchlist": "Añadir a la lista de seguimiento"
+    },
     "dates": { "listed": "Publicado {date}", "updated": "· Actualizado {date}" },
-    "confirm": { "markSold": { "title": "Marcar como vendido", "message": "¿Marcar este anuncio como vendido? ¡Felicidades por tu venta!", "confirm": "Marcar como vendido" }, "delete": { "title": "Eliminar anuncio", "message": "¿Estás seguro de que quieres eliminar este anuncio? Esta acción no se puede deshacer.", "confirm": "Eliminar" } },
-    "notFound": { "title": "Anuncio no encontrado", "message": "El anuncio que buscas no existe o ha sido eliminado.", "browseAll": "Explorar todos los anuncios" },
-    "toast": { "approved": { "title": "Anuncio aprobado", "description": "Este anuncio ahora está activo y es visible para todos los usuarios." }, "approveError": "No se pudo aprobar el anuncio. Inténtalo de nuevo.", "markedSold": { "title": "Anuncio marcado como vendido", "description": "¡Felicidades por tu venta!" }, "markSoldError": "No se pudo marcar el anuncio como vendido. Inténtalo de nuevo.", "deleted": { "title": "Anuncio eliminado", "description": "Tu anuncio se ha eliminado permanentemente." }, "deleteError": "No se pudo eliminar el anuncio. Inténtalo de nuevo.", "error": { "title": "Error" } }
+    "confirm": {
+      "markSold": {
+        "title": "Marcar como vendido",
+        "message": "¿Marcar este anuncio como vendido? ¡Felicidades por tu venta!",
+        "confirm": "Marcar como vendido"
+      },
+      "delete": {
+        "title": "Eliminar anuncio",
+        "message": "¿Estás seguro de que quieres eliminar este anuncio? Esta acción no se puede deshacer.",
+        "confirm": "Eliminar"
+      }
+    },
+    "notFound": {
+      "title": "Anuncio no encontrado",
+      "message": "El anuncio que buscas no existe o ha sido eliminado.",
+      "browseAll": "Explorar todos los anuncios"
+    },
+    "toast": {
+      "approved": {
+        "title": "Anuncio aprobado",
+        "description": "Este anuncio ahora está activo y es visible para todos los usuarios."
+      },
+      "approveError": "No se pudo aprobar el anuncio. Inténtalo de nuevo.",
+      "markedSold": { "title": "Anuncio marcado como vendido", "description": "¡Felicidades por tu venta!" },
+      "markSoldError": "No se pudo marcar el anuncio como vendido. Inténtalo de nuevo.",
+      "deleted": { "title": "Anuncio eliminado", "description": "Tu anuncio se ha eliminado permanentemente." },
+      "deleteError": "No se pudo eliminar el anuncio. Inténtalo de nuevo.",
+      "error": { "title": "Error" }
+    }
   },
   "fr": {
-    "adminPreview": { "intro": "Aperçu administrateur — Cette annonce est", "outro": "et n'est pas visible par le public.", "approve": "Approuver" },
+    "adminPreview": {
+      "intro": "Aperçu administrateur — Cette annonce est",
+      "outro": "et n'est pas visible par le public.",
+      "approve": "Approuver"
+    },
     "exampleDisclaimer": "Ceci est une annonce exemple à des fins de démonstration et n'est pas à vendre.",
     "backToListings": "Retour aux annonces",
     "anonymous": "Anonyme",
     "sections": { "description": "Description", "specifications": "Caractéristiques", "location": "Emplacement" },
-    "specs": { "mileage": "Kilométrage", "milesValue": "{miles} miles", "engineSize": "Cylindrée", "transmission": "Transmission", "color": "Couleur", "enginePlateDetails": "Détails de la plaque moteur", "partNumber": "Numéro de pièce", "type": "Type", "oem": "OEM", "oemAftermarketMix": "Mélange OEM et adaptable", "aftermarket": "Adaptable", "quantityAvailable": "Quantité disponible", "fitsModels": "Modèles compatibles" },
-    "shipping": { "title": "Expédition", "pickupOnly": "Retrait uniquement", "freeShipping": "Livraison gratuite", "domestic": "National :", "international": "International :", "free": "Gratuit", "shipsTo": "Expédie vers :", "delivery": "Livraison :", "businessDaysRange": "{min}-{max} jours ouvrables", "businessDaysMin": "{min}+ jours ouvrables", "businessDaysMax": "Jusqu'à {max} jours ouvrables", "weightKg": "{weight} kg", "estimateCost": "Estimer les frais d'expédition", "tracking": "Suivi", "trackPackage": "Suivre le colis", "via": "via {carrier}" },
-    "history": { "title": "Historique des modifications", "showLess": "Afficher moins", "showMore": "Afficher {count} de plus" },
+    "specs": {
+      "mileage": "Kilométrage",
+      "milesValue": "{miles} miles",
+      "engineSize": "Cylindrée",
+      "transmission": "Transmission",
+      "color": "Couleur",
+      "enginePlateDetails": "Détails de la plaque moteur",
+      "partNumber": "Numéro de pièce",
+      "type": "Type",
+      "oem": "OEM",
+      "oemAftermarketMix": "Mélange OEM et adaptable",
+      "aftermarket": "Adaptable",
+      "quantityAvailable": "Quantité disponible",
+      "fitsModels": "Modèles compatibles"
+    },
+    "shipping": {
+      "title": "Expédition",
+      "pickupOnly": "Retrait uniquement",
+      "freeShipping": "Livraison gratuite",
+      "domestic": "National :",
+      "international": "International :",
+      "free": "Gratuit",
+      "shipsTo": "Expédie vers :",
+      "delivery": "Livraison :",
+      "businessDaysRange": "{min}-{max} jours ouvrables",
+      "businessDaysMin": "{min}+ jours ouvrables",
+      "businessDaysMax": "Jusqu'à {max} jours ouvrables",
+      "weightKg": "{weight} kg",
+      "estimateCost": "Estimer les frais d'expédition",
+      "tracking": "Suivi",
+      "trackPackage": "Suivre le colis",
+      "via": "via {carrier}"
+    },
+    "history": {
+      "title": "Historique des modifications",
+      "showLess": "Afficher moins",
+      "showMore": "Afficher {count} de plus"
+    },
     "sold": { "badge": "VENDU", "soldFor": "Vendu pour" },
     "aboutInCurrency": "Environ {amount} en {currency}",
     "price": { "askingPrice": "Prix demandé", "exampleNotForSale": "Annonce exemple — non à vendre" },
     "details": { "views": "{count} vues", "listingLocationFallback": "Emplacement de l'annonce" },
     "heritage": { "certified": "Certifié patrimoine" },
     "seller": { "label": "Vendeur", "altFallback": "Vendeur" },
-    "actions": { "markSold": "Marquer comme vendu", "delete": "Supprimer", "editListing": "Modifier l'annonce", "manageListings": "Gérer les annonces", "messageSeller": "Contacter le vendeur", "removeFromWatchlist": "Retirer de la liste de suivi", "addToWatchlist": "Ajouter à la liste de suivi" },
+    "actions": {
+      "markSold": "Marquer comme vendu",
+      "delete": "Supprimer",
+      "editListing": "Modifier l'annonce",
+      "manageListings": "Gérer les annonces",
+      "messageSeller": "Contacter le vendeur",
+      "removeFromWatchlist": "Retirer de la liste de suivi",
+      "addToWatchlist": "Ajouter à la liste de suivi"
+    },
     "dates": { "listed": "Publié {date}", "updated": "· Mis à jour {date}" },
-    "confirm": { "markSold": { "title": "Marquer comme vendu", "message": "Marquer cette annonce comme vendue ? Félicitations pour votre vente !", "confirm": "Marquer comme vendu" }, "delete": { "title": "Supprimer l'annonce", "message": "Êtes-vous sûr de vouloir supprimer cette annonce ? Cette action est irréversible.", "confirm": "Supprimer" } },
-    "notFound": { "title": "Annonce introuvable", "message": "L'annonce que vous recherchez n'existe pas ou a été supprimée.", "browseAll": "Parcourir toutes les annonces" },
-    "toast": { "approved": { "title": "Annonce approuvée", "description": "Cette annonce est maintenant active et visible par tous les utilisateurs." }, "approveError": "Échec de l'approbation de l'annonce. Veuillez réessayer.", "markedSold": { "title": "Annonce marquée comme vendue", "description": "Félicitations pour votre vente !" }, "markSoldError": "Échec du marquage de l'annonce comme vendue. Veuillez réessayer.", "deleted": { "title": "Annonce supprimée", "description": "Votre annonce a été définitivement supprimée." }, "deleteError": "Échec de la suppression de l'annonce. Veuillez réessayer.", "error": { "title": "Erreur" } }
+    "confirm": {
+      "markSold": {
+        "title": "Marquer comme vendu",
+        "message": "Marquer cette annonce comme vendue ? Félicitations pour votre vente !",
+        "confirm": "Marquer comme vendu"
+      },
+      "delete": {
+        "title": "Supprimer l'annonce",
+        "message": "Êtes-vous sûr de vouloir supprimer cette annonce ? Cette action est irréversible.",
+        "confirm": "Supprimer"
+      }
+    },
+    "notFound": {
+      "title": "Annonce introuvable",
+      "message": "L'annonce que vous recherchez n'existe pas ou a été supprimée.",
+      "browseAll": "Parcourir toutes les annonces"
+    },
+    "toast": {
+      "approved": {
+        "title": "Annonce approuvée",
+        "description": "Cette annonce est maintenant active et visible par tous les utilisateurs."
+      },
+      "approveError": "Échec de l'approbation de l'annonce. Veuillez réessayer.",
+      "markedSold": { "title": "Annonce marquée comme vendue", "description": "Félicitations pour votre vente !" },
+      "markSoldError": "Échec du marquage de l'annonce comme vendue. Veuillez réessayer.",
+      "deleted": { "title": "Annonce supprimée", "description": "Votre annonce a été définitivement supprimée." },
+      "deleteError": "Échec de la suppression de l'annonce. Veuillez réessayer.",
+      "error": { "title": "Erreur" }
+    }
   },
   "de": {
-    "adminPreview": { "intro": "Admin-Vorschau — Diese Anzeige ist", "outro": "und für die Öffentlichkeit nicht sichtbar.", "approve": "Genehmigen" },
+    "adminPreview": {
+      "intro": "Admin-Vorschau — Diese Anzeige ist",
+      "outro": "und für die Öffentlichkeit nicht sichtbar.",
+      "approve": "Genehmigen"
+    },
     "exampleDisclaimer": "Dies ist eine Beispielanzeige zu Demonstrationszwecken und steht nicht zum Verkauf.",
     "backToListings": "Zurück zu den Anzeigen",
     "anonymous": "Anonym",
     "sections": { "description": "Beschreibung", "specifications": "Spezifikationen", "location": "Standort" },
-    "specs": { "mileage": "Kilometerstand", "milesValue": "{miles} Meilen", "engineSize": "Hubraum", "transmission": "Getriebe", "color": "Farbe", "enginePlateDetails": "Motorplakettendetails", "partNumber": "Teilenummer", "type": "Typ", "oem": "OEM", "oemAftermarketMix": "Mischung aus OEM und Zubehör", "aftermarket": "Zubehör", "quantityAvailable": "Verfügbare Menge", "fitsModels": "Passende Modelle" },
-    "shipping": { "title": "Versand", "pickupOnly": "Nur Abholung", "freeShipping": "Kostenloser Versand", "domestic": "Inland:", "international": "International:", "free": "Kostenlos", "shipsTo": "Versand nach:", "delivery": "Lieferung:", "businessDaysRange": "{min}-{max} Werktage", "businessDaysMin": "{min}+ Werktage", "businessDaysMax": "Bis zu {max} Werktage", "weightKg": "{weight} kg", "estimateCost": "Versandkosten schätzen", "tracking": "Sendungsverfolgung", "trackPackage": "Paket verfolgen", "via": "über {carrier}" },
+    "specs": {
+      "mileage": "Kilometerstand",
+      "milesValue": "{miles} Meilen",
+      "engineSize": "Hubraum",
+      "transmission": "Getriebe",
+      "color": "Farbe",
+      "enginePlateDetails": "Motorplakettendetails",
+      "partNumber": "Teilenummer",
+      "type": "Typ",
+      "oem": "OEM",
+      "oemAftermarketMix": "Mischung aus OEM und Zubehör",
+      "aftermarket": "Zubehör",
+      "quantityAvailable": "Verfügbare Menge",
+      "fitsModels": "Passende Modelle"
+    },
+    "shipping": {
+      "title": "Versand",
+      "pickupOnly": "Nur Abholung",
+      "freeShipping": "Kostenloser Versand",
+      "domestic": "Inland:",
+      "international": "International:",
+      "free": "Kostenlos",
+      "shipsTo": "Versand nach:",
+      "delivery": "Lieferung:",
+      "businessDaysRange": "{min}-{max} Werktage",
+      "businessDaysMin": "{min}+ Werktage",
+      "businessDaysMax": "Bis zu {max} Werktage",
+      "weightKg": "{weight} kg",
+      "estimateCost": "Versandkosten schätzen",
+      "tracking": "Sendungsverfolgung",
+      "trackPackage": "Paket verfolgen",
+      "via": "über {carrier}"
+    },
     "history": { "title": "Änderungsverlauf", "showLess": "Weniger anzeigen", "showMore": "{count} weitere anzeigen" },
     "sold": { "badge": "VERKAUFT", "soldFor": "Verkauft für" },
     "aboutInCurrency": "Etwa {amount} in {currency}",
@@ -1330,20 +1618,89 @@
     "details": { "views": "{count} Aufrufe", "listingLocationFallback": "Anzeigenstandort" },
     "heritage": { "certified": "Heritage-zertifiziert" },
     "seller": { "label": "Verkäufer", "altFallback": "Verkäufer" },
-    "actions": { "markSold": "Als verkauft markieren", "delete": "Löschen", "editListing": "Anzeige bearbeiten", "manageListings": "Anzeigen verwalten", "messageSeller": "Verkäufer kontaktieren", "removeFromWatchlist": "Von der Merkliste entfernen", "addToWatchlist": "Zur Merkliste hinzufügen" },
+    "actions": {
+      "markSold": "Als verkauft markieren",
+      "delete": "Löschen",
+      "editListing": "Anzeige bearbeiten",
+      "manageListings": "Anzeigen verwalten",
+      "messageSeller": "Verkäufer kontaktieren",
+      "removeFromWatchlist": "Von der Merkliste entfernen",
+      "addToWatchlist": "Zur Merkliste hinzufügen"
+    },
     "dates": { "listed": "Eingestellt {date}", "updated": "· Aktualisiert {date}" },
-    "confirm": { "markSold": { "title": "Als verkauft markieren", "message": "Diese Anzeige als verkauft markieren? Glückwunsch zu deinem Verkauf!", "confirm": "Als verkauft markieren" }, "delete": { "title": "Anzeige löschen", "message": "Möchtest du diese Anzeige wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.", "confirm": "Löschen" } },
-    "notFound": { "title": "Anzeige nicht gefunden", "message": "Die gesuchte Anzeige existiert nicht oder wurde entfernt.", "browseAll": "Alle Anzeigen durchsuchen" },
-    "toast": { "approved": { "title": "Anzeige genehmigt", "description": "Diese Anzeige ist jetzt aktiv und für alle Nutzer sichtbar." }, "approveError": "Anzeige konnte nicht genehmigt werden. Bitte erneut versuchen.", "markedSold": { "title": "Anzeige als verkauft markiert", "description": "Glückwunsch zu deinem Verkauf!" }, "markSoldError": "Anzeige konnte nicht als verkauft markiert werden. Bitte erneut versuchen.", "deleted": { "title": "Anzeige gelöscht", "description": "Deine Anzeige wurde dauerhaft gelöscht." }, "deleteError": "Anzeige konnte nicht gelöscht werden. Bitte erneut versuchen.", "error": { "title": "Fehler" } }
+    "confirm": {
+      "markSold": {
+        "title": "Als verkauft markieren",
+        "message": "Diese Anzeige als verkauft markieren? Glückwunsch zu deinem Verkauf!",
+        "confirm": "Als verkauft markieren"
+      },
+      "delete": {
+        "title": "Anzeige löschen",
+        "message": "Möchtest du diese Anzeige wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Löschen"
+      }
+    },
+    "notFound": {
+      "title": "Anzeige nicht gefunden",
+      "message": "Die gesuchte Anzeige existiert nicht oder wurde entfernt.",
+      "browseAll": "Alle Anzeigen durchsuchen"
+    },
+    "toast": {
+      "approved": {
+        "title": "Anzeige genehmigt",
+        "description": "Diese Anzeige ist jetzt aktiv und für alle Nutzer sichtbar."
+      },
+      "approveError": "Anzeige konnte nicht genehmigt werden. Bitte erneut versuchen.",
+      "markedSold": { "title": "Anzeige als verkauft markiert", "description": "Glückwunsch zu deinem Verkauf!" },
+      "markSoldError": "Anzeige konnte nicht als verkauft markiert werden. Bitte erneut versuchen.",
+      "deleted": { "title": "Anzeige gelöscht", "description": "Deine Anzeige wurde dauerhaft gelöscht." },
+      "deleteError": "Anzeige konnte nicht gelöscht werden. Bitte erneut versuchen.",
+      "error": { "title": "Fehler" }
+    }
   },
   "it": {
-    "adminPreview": { "intro": "Anteprima amministratore — Questo annuncio è", "outro": "e non è visibile al pubblico.", "approve": "Approva" },
+    "adminPreview": {
+      "intro": "Anteprima amministratore — Questo annuncio è",
+      "outro": "e non è visibile al pubblico.",
+      "approve": "Approva"
+    },
     "exampleDisclaimer": "Questo è un annuncio di esempio a scopo dimostrativo e non è in vendita.",
     "backToListings": "Torna agli annunci",
     "anonymous": "Anonimo",
     "sections": { "description": "Descrizione", "specifications": "Specifiche", "location": "Posizione" },
-    "specs": { "mileage": "Chilometraggio", "milesValue": "{miles} miglia", "engineSize": "Cilindrata", "transmission": "Trasmissione", "color": "Colore", "enginePlateDetails": "Dettagli targhetta motore", "partNumber": "Numero ricambio", "type": "Tipo", "oem": "OEM", "oemAftermarketMix": "Mix OEM e aftermarket", "aftermarket": "Aftermarket", "quantityAvailable": "Quantità disponibile", "fitsModels": "Modelli compatibili" },
-    "shipping": { "title": "Spedizione", "pickupOnly": "Solo ritiro", "freeShipping": "Spedizione gratuita", "domestic": "Nazionale:", "international": "Internazionale:", "free": "Gratis", "shipsTo": "Spedisce a:", "delivery": "Consegna:", "businessDaysRange": "{min}-{max} giorni lavorativi", "businessDaysMin": "{min}+ giorni lavorativi", "businessDaysMax": "Fino a {max} giorni lavorativi", "weightKg": "{weight} kg", "estimateCost": "Stima i costi di spedizione", "tracking": "Tracciamento", "trackPackage": "Traccia pacco", "via": "tramite {carrier}" },
+    "specs": {
+      "mileage": "Chilometraggio",
+      "milesValue": "{miles} miglia",
+      "engineSize": "Cilindrata",
+      "transmission": "Trasmissione",
+      "color": "Colore",
+      "enginePlateDetails": "Dettagli targhetta motore",
+      "partNumber": "Numero ricambio",
+      "type": "Tipo",
+      "oem": "OEM",
+      "oemAftermarketMix": "Mix OEM e aftermarket",
+      "aftermarket": "Aftermarket",
+      "quantityAvailable": "Quantità disponibile",
+      "fitsModels": "Modelli compatibili"
+    },
+    "shipping": {
+      "title": "Spedizione",
+      "pickupOnly": "Solo ritiro",
+      "freeShipping": "Spedizione gratuita",
+      "domestic": "Nazionale:",
+      "international": "Internazionale:",
+      "free": "Gratis",
+      "shipsTo": "Spedisce a:",
+      "delivery": "Consegna:",
+      "businessDaysRange": "{min}-{max} giorni lavorativi",
+      "businessDaysMin": "{min}+ giorni lavorativi",
+      "businessDaysMax": "Fino a {max} giorni lavorativi",
+      "weightKg": "{weight} kg",
+      "estimateCost": "Stima i costi di spedizione",
+      "tracking": "Tracciamento",
+      "trackPackage": "Traccia pacco",
+      "via": "tramite {carrier}"
+    },
     "history": { "title": "Cronologia modifiche", "showLess": "Mostra meno", "showMore": "Mostra altri {count}" },
     "sold": { "badge": "VENDUTO", "soldFor": "Venduto a" },
     "aboutInCurrency": "Circa {amount} in {currency}",
@@ -1351,20 +1708,89 @@
     "details": { "views": "{count} visualizzazioni", "listingLocationFallback": "Posizione annuncio" },
     "heritage": { "certified": "Certificato Heritage" },
     "seller": { "label": "Venditore", "altFallback": "Venditore" },
-    "actions": { "markSold": "Segna come venduto", "delete": "Elimina", "editListing": "Modifica annuncio", "manageListings": "Gestisci annunci", "messageSeller": "Contatta il venditore", "removeFromWatchlist": "Rimuovi dalla lista", "addToWatchlist": "Aggiungi alla lista" },
+    "actions": {
+      "markSold": "Segna come venduto",
+      "delete": "Elimina",
+      "editListing": "Modifica annuncio",
+      "manageListings": "Gestisci annunci",
+      "messageSeller": "Contatta il venditore",
+      "removeFromWatchlist": "Rimuovi dalla lista",
+      "addToWatchlist": "Aggiungi alla lista"
+    },
     "dates": { "listed": "Pubblicato {date}", "updated": "· Aggiornato {date}" },
-    "confirm": { "markSold": { "title": "Segna come venduto", "message": "Segnare questo annuncio come venduto? Congratulazioni per la vendita!", "confirm": "Segna come venduto" }, "delete": { "title": "Elimina annuncio", "message": "Sei sicuro di voler eliminare questo annuncio? Questa azione non può essere annullata.", "confirm": "Elimina" } },
-    "notFound": { "title": "Annuncio non trovato", "message": "L'annuncio che cerchi non esiste o è stato rimosso.", "browseAll": "Sfoglia tutti gli annunci" },
-    "toast": { "approved": { "title": "Annuncio approvato", "description": "Questo annuncio è ora attivo e visibile a tutti gli utenti." }, "approveError": "Impossibile approvare l'annuncio. Riprova.", "markedSold": { "title": "Annuncio segnato come venduto", "description": "Congratulazioni per la vendita!" }, "markSoldError": "Impossibile segnare l'annuncio come venduto. Riprova.", "deleted": { "title": "Annuncio eliminato", "description": "Il tuo annuncio è stato eliminato definitivamente." }, "deleteError": "Impossibile eliminare l'annuncio. Riprova.", "error": { "title": "Errore" } }
+    "confirm": {
+      "markSold": {
+        "title": "Segna come venduto",
+        "message": "Segnare questo annuncio come venduto? Congratulazioni per la vendita!",
+        "confirm": "Segna come venduto"
+      },
+      "delete": {
+        "title": "Elimina annuncio",
+        "message": "Sei sicuro di voler eliminare questo annuncio? Questa azione non può essere annullata.",
+        "confirm": "Elimina"
+      }
+    },
+    "notFound": {
+      "title": "Annuncio non trovato",
+      "message": "L'annuncio che cerchi non esiste o è stato rimosso.",
+      "browseAll": "Sfoglia tutti gli annunci"
+    },
+    "toast": {
+      "approved": {
+        "title": "Annuncio approvato",
+        "description": "Questo annuncio è ora attivo e visibile a tutti gli utenti."
+      },
+      "approveError": "Impossibile approvare l'annuncio. Riprova.",
+      "markedSold": { "title": "Annuncio segnato come venduto", "description": "Congratulazioni per la vendita!" },
+      "markSoldError": "Impossibile segnare l'annuncio come venduto. Riprova.",
+      "deleted": { "title": "Annuncio eliminato", "description": "Il tuo annuncio è stato eliminato definitivamente." },
+      "deleteError": "Impossibile eliminare l'annuncio. Riprova.",
+      "error": { "title": "Errore" }
+    }
   },
   "pt": {
-    "adminPreview": { "intro": "Pré-visualização de administrador — Este anúncio está", "outro": "e não é visível ao público.", "approve": "Aprovar" },
+    "adminPreview": {
+      "intro": "Pré-visualização de administrador — Este anúncio está",
+      "outro": "e não é visível ao público.",
+      "approve": "Aprovar"
+    },
     "exampleDisclaimer": "Este é um anúncio de exemplo para fins de demonstração e não está à venda.",
     "backToListings": "Voltar aos anúncios",
     "anonymous": "Anônimo",
     "sections": { "description": "Descrição", "specifications": "Especificações", "location": "Localização" },
-    "specs": { "mileage": "Quilometragem", "milesValue": "{miles} milhas", "engineSize": "Cilindrada", "transmission": "Transmissão", "color": "Cor", "enginePlateDetails": "Detalhes da placa do motor", "partNumber": "Número da peça", "type": "Tipo", "oem": "OEM", "oemAftermarketMix": "Mistura OEM e aftermarket", "aftermarket": "Aftermarket", "quantityAvailable": "Quantidade disponível", "fitsModels": "Modelos compatíveis" },
-    "shipping": { "title": "Envio", "pickupOnly": "Apenas retirada", "freeShipping": "Frete grátis", "domestic": "Nacional:", "international": "Internacional:", "free": "Grátis", "shipsTo": "Envia para:", "delivery": "Entrega:", "businessDaysRange": "{min}-{max} dias úteis", "businessDaysMin": "{min}+ dias úteis", "businessDaysMax": "Até {max} dias úteis", "weightKg": "{weight} kg", "estimateCost": "Estimar custo de envio", "tracking": "Rastreamento", "trackPackage": "Rastrear pacote", "via": "via {carrier}" },
+    "specs": {
+      "mileage": "Quilometragem",
+      "milesValue": "{miles} milhas",
+      "engineSize": "Cilindrada",
+      "transmission": "Transmissão",
+      "color": "Cor",
+      "enginePlateDetails": "Detalhes da placa do motor",
+      "partNumber": "Número da peça",
+      "type": "Tipo",
+      "oem": "OEM",
+      "oemAftermarketMix": "Mistura OEM e aftermarket",
+      "aftermarket": "Aftermarket",
+      "quantityAvailable": "Quantidade disponível",
+      "fitsModels": "Modelos compatíveis"
+    },
+    "shipping": {
+      "title": "Envio",
+      "pickupOnly": "Apenas retirada",
+      "freeShipping": "Frete grátis",
+      "domestic": "Nacional:",
+      "international": "Internacional:",
+      "free": "Grátis",
+      "shipsTo": "Envia para:",
+      "delivery": "Entrega:",
+      "businessDaysRange": "{min}-{max} dias úteis",
+      "businessDaysMin": "{min}+ dias úteis",
+      "businessDaysMax": "Até {max} dias úteis",
+      "weightKg": "{weight} kg",
+      "estimateCost": "Estimar custo de envio",
+      "tracking": "Rastreamento",
+      "trackPackage": "Rastrear pacote",
+      "via": "via {carrier}"
+    },
     "history": { "title": "Histórico de alterações", "showLess": "Mostrar menos", "showMore": "Mostrar mais {count}" },
     "sold": { "badge": "VENDIDO", "soldFor": "Vendido por" },
     "aboutInCurrency": "Cerca de {amount} em {currency}",
@@ -1372,20 +1798,89 @@
     "details": { "views": "{count} visualizações", "listingLocationFallback": "Localização do anúncio" },
     "heritage": { "certified": "Certificado de patrimônio" },
     "seller": { "label": "Vendedor", "altFallback": "Vendedor" },
-    "actions": { "markSold": "Marcar como vendido", "delete": "Excluir", "editListing": "Editar anúncio", "manageListings": "Gerenciar anúncios", "messageSeller": "Enviar mensagem ao vendedor", "removeFromWatchlist": "Remover da lista de observação", "addToWatchlist": "Adicionar à lista de observação" },
+    "actions": {
+      "markSold": "Marcar como vendido",
+      "delete": "Excluir",
+      "editListing": "Editar anúncio",
+      "manageListings": "Gerenciar anúncios",
+      "messageSeller": "Enviar mensagem ao vendedor",
+      "removeFromWatchlist": "Remover da lista de observação",
+      "addToWatchlist": "Adicionar à lista de observação"
+    },
     "dates": { "listed": "Publicado {date}", "updated": "· Atualizado {date}" },
-    "confirm": { "markSold": { "title": "Marcar como vendido", "message": "Marcar este anúncio como vendido? Parabéns pela sua venda!", "confirm": "Marcar como vendido" }, "delete": { "title": "Excluir anúncio", "message": "Tem certeza de que deseja excluir este anúncio? Esta ação não pode ser desfeita.", "confirm": "Excluir" } },
-    "notFound": { "title": "Anúncio não encontrado", "message": "O anúncio que você procura não existe ou foi removido.", "browseAll": "Explorar todos os anúncios" },
-    "toast": { "approved": { "title": "Anúncio aprovado", "description": "Este anúncio agora está ativo e visível para todos os usuários." }, "approveError": "Falha ao aprovar o anúncio. Tente novamente.", "markedSold": { "title": "Anúncio marcado como vendido", "description": "Parabéns pela sua venda!" }, "markSoldError": "Falha ao marcar o anúncio como vendido. Tente novamente.", "deleted": { "title": "Anúncio excluído", "description": "Seu anúncio foi excluído permanentemente." }, "deleteError": "Falha ao excluir o anúncio. Tente novamente.", "error": { "title": "Erro" } }
+    "confirm": {
+      "markSold": {
+        "title": "Marcar como vendido",
+        "message": "Marcar este anúncio como vendido? Parabéns pela sua venda!",
+        "confirm": "Marcar como vendido"
+      },
+      "delete": {
+        "title": "Excluir anúncio",
+        "message": "Tem certeza de que deseja excluir este anúncio? Esta ação não pode ser desfeita.",
+        "confirm": "Excluir"
+      }
+    },
+    "notFound": {
+      "title": "Anúncio não encontrado",
+      "message": "O anúncio que você procura não existe ou foi removido.",
+      "browseAll": "Explorar todos os anúncios"
+    },
+    "toast": {
+      "approved": {
+        "title": "Anúncio aprovado",
+        "description": "Este anúncio agora está ativo e visível para todos os usuários."
+      },
+      "approveError": "Falha ao aprovar o anúncio. Tente novamente.",
+      "markedSold": { "title": "Anúncio marcado como vendido", "description": "Parabéns pela sua venda!" },
+      "markSoldError": "Falha ao marcar o anúncio como vendido. Tente novamente.",
+      "deleted": { "title": "Anúncio excluído", "description": "Seu anúncio foi excluído permanentemente." },
+      "deleteError": "Falha ao excluir o anúncio. Tente novamente.",
+      "error": { "title": "Erro" }
+    }
   },
   "ru": {
-    "adminPreview": { "intro": "Предпросмотр администратора — Это объявление имеет статус", "outro": "и недоступно для публики.", "approve": "Одобрить" },
+    "adminPreview": {
+      "intro": "Предпросмотр администратора — Это объявление имеет статус",
+      "outro": "и недоступно для публики.",
+      "approve": "Одобрить"
+    },
     "exampleDisclaimer": "Это пример объявления в демонстрационных целях, оно не продаётся.",
     "backToListings": "Назад к объявлениям",
     "anonymous": "Аноним",
     "sections": { "description": "Описание", "specifications": "Характеристики", "location": "Местоположение" },
-    "specs": { "mileage": "Пробег", "milesValue": "{miles} миль", "engineSize": "Объём двигателя", "transmission": "Коробка передач", "color": "Цвет", "enginePlateDetails": "Данные таблички двигателя", "partNumber": "Номер детали", "type": "Тип", "oem": "OEM", "oemAftermarketMix": "Смесь OEM и неоригинальных", "aftermarket": "Неоригинальная", "quantityAvailable": "Доступное количество", "fitsModels": "Подходящие модели" },
-    "shipping": { "title": "Доставка", "pickupOnly": "Только самовывоз", "freeShipping": "Бесплатная доставка", "domestic": "По стране:", "international": "Международная:", "free": "Бесплатно", "shipsTo": "Доставка в:", "delivery": "Срок доставки:", "businessDaysRange": "{min}-{max} рабочих дней", "businessDaysMin": "{min}+ рабочих дней", "businessDaysMax": "До {max} рабочих дней", "weightKg": "{weight} кг", "estimateCost": "Оценить стоимость доставки", "tracking": "Отслеживание", "trackPackage": "Отследить посылку", "via": "через {carrier}" },
+    "specs": {
+      "mileage": "Пробег",
+      "milesValue": "{miles} миль",
+      "engineSize": "Объём двигателя",
+      "transmission": "Коробка передач",
+      "color": "Цвет",
+      "enginePlateDetails": "Данные таблички двигателя",
+      "partNumber": "Номер детали",
+      "type": "Тип",
+      "oem": "OEM",
+      "oemAftermarketMix": "Смесь OEM и неоригинальных",
+      "aftermarket": "Неоригинальная",
+      "quantityAvailable": "Доступное количество",
+      "fitsModels": "Подходящие модели"
+    },
+    "shipping": {
+      "title": "Доставка",
+      "pickupOnly": "Только самовывоз",
+      "freeShipping": "Бесплатная доставка",
+      "domestic": "По стране:",
+      "international": "Международная:",
+      "free": "Бесплатно",
+      "shipsTo": "Доставка в:",
+      "delivery": "Срок доставки:",
+      "businessDaysRange": "{min}-{max} рабочих дней",
+      "businessDaysMin": "{min}+ рабочих дней",
+      "businessDaysMax": "До {max} рабочих дней",
+      "weightKg": "{weight} кг",
+      "estimateCost": "Оценить стоимость доставки",
+      "tracking": "Отслеживание",
+      "trackPackage": "Отследить посылку",
+      "via": "через {carrier}"
+    },
     "history": { "title": "История изменений", "showLess": "Показать меньше", "showMore": "Показать ещё {count}" },
     "sold": { "badge": "ПРОДАНО", "soldFor": "Продано за" },
     "aboutInCurrency": "Около {amount} в {currency}",
@@ -1393,20 +1888,89 @@
     "details": { "views": "{count} просмотров", "listingLocationFallback": "Местоположение объявления" },
     "heritage": { "certified": "Сертифицировано Heritage" },
     "seller": { "label": "Продавец", "altFallback": "Продавец" },
-    "actions": { "markSold": "Отметить как проданное", "delete": "Удалить", "editListing": "Редактировать объявление", "manageListings": "Управление объявлениями", "messageSeller": "Написать продавцу", "removeFromWatchlist": "Удалить из списка отслеживания", "addToWatchlist": "Добавить в список отслеживания" },
+    "actions": {
+      "markSold": "Отметить как проданное",
+      "delete": "Удалить",
+      "editListing": "Редактировать объявление",
+      "manageListings": "Управление объявлениями",
+      "messageSeller": "Написать продавцу",
+      "removeFromWatchlist": "Удалить из списка отслеживания",
+      "addToWatchlist": "Добавить в список отслеживания"
+    },
     "dates": { "listed": "Опубликовано {date}", "updated": "· Обновлено {date}" },
-    "confirm": { "markSold": { "title": "Отметить как проданное", "message": "Отметить это объявление как проданное? Поздравляем с продажей!", "confirm": "Отметить как проданное" }, "delete": { "title": "Удалить объявление", "message": "Вы уверены, что хотите удалить это объявление? Это действие нельзя отменить.", "confirm": "Удалить" } },
-    "notFound": { "title": "Объявление не найдено", "message": "Объявление, которое вы ищете, не существует или было удалено.", "browseAll": "Просмотреть все объявления" },
-    "toast": { "approved": { "title": "Объявление одобрено", "description": "Это объявление теперь активно и видно всем пользователям." }, "approveError": "Не удалось одобрить объявление. Попробуйте ещё раз.", "markedSold": { "title": "Объявление отмечено как проданное", "description": "Поздравляем с продажей!" }, "markSoldError": "Не удалось отметить объявление как проданное. Попробуйте ещё раз.", "deleted": { "title": "Объявление удалено", "description": "Ваше объявление было удалено навсегда." }, "deleteError": "Не удалось удалить объявление. Попробуйте ещё раз.", "error": { "title": "Ошибка" } }
+    "confirm": {
+      "markSold": {
+        "title": "Отметить как проданное",
+        "message": "Отметить это объявление как проданное? Поздравляем с продажей!",
+        "confirm": "Отметить как проданное"
+      },
+      "delete": {
+        "title": "Удалить объявление",
+        "message": "Вы уверены, что хотите удалить это объявление? Это действие нельзя отменить.",
+        "confirm": "Удалить"
+      }
+    },
+    "notFound": {
+      "title": "Объявление не найдено",
+      "message": "Объявление, которое вы ищете, не существует или было удалено.",
+      "browseAll": "Просмотреть все объявления"
+    },
+    "toast": {
+      "approved": {
+        "title": "Объявление одобрено",
+        "description": "Это объявление теперь активно и видно всем пользователям."
+      },
+      "approveError": "Не удалось одобрить объявление. Попробуйте ещё раз.",
+      "markedSold": { "title": "Объявление отмечено как проданное", "description": "Поздравляем с продажей!" },
+      "markSoldError": "Не удалось отметить объявление как проданное. Попробуйте ещё раз.",
+      "deleted": { "title": "Объявление удалено", "description": "Ваше объявление было удалено навсегда." },
+      "deleteError": "Не удалось удалить объявление. Попробуйте ещё раз.",
+      "error": { "title": "Ошибка" }
+    }
   },
   "ja": {
-    "adminPreview": { "intro": "管理者プレビュー — この出品は", "outro": "で、一般には公開されていません。", "approve": "承認" },
+    "adminPreview": {
+      "intro": "管理者プレビュー — この出品は",
+      "outro": "で、一般には公開されていません。",
+      "approve": "承認"
+    },
     "exampleDisclaimer": "これはデモ用のサンプル出品であり、販売対象ではありません。",
     "backToListings": "出品一覧に戻る",
     "anonymous": "匿名",
     "sections": { "description": "説明", "specifications": "仕様", "location": "場所" },
-    "specs": { "mileage": "走行距離", "milesValue": "{miles} マイル", "engineSize": "エンジン排気量", "transmission": "トランスミッション", "color": "色", "enginePlateDetails": "エンジンプレート詳細", "partNumber": "部品番号", "type": "タイプ", "oem": "OEM", "oemAftermarketMix": "OEM・社外品の混合", "aftermarket": "社外品", "quantityAvailable": "在庫数", "fitsModels": "適合モデル" },
-    "shipping": { "title": "配送", "pickupOnly": "引き取りのみ", "freeShipping": "送料無料", "domestic": "国内:", "international": "国際:", "free": "無料", "shipsTo": "発送先:", "delivery": "お届け:", "businessDaysRange": "{min}〜{max} 営業日", "businessDaysMin": "{min}+ 営業日", "businessDaysMax": "最大 {max} 営業日", "weightKg": "{weight} kg", "estimateCost": "送料を見積もる", "tracking": "追跡", "trackPackage": "荷物を追跡", "via": "{carrier} 経由" },
+    "specs": {
+      "mileage": "走行距離",
+      "milesValue": "{miles} マイル",
+      "engineSize": "エンジン排気量",
+      "transmission": "トランスミッション",
+      "color": "色",
+      "enginePlateDetails": "エンジンプレート詳細",
+      "partNumber": "部品番号",
+      "type": "タイプ",
+      "oem": "OEM",
+      "oemAftermarketMix": "OEM・社外品の混合",
+      "aftermarket": "社外品",
+      "quantityAvailable": "在庫数",
+      "fitsModels": "適合モデル"
+    },
+    "shipping": {
+      "title": "配送",
+      "pickupOnly": "引き取りのみ",
+      "freeShipping": "送料無料",
+      "domestic": "国内:",
+      "international": "国際:",
+      "free": "無料",
+      "shipsTo": "発送先:",
+      "delivery": "お届け:",
+      "businessDaysRange": "{min}〜{max} 営業日",
+      "businessDaysMin": "{min}+ 営業日",
+      "businessDaysMax": "最大 {max} 営業日",
+      "weightKg": "{weight} kg",
+      "estimateCost": "送料を見積もる",
+      "tracking": "追跡",
+      "trackPackage": "荷物を追跡",
+      "via": "{carrier} 経由"
+    },
     "history": { "title": "変更履歴", "showLess": "表示を減らす", "showMore": "さらに {count} 件を表示" },
     "sold": { "badge": "売却済み", "soldFor": "販売価格" },
     "aboutInCurrency": "約 {amount}（{currency}）",
@@ -1414,11 +1978,45 @@
     "details": { "views": "{count} 回表示", "listingLocationFallback": "出品場所" },
     "heritage": { "certified": "ヘリテージ認定" },
     "seller": { "label": "出品者", "altFallback": "出品者" },
-    "actions": { "markSold": "売却済みにする", "delete": "削除", "editListing": "出品を編集", "manageListings": "出品を管理", "messageSeller": "出品者にメッセージ", "removeFromWatchlist": "ウォッチリストから削除", "addToWatchlist": "ウォッチリストに追加" },
+    "actions": {
+      "markSold": "売却済みにする",
+      "delete": "削除",
+      "editListing": "出品を編集",
+      "manageListings": "出品を管理",
+      "messageSeller": "出品者にメッセージ",
+      "removeFromWatchlist": "ウォッチリストから削除",
+      "addToWatchlist": "ウォッチリストに追加"
+    },
     "dates": { "listed": "{date} に出品", "updated": "· {date} に更新" },
-    "confirm": { "markSold": { "title": "売却済みにする", "message": "この出品を売却済みにしますか？ ご成約おめでとうございます！", "confirm": "売却済みにする" }, "delete": { "title": "出品を削除", "message": "この出品を削除してもよろしいですか？ この操作は取り消せません。", "confirm": "削除" } },
-    "notFound": { "title": "出品が見つかりません", "message": "お探しの出品は存在しないか、削除されました。", "browseAll": "すべての出品を見る" },
-    "toast": { "approved": { "title": "出品を承認しました", "description": "この出品は有効になり、すべてのユーザーに表示されます。" }, "approveError": "出品の承認に失敗しました。もう一度お試しください。", "markedSold": { "title": "出品を売却済みにしました", "description": "ご成約おめでとうございます！" }, "markSoldError": "出品を売却済みにできませんでした。もう一度お試しください。", "deleted": { "title": "出品を削除しました", "description": "出品は完全に削除されました。" }, "deleteError": "出品の削除に失敗しました。もう一度お試しください。", "error": { "title": "エラー" } }
+    "confirm": {
+      "markSold": {
+        "title": "売却済みにする",
+        "message": "この出品を売却済みにしますか？ ご成約おめでとうございます！",
+        "confirm": "売却済みにする"
+      },
+      "delete": {
+        "title": "出品を削除",
+        "message": "この出品を削除してもよろしいですか？ この操作は取り消せません。",
+        "confirm": "削除"
+      }
+    },
+    "notFound": {
+      "title": "出品が見つかりません",
+      "message": "お探しの出品は存在しないか、削除されました。",
+      "browseAll": "すべての出品を見る"
+    },
+    "toast": {
+      "approved": {
+        "title": "出品を承認しました",
+        "description": "この出品は有効になり、すべてのユーザーに表示されます。"
+      },
+      "approveError": "出品の承認に失敗しました。もう一度お試しください。",
+      "markedSold": { "title": "出品を売却済みにしました", "description": "ご成約おめでとうございます！" },
+      "markSoldError": "出品を売却済みにできませんでした。もう一度お試しください。",
+      "deleted": { "title": "出品を削除しました", "description": "出品は完全に削除されました。" },
+      "deleteError": "出品の削除に失敗しました。もう一度お試しください。",
+      "error": { "title": "エラー" }
+    }
   },
   "zh": {
     "adminPreview": { "intro": "管理员预览 — 此刊登状态为", "outro": "，对公众不可见。", "approve": "批准" },
@@ -1426,8 +2024,39 @@
     "backToListings": "返回刊登列表",
     "anonymous": "匿名",
     "sections": { "description": "描述", "specifications": "规格", "location": "位置" },
-    "specs": { "mileage": "里程", "milesValue": "{miles} 英里", "engineSize": "发动机排量", "transmission": "变速箱", "color": "颜色", "enginePlateDetails": "发动机铭牌详情", "partNumber": "零件编号", "type": "类型", "oem": "原厂", "oemAftermarketMix": "原厂与副厂混合", "aftermarket": "副厂", "quantityAvailable": "可用数量", "fitsModels": "适配车型" },
-    "shipping": { "title": "配送", "pickupOnly": "仅自取", "freeShipping": "免运费", "domestic": "国内:", "international": "国际:", "free": "免费", "shipsTo": "配送至:", "delivery": "送达:", "businessDaysRange": "{min}-{max} 个工作日", "businessDaysMin": "{min}+ 个工作日", "businessDaysMax": "最多 {max} 个工作日", "weightKg": "{weight} 公斤", "estimateCost": "估算运费", "tracking": "物流追踪", "trackPackage": "追踪包裹", "via": "通过 {carrier}" },
+    "specs": {
+      "mileage": "里程",
+      "milesValue": "{miles} 英里",
+      "engineSize": "发动机排量",
+      "transmission": "变速箱",
+      "color": "颜色",
+      "enginePlateDetails": "发动机铭牌详情",
+      "partNumber": "零件编号",
+      "type": "类型",
+      "oem": "原厂",
+      "oemAftermarketMix": "原厂与副厂混合",
+      "aftermarket": "副厂",
+      "quantityAvailable": "可用数量",
+      "fitsModels": "适配车型"
+    },
+    "shipping": {
+      "title": "配送",
+      "pickupOnly": "仅自取",
+      "freeShipping": "免运费",
+      "domestic": "国内:",
+      "international": "国际:",
+      "free": "免费",
+      "shipsTo": "配送至:",
+      "delivery": "送达:",
+      "businessDaysRange": "{min}-{max} 个工作日",
+      "businessDaysMin": "{min}+ 个工作日",
+      "businessDaysMax": "最多 {max} 个工作日",
+      "weightKg": "{weight} 公斤",
+      "estimateCost": "估算运费",
+      "tracking": "物流追踪",
+      "trackPackage": "追踪包裹",
+      "via": "通过 {carrier}"
+    },
     "history": { "title": "变更历史", "showLess": "收起", "showMore": "显示另外 {count} 条" },
     "sold": { "badge": "已售", "soldFor": "售出价" },
     "aboutInCurrency": "约 {amount}（{currency}）",
@@ -1435,20 +2064,74 @@
     "details": { "views": "{count} 次浏览", "listingLocationFallback": "刊登位置" },
     "heritage": { "certified": "传承认证" },
     "seller": { "label": "卖家", "altFallback": "卖家" },
-    "actions": { "markSold": "标记为已售", "delete": "删除", "editListing": "编辑刊登", "manageListings": "管理刊登", "messageSeller": "联系卖家", "removeFromWatchlist": "从关注列表移除", "addToWatchlist": "加入关注列表" },
+    "actions": {
+      "markSold": "标记为已售",
+      "delete": "删除",
+      "editListing": "编辑刊登",
+      "manageListings": "管理刊登",
+      "messageSeller": "联系卖家",
+      "removeFromWatchlist": "从关注列表移除",
+      "addToWatchlist": "加入关注列表"
+    },
     "dates": { "listed": "发布于 {date}", "updated": "· 更新于 {date}" },
-    "confirm": { "markSold": { "title": "标记为已售", "message": "将此刊登标记为已售？恭喜成交！", "confirm": "标记为已售" }, "delete": { "title": "删除刊登", "message": "确定要删除此刊登吗？此操作无法撤销。", "confirm": "删除" } },
+    "confirm": {
+      "markSold": { "title": "标记为已售", "message": "将此刊登标记为已售？恭喜成交！", "confirm": "标记为已售" },
+      "delete": { "title": "删除刊登", "message": "确定要删除此刊登吗？此操作无法撤销。", "confirm": "删除" }
+    },
     "notFound": { "title": "未找到刊登", "message": "您查找的刊登不存在或已被移除。", "browseAll": "浏览所有刊登" },
-    "toast": { "approved": { "title": "刊登已批准", "description": "此刊登现已生效，对所有用户可见。" }, "approveError": "批准刊登失败。请重试。", "markedSold": { "title": "刊登已标记为已售", "description": "恭喜成交！" }, "markSoldError": "无法将刊登标记为已售。请重试。", "deleted": { "title": "刊登已删除", "description": "您的刊登已被永久删除。" }, "deleteError": "删除刊登失败。请重试。", "error": { "title": "错误" } }
+    "toast": {
+      "approved": { "title": "刊登已批准", "description": "此刊登现已生效，对所有用户可见。" },
+      "approveError": "批准刊登失败。请重试。",
+      "markedSold": { "title": "刊登已标记为已售", "description": "恭喜成交！" },
+      "markSoldError": "无法将刊登标记为已售。请重试。",
+      "deleted": { "title": "刊登已删除", "description": "您的刊登已被永久删除。" },
+      "deleteError": "删除刊登失败。请重试。",
+      "error": { "title": "错误" }
+    }
   },
   "ko": {
-    "adminPreview": { "intro": "관리자 미리보기 — 이 매물의 상태는", "outro": "이며 공개되지 않습니다.", "approve": "승인" },
+    "adminPreview": {
+      "intro": "관리자 미리보기 — 이 매물의 상태는",
+      "outro": "이며 공개되지 않습니다.",
+      "approve": "승인"
+    },
     "exampleDisclaimer": "이것은 시연용 예시 매물이며 판매 대상이 아닙니다.",
     "backToListings": "매물 목록으로 돌아가기",
     "anonymous": "익명",
     "sections": { "description": "설명", "specifications": "사양", "location": "위치" },
-    "specs": { "mileage": "주행거리", "milesValue": "{miles} 마일", "engineSize": "엔진 배기량", "transmission": "변속기", "color": "색상", "enginePlateDetails": "엔진 플레이트 정보", "partNumber": "부품 번호", "type": "유형", "oem": "OEM", "oemAftermarketMix": "OEM 및 애프터마켓 혼합", "aftermarket": "애프터마켓", "quantityAvailable": "재고 수량", "fitsModels": "호환 모델" },
-    "shipping": { "title": "배송", "pickupOnly": "직접 수령만", "freeShipping": "무료 배송", "domestic": "국내:", "international": "국제:", "free": "무료", "shipsTo": "배송 지역:", "delivery": "배송:", "businessDaysRange": "영업일 {min}~{max}일", "businessDaysMin": "영업일 {min}일 이상", "businessDaysMax": "최대 영업일 {max}일", "weightKg": "{weight} kg", "estimateCost": "배송비 견적", "tracking": "배송 조회", "trackPackage": "패키지 추적", "via": "{carrier} 경유" },
+    "specs": {
+      "mileage": "주행거리",
+      "milesValue": "{miles} 마일",
+      "engineSize": "엔진 배기량",
+      "transmission": "변속기",
+      "color": "색상",
+      "enginePlateDetails": "엔진 플레이트 정보",
+      "partNumber": "부품 번호",
+      "type": "유형",
+      "oem": "OEM",
+      "oemAftermarketMix": "OEM 및 애프터마켓 혼합",
+      "aftermarket": "애프터마켓",
+      "quantityAvailable": "재고 수량",
+      "fitsModels": "호환 모델"
+    },
+    "shipping": {
+      "title": "배송",
+      "pickupOnly": "직접 수령만",
+      "freeShipping": "무료 배송",
+      "domestic": "국내:",
+      "international": "국제:",
+      "free": "무료",
+      "shipsTo": "배송 지역:",
+      "delivery": "배송:",
+      "businessDaysRange": "영업일 {min}~{max}일",
+      "businessDaysMin": "영업일 {min}일 이상",
+      "businessDaysMax": "최대 영업일 {max}일",
+      "weightKg": "{weight} kg",
+      "estimateCost": "배송비 견적",
+      "tracking": "배송 조회",
+      "trackPackage": "패키지 추적",
+      "via": "{carrier} 경유"
+    },
     "history": { "title": "변경 내역", "showLess": "간략히 보기", "showMore": "{count}개 더 보기" },
     "sold": { "badge": "판매됨", "soldFor": "판매가" },
     "aboutInCurrency": "약 {amount} ({currency})",
@@ -1456,11 +2139,42 @@
     "details": { "views": "조회수 {count}회", "listingLocationFallback": "매물 위치" },
     "heritage": { "certified": "헤리티지 인증" },
     "seller": { "label": "판매자", "altFallback": "판매자" },
-    "actions": { "markSold": "판매됨으로 표시", "delete": "삭제", "editListing": "매물 편집", "manageListings": "매물 관리", "messageSeller": "판매자에게 메시지", "removeFromWatchlist": "관심 목록에서 제거", "addToWatchlist": "관심 목록에 추가" },
+    "actions": {
+      "markSold": "판매됨으로 표시",
+      "delete": "삭제",
+      "editListing": "매물 편집",
+      "manageListings": "매물 관리",
+      "messageSeller": "판매자에게 메시지",
+      "removeFromWatchlist": "관심 목록에서 제거",
+      "addToWatchlist": "관심 목록에 추가"
+    },
     "dates": { "listed": "{date} 등록", "updated": "· {date} 업데이트" },
-    "confirm": { "markSold": { "title": "판매됨으로 표시", "message": "이 매물을 판매됨으로 표시할까요? 판매를 축하합니다!", "confirm": "판매됨으로 표시" }, "delete": { "title": "매물 삭제", "message": "이 매물을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.", "confirm": "삭제" } },
-    "notFound": { "title": "매물을 찾을 수 없습니다", "message": "찾으시는 매물이 존재하지 않거나 삭제되었습니다.", "browseAll": "모든 매물 둘러보기" },
-    "toast": { "approved": { "title": "매물 승인됨", "description": "이 매물은 이제 활성화되어 모든 사용자에게 표시됩니다." }, "approveError": "매물 승인에 실패했습니다. 다시 시도해 주세요.", "markedSold": { "title": "매물이 판매됨으로 표시됨", "description": "판매를 축하합니다!" }, "markSoldError": "매물을 판매됨으로 표시하지 못했습니다. 다시 시도해 주세요.", "deleted": { "title": "매물 삭제됨", "description": "매물이 영구적으로 삭제되었습니다." }, "deleteError": "매물 삭제에 실패했습니다. 다시 시도해 주세요.", "error": { "title": "오류" } }
+    "confirm": {
+      "markSold": {
+        "title": "판매됨으로 표시",
+        "message": "이 매물을 판매됨으로 표시할까요? 판매를 축하합니다!",
+        "confirm": "판매됨으로 표시"
+      },
+      "delete": {
+        "title": "매물 삭제",
+        "message": "이 매물을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+        "confirm": "삭제"
+      }
+    },
+    "notFound": {
+      "title": "매물을 찾을 수 없습니다",
+      "message": "찾으시는 매물이 존재하지 않거나 삭제되었습니다.",
+      "browseAll": "모든 매물 둘러보기"
+    },
+    "toast": {
+      "approved": { "title": "매물 승인됨", "description": "이 매물은 이제 활성화되어 모든 사용자에게 표시됩니다." },
+      "approveError": "매물 승인에 실패했습니다. 다시 시도해 주세요.",
+      "markedSold": { "title": "매물이 판매됨으로 표시됨", "description": "판매를 축하합니다!" },
+      "markSoldError": "매물을 판매됨으로 표시하지 못했습니다. 다시 시도해 주세요.",
+      "deleted": { "title": "매물 삭제됨", "description": "매물이 영구적으로 삭제되었습니다." },
+      "deleteError": "매물 삭제에 실패했습니다. 다시 시도해 주세요.",
+      "error": { "title": "오류" }
+    }
   }
 }
 </i18n>

--- a/app/pages/exchange/sold/index.vue
+++ b/app/pages/exchange/sold/index.vue
@@ -81,7 +81,7 @@
                 <p class="text-sm text-base-content/70 line-clamp-1">{{ listing.title }}</p>
 
                 <div class="mt-2">
-                  <div class="text-lg font-bold text-success">
+                  <div v-if="hasDisclosedPrice(listing)" class="text-lg font-bold text-success">
                     {{
                       formatListingPrice(
                         getSoldPrice(listing),
@@ -89,13 +89,33 @@
                       )
                     }}
                   </div>
+                  <template v-else>
+                    <div class="text-base font-semibold text-base-content/70">
+                      {{
+                        t('price.asked', {
+                          amount: formatListingPrice(
+                            getSoldPrice(listing),
+                            formatCurrency(getSoldPrice(listing), getListingCurrency(listing))
+                          ),
+                        })
+                      }}
+                    </div>
+                    <div class="text-xs text-base-content/50">{{ t('price.notDisclosed') }}</div>
+                  </template>
                   <div
-                    v-if="getConvertedPrice(listing) && getSoldPrice(listing) !== 0"
+                    v-if="hasDisclosedPrice(listing) && getConvertedPrice(listing) && getSoldPrice(listing) !== 0"
                     class="text-xs text-base-content/60"
                   >
-                    {{ t('price.about', { amount: formatCurrency(getConvertedPrice(listing)!, userCurrency), currency: userCurrency }) }}
+                    {{
+                      t('price.about', {
+                        amount: formatCurrency(getConvertedPrice(listing)!, userCurrency),
+                        currency: userCurrency,
+                      })
+                    }}
                   </div>
-                  <div class="text-xs text-base-content/60">{{ t('price.soldOn', { date: formatSoldDate(listing.sold_date) }) }}</div>
+                  <div class="text-xs text-base-content/60">
+                    {{ t('price.soldOn', { date: formatSoldDate(listing.sold_date) }) }}
+                  </div>
                 </div>
 
                 <div v-if="displayLocation(listing)" class="mt-2">
@@ -134,12 +154,19 @@
     description: () => t('seo.description'),
     ogTitle: () => t('seo.title'),
     ogDescription: () => t('seo.description'),
-    robots: 'noindex, follow',
   });
 
-  useHead({
-    link: [{ rel: 'canonical', href: 'https://www.classicminidiy.com/exchange/sold' }],
-  });
+  // The `robots: 'noindex, follow'` that used to sit above was inherited verbatim when
+  // this page was ported from The Mini Exchange (Stage 3 of the consolidation) — it was
+  // never a CMDIY decision, and it was suppressing the one marketplace surface with
+  // durable organic value. Unlike live listings, which sell and go stale, a sold
+  // archive only accumulates: "what did a Cooper S actually go for" is a real,
+  // high-intent query and nobody else answers it for Classic Minis.
+  //
+  // Search and sort permutations are still near-duplicates of the archive itself, so
+  // only pagination stays indexable. Also replaces a hardcoded canonical that ignored
+  // the query string entirely.
+  useFacetedSeo('/exchange/sold');
 
   const supabase = useSupabase();
   const { getPhotoUrl } = useListings();
@@ -159,6 +186,22 @@
     const finalPrice = (listing as any).final_price;
     if (finalPrice !== null && finalPrice !== undefined) return finalPrice;
     return listing.price;
+  };
+
+  /**
+   * Whether the seller actually disclosed what it sold for.
+   *
+   * This matters more than it looks. `getSoldPrice()` falls back to the ASKING price
+   * when `final_price` is null, and until the mark-as-sold dialog started capturing a
+   * price nothing ever set that column — so the archive was rendering asking prices
+   * styled as sale prices. That was survivable while the page was noindex; now that it
+   * is indexed and the figure feeds Product/Offer schema, presenting an asking price as
+   * a transaction price would be actively misleading. Label the two differently.
+   */
+  const hasDisclosedPrice = (listing: ListingWithPhotos): boolean => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const finalPrice = (listing as any).final_price;
+    return finalPrice !== null && finalPrice !== undefined;
   };
 
   // Get converted price for a listing
@@ -308,9 +351,19 @@
     if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
   });
 
-  // Initial load
+  // Initial load runs during SSR so the archive ships real, crawlable sold entries
+  // instead of an empty shell. This page is now indexable (see the SEO block above),
+  // which only means anything if a crawler can actually see the listings. `listings`
+  // is a plain ref populated inside useAsyncData, so it serialises into the payload
+  // and the client hydrates against identical markup rather than refetching.
+  await useAsyncData('sold-index-initial', async () => {
+    await performSearch();
+    return true;
+  });
+
+  // Currency conversion is a client concern (it reads the visitor's locale/currency)
+  // and must not gate the SSR render.
   onMounted(() => {
-    performSearch();
     fetchExchangeRates();
   });
 </script>
@@ -318,114 +371,474 @@
 <i18n lang="json">
 {
   "en": {
-    "seo": { "title": "Sold Listings Archive - The Mini Exchange", "description": "Browse previously sold Classic Mini listings. Research past prices for vehicles, engines, and parts." },
-    "header": { "title": "Sold Listings Archive", "subtitle": "Browse {count} sold listings for market research" },
-    "search": { "placeholder": "Search sold listings..." },
-    "results": { "searching": "Searching...", "showing": "Showing {shown} of {total} sold listings", "none": "No sold listings found" },
-    "sort": { "ariaLabel": "Sort sold listings", "newest": "Recently Sold", "oldest": "Oldest First", "priceDesc": "Highest Price", "priceAsc": "Lowest Price" },
-    "badge": { "sold": "SOLD" },
-    "price": { "about": "About {amount} in {currency}", "soldOn": "Sold {date}" },
-    "empty": { "title": "No Sold Listings Found", "body": "Try adjusting your search to see more results.", "clear": "Clear Search" },
-    "date": { "unknown": "Unknown date", "today": "Today", "yesterday": "Yesterday", "daysAgo": "{count} days ago", "weeksAgo": "{count} weeks ago", "monthsAgo": "{count} months ago" }
+    "seo": {
+      "title": "Sold Listings Archive - The Mini Exchange",
+      "description": "Browse previously sold Classic Mini listings. Research past prices for vehicles, engines, and parts."
+    },
+    "header": {
+      "title": "Sold Listings Archive",
+      "subtitle": "Browse {count} sold listings for market research"
+    },
+    "search": {
+      "placeholder": "Search sold listings..."
+    },
+    "results": {
+      "searching": "Searching...",
+      "showing": "Showing {shown} of {total} sold listings",
+      "none": "No sold listings found"
+    },
+    "sort": {
+      "ariaLabel": "Sort sold listings",
+      "newest": "Recently Sold",
+      "oldest": "Oldest First",
+      "priceDesc": "Highest Price",
+      "priceAsc": "Lowest Price"
+    },
+    "badge": {
+      "sold": "SOLD"
+    },
+    "price": {
+      "about": "About {amount} in {currency}",
+      "soldOn": "Sold {date}",
+      "asked": "Asked {amount}",
+      "notDisclosed": "Sale price not disclosed"
+    },
+    "empty": {
+      "title": "No Sold Listings Found",
+      "body": "Try adjusting your search to see more results.",
+      "clear": "Clear Search"
+    },
+    "date": {
+      "unknown": "Unknown date",
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "daysAgo": "{count} days ago",
+      "weeksAgo": "{count} weeks ago",
+      "monthsAgo": "{count} months ago"
+    }
   },
   "es": {
-    "seo": { "title": "Archivo de anuncios vendidos - The Mini Exchange", "description": "Explora anuncios de Classic Mini vendidos anteriormente. Investiga precios pasados de vehículos, motores y piezas." },
-    "header": { "title": "Archivo de anuncios vendidos", "subtitle": "Explora {count} anuncios vendidos para estudios de mercado" },
-    "search": { "placeholder": "Buscar anuncios vendidos..." },
-    "results": { "searching": "Buscando...", "showing": "Mostrando {shown} de {total} anuncios vendidos", "none": "No se encontraron anuncios vendidos" },
-    "sort": { "ariaLabel": "Ordenar anuncios vendidos", "newest": "Vendidos recientemente", "oldest": "Más antiguos primero", "priceDesc": "Precio más alto", "priceAsc": "Precio más bajo" },
-    "badge": { "sold": "VENDIDO" },
-    "price": { "about": "Aproximadamente {amount} en {currency}", "soldOn": "Vendido {date}" },
-    "empty": { "title": "No se encontraron anuncios vendidos", "body": "Intenta ajustar tu búsqueda para ver más resultados.", "clear": "Borrar búsqueda" },
-    "date": { "unknown": "Fecha desconocida", "today": "Hoy", "yesterday": "Ayer", "daysAgo": "hace {count} días", "weeksAgo": "hace {count} semanas", "monthsAgo": "hace {count} meses" }
+    "seo": {
+      "title": "Archivo de anuncios vendidos - The Mini Exchange",
+      "description": "Explora anuncios de Classic Mini vendidos anteriormente. Investiga precios pasados de vehículos, motores y piezas."
+    },
+    "header": {
+      "title": "Archivo de anuncios vendidos",
+      "subtitle": "Explora {count} anuncios vendidos para estudios de mercado"
+    },
+    "search": {
+      "placeholder": "Buscar anuncios vendidos..."
+    },
+    "results": {
+      "searching": "Buscando...",
+      "showing": "Mostrando {shown} de {total} anuncios vendidos",
+      "none": "No se encontraron anuncios vendidos"
+    },
+    "sort": {
+      "ariaLabel": "Ordenar anuncios vendidos",
+      "newest": "Vendidos recientemente",
+      "oldest": "Más antiguos primero",
+      "priceDesc": "Precio más alto",
+      "priceAsc": "Precio más bajo"
+    },
+    "badge": {
+      "sold": "VENDIDO"
+    },
+    "price": {
+      "about": "Aproximadamente {amount} en {currency}",
+      "soldOn": "Vendido {date}",
+      "asked": "Pedía {amount}",
+      "notDisclosed": "Precio de venta no revelado"
+    },
+    "empty": {
+      "title": "No se encontraron anuncios vendidos",
+      "body": "Intenta ajustar tu búsqueda para ver más resultados.",
+      "clear": "Borrar búsqueda"
+    },
+    "date": {
+      "unknown": "Fecha desconocida",
+      "today": "Hoy",
+      "yesterday": "Ayer",
+      "daysAgo": "hace {count} días",
+      "weeksAgo": "hace {count} semanas",
+      "monthsAgo": "hace {count} meses"
+    }
   },
   "fr": {
-    "seo": { "title": "Archive des annonces vendues - The Mini Exchange", "description": "Parcourez les annonces de Classic Mini déjà vendues. Recherchez les prix passés des véhicules, moteurs et pièces." },
-    "header": { "title": "Archive des annonces vendues", "subtitle": "Parcourez {count} annonces vendues pour vos études de marché" },
-    "search": { "placeholder": "Rechercher des annonces vendues..." },
-    "results": { "searching": "Recherche...", "showing": "Affichage de {shown} sur {total} annonces vendues", "none": "Aucune annonce vendue trouvée" },
-    "sort": { "ariaLabel": "Trier les annonces vendues", "newest": "Vendues récemment", "oldest": "Les plus anciennes d'abord", "priceDesc": "Prix le plus élevé", "priceAsc": "Prix le plus bas" },
-    "badge": { "sold": "VENDU" },
-    "price": { "about": "Environ {amount} en {currency}", "soldOn": "Vendu {date}" },
-    "empty": { "title": "Aucune annonce vendue trouvée", "body": "Essayez d'ajuster votre recherche pour voir plus de résultats.", "clear": "Effacer la recherche" },
-    "date": { "unknown": "Date inconnue", "today": "Aujourd'hui", "yesterday": "Hier", "daysAgo": "il y a {count} jours", "weeksAgo": "il y a {count} semaines", "monthsAgo": "il y a {count} mois" }
+    "seo": {
+      "title": "Archive des annonces vendues - The Mini Exchange",
+      "description": "Parcourez les annonces de Classic Mini déjà vendues. Recherchez les prix passés des véhicules, moteurs et pièces."
+    },
+    "header": {
+      "title": "Archive des annonces vendues",
+      "subtitle": "Parcourez {count} annonces vendues pour vos études de marché"
+    },
+    "search": {
+      "placeholder": "Rechercher des annonces vendues..."
+    },
+    "results": {
+      "searching": "Recherche...",
+      "showing": "Affichage de {shown} sur {total} annonces vendues",
+      "none": "Aucune annonce vendue trouvée"
+    },
+    "sort": {
+      "ariaLabel": "Trier les annonces vendues",
+      "newest": "Vendues récemment",
+      "oldest": "Les plus anciennes d'abord",
+      "priceDesc": "Prix le plus élevé",
+      "priceAsc": "Prix le plus bas"
+    },
+    "badge": {
+      "sold": "VENDU"
+    },
+    "price": {
+      "about": "Environ {amount} en {currency}",
+      "soldOn": "Vendu {date}",
+      "asked": "Demandait {amount}",
+      "notDisclosed": "Prix de vente non communiqué"
+    },
+    "empty": {
+      "title": "Aucune annonce vendue trouvée",
+      "body": "Essayez d'ajuster votre recherche pour voir plus de résultats.",
+      "clear": "Effacer la recherche"
+    },
+    "date": {
+      "unknown": "Date inconnue",
+      "today": "Aujourd'hui",
+      "yesterday": "Hier",
+      "daysAgo": "il y a {count} jours",
+      "weeksAgo": "il y a {count} semaines",
+      "monthsAgo": "il y a {count} mois"
+    }
   },
   "de": {
-    "seo": { "title": "Archiv verkaufter Anzeigen - The Mini Exchange", "description": "Durchsuche zuvor verkaufte Classic-Mini-Anzeigen. Recherchiere frühere Preise für Fahrzeuge, Motoren und Teile." },
-    "header": { "title": "Archiv verkaufter Anzeigen", "subtitle": "Durchsuche {count} verkaufte Anzeigen für die Marktforschung" },
-    "search": { "placeholder": "Verkaufte Anzeigen suchen..." },
-    "results": { "searching": "Suche läuft...", "showing": "Zeige {shown} von {total} verkauften Anzeigen", "none": "Keine verkauften Anzeigen gefunden" },
-    "sort": { "ariaLabel": "Verkaufte Anzeigen sortieren", "newest": "Kürzlich verkauft", "oldest": "Älteste zuerst", "priceDesc": "Höchster Preis", "priceAsc": "Niedrigster Preis" },
-    "badge": { "sold": "VERKAUFT" },
-    "price": { "about": "Etwa {amount} in {currency}", "soldOn": "Verkauft {date}" },
-    "empty": { "title": "Keine verkauften Anzeigen gefunden", "body": "Passe deine Suche an, um mehr Ergebnisse zu sehen.", "clear": "Suche zurücksetzen" },
-    "date": { "unknown": "Unbekanntes Datum", "today": "Heute", "yesterday": "Gestern", "daysAgo": "vor {count} Tagen", "weeksAgo": "vor {count} Wochen", "monthsAgo": "vor {count} Monaten" }
+    "seo": {
+      "title": "Archiv verkaufter Anzeigen - The Mini Exchange",
+      "description": "Durchsuche zuvor verkaufte Classic-Mini-Anzeigen. Recherchiere frühere Preise für Fahrzeuge, Motoren und Teile."
+    },
+    "header": {
+      "title": "Archiv verkaufter Anzeigen",
+      "subtitle": "Durchsuche {count} verkaufte Anzeigen für die Marktforschung"
+    },
+    "search": {
+      "placeholder": "Verkaufte Anzeigen suchen..."
+    },
+    "results": {
+      "searching": "Suche läuft...",
+      "showing": "Zeige {shown} von {total} verkauften Anzeigen",
+      "none": "Keine verkauften Anzeigen gefunden"
+    },
+    "sort": {
+      "ariaLabel": "Verkaufte Anzeigen sortieren",
+      "newest": "Kürzlich verkauft",
+      "oldest": "Älteste zuerst",
+      "priceDesc": "Höchster Preis",
+      "priceAsc": "Niedrigster Preis"
+    },
+    "badge": {
+      "sold": "VERKAUFT"
+    },
+    "price": {
+      "about": "Etwa {amount} in {currency}",
+      "soldOn": "Verkauft {date}",
+      "asked": "Gefordert {amount}",
+      "notDisclosed": "Verkaufspreis nicht angegeben"
+    },
+    "empty": {
+      "title": "Keine verkauften Anzeigen gefunden",
+      "body": "Passe deine Suche an, um mehr Ergebnisse zu sehen.",
+      "clear": "Suche zurücksetzen"
+    },
+    "date": {
+      "unknown": "Unbekanntes Datum",
+      "today": "Heute",
+      "yesterday": "Gestern",
+      "daysAgo": "vor {count} Tagen",
+      "weeksAgo": "vor {count} Wochen",
+      "monthsAgo": "vor {count} Monaten"
+    }
   },
   "it": {
-    "seo": { "title": "Archivio annunci venduti - The Mini Exchange", "description": "Sfoglia gli annunci di Classic Mini venduti in precedenza. Ricerca i prezzi passati di veicoli, motori e ricambi." },
-    "header": { "title": "Archivio annunci venduti", "subtitle": "Sfoglia {count} annunci venduti per ricerche di mercato" },
-    "search": { "placeholder": "Cerca annunci venduti..." },
-    "results": { "searching": "Ricerca in corso...", "showing": "Mostrando {shown} di {total} annunci venduti", "none": "Nessun annuncio venduto trovato" },
-    "sort": { "ariaLabel": "Ordina annunci venduti", "newest": "Venduti di recente", "oldest": "Prima i più vecchi", "priceDesc": "Prezzo più alto", "priceAsc": "Prezzo più basso" },
-    "badge": { "sold": "VENDUTO" },
-    "price": { "about": "Circa {amount} in {currency}", "soldOn": "Venduto {date}" },
-    "empty": { "title": "Nessun annuncio venduto trovato", "body": "Prova a modificare la ricerca per vedere più risultati.", "clear": "Cancella ricerca" },
-    "date": { "unknown": "Data sconosciuta", "today": "Oggi", "yesterday": "Ieri", "daysAgo": "{count} giorni fa", "weeksAgo": "{count} settimane fa", "monthsAgo": "{count} mesi fa" }
+    "seo": {
+      "title": "Archivio annunci venduti - The Mini Exchange",
+      "description": "Sfoglia gli annunci di Classic Mini venduti in precedenza. Ricerca i prezzi passati di veicoli, motori e ricambi."
+    },
+    "header": {
+      "title": "Archivio annunci venduti",
+      "subtitle": "Sfoglia {count} annunci venduti per ricerche di mercato"
+    },
+    "search": {
+      "placeholder": "Cerca annunci venduti..."
+    },
+    "results": {
+      "searching": "Ricerca in corso...",
+      "showing": "Mostrando {shown} di {total} annunci venduti",
+      "none": "Nessun annuncio venduto trovato"
+    },
+    "sort": {
+      "ariaLabel": "Ordina annunci venduti",
+      "newest": "Venduti di recente",
+      "oldest": "Prima i più vecchi",
+      "priceDesc": "Prezzo più alto",
+      "priceAsc": "Prezzo più basso"
+    },
+    "badge": {
+      "sold": "VENDUTO"
+    },
+    "price": {
+      "about": "Circa {amount} in {currency}",
+      "soldOn": "Venduto {date}",
+      "asked": "Chiedeva {amount}",
+      "notDisclosed": "Prezzo di vendita non dichiarato"
+    },
+    "empty": {
+      "title": "Nessun annuncio venduto trovato",
+      "body": "Prova a modificare la ricerca per vedere più risultati.",
+      "clear": "Cancella ricerca"
+    },
+    "date": {
+      "unknown": "Data sconosciuta",
+      "today": "Oggi",
+      "yesterday": "Ieri",
+      "daysAgo": "{count} giorni fa",
+      "weeksAgo": "{count} settimane fa",
+      "monthsAgo": "{count} mesi fa"
+    }
   },
   "pt": {
-    "seo": { "title": "Arquivo de anúncios vendidos - The Mini Exchange", "description": "Navegue por anúncios de Classic Mini vendidos anteriormente. Pesquise preços passados de veículos, motores e peças." },
-    "header": { "title": "Arquivo de anúncios vendidos", "subtitle": "Navegue por {count} anúncios vendidos para pesquisa de mercado" },
-    "search": { "placeholder": "Pesquisar anúncios vendidos..." },
-    "results": { "searching": "Pesquisando...", "showing": "Mostrando {shown} de {total} anúncios vendidos", "none": "Nenhum anúncio vendido encontrado" },
-    "sort": { "ariaLabel": "Ordenar anúncios vendidos", "newest": "Vendidos recentemente", "oldest": "Mais antigos primeiro", "priceDesc": "Maior preço", "priceAsc": "Menor preço" },
-    "badge": { "sold": "VENDIDO" },
-    "price": { "about": "Cerca de {amount} em {currency}", "soldOn": "Vendido {date}" },
-    "empty": { "title": "Nenhum anúncio vendido encontrado", "body": "Tente ajustar sua pesquisa para ver mais resultados.", "clear": "Limpar pesquisa" },
-    "date": { "unknown": "Data desconhecida", "today": "Hoje", "yesterday": "Ontem", "daysAgo": "há {count} dias", "weeksAgo": "há {count} semanas", "monthsAgo": "há {count} meses" }
+    "seo": {
+      "title": "Arquivo de anúncios vendidos - The Mini Exchange",
+      "description": "Navegue por anúncios de Classic Mini vendidos anteriormente. Pesquise preços passados de veículos, motores e peças."
+    },
+    "header": {
+      "title": "Arquivo de anúncios vendidos",
+      "subtitle": "Navegue por {count} anúncios vendidos para pesquisa de mercado"
+    },
+    "search": {
+      "placeholder": "Pesquisar anúncios vendidos..."
+    },
+    "results": {
+      "searching": "Pesquisando...",
+      "showing": "Mostrando {shown} de {total} anúncios vendidos",
+      "none": "Nenhum anúncio vendido encontrado"
+    },
+    "sort": {
+      "ariaLabel": "Ordenar anúncios vendidos",
+      "newest": "Vendidos recentemente",
+      "oldest": "Mais antigos primeiro",
+      "priceDesc": "Maior preço",
+      "priceAsc": "Menor preço"
+    },
+    "badge": {
+      "sold": "VENDIDO"
+    },
+    "price": {
+      "about": "Cerca de {amount} em {currency}",
+      "soldOn": "Vendido {date}",
+      "asked": "Pedia {amount}",
+      "notDisclosed": "Preço de venda não divulgado"
+    },
+    "empty": {
+      "title": "Nenhum anúncio vendido encontrado",
+      "body": "Tente ajustar sua pesquisa para ver mais resultados.",
+      "clear": "Limpar pesquisa"
+    },
+    "date": {
+      "unknown": "Data desconhecida",
+      "today": "Hoje",
+      "yesterday": "Ontem",
+      "daysAgo": "há {count} dias",
+      "weeksAgo": "há {count} semanas",
+      "monthsAgo": "há {count} meses"
+    }
   },
   "ru": {
-    "seo": { "title": "Архив проданных объявлений - The Mini Exchange", "description": "Просматривайте ранее проданные объявления Classic Mini. Изучайте прошлые цены на автомобили, двигатели и запчасти." },
-    "header": { "title": "Архив проданных объявлений", "subtitle": "Просмотрите {count} проданных объявлений для анализа рынка" },
-    "search": { "placeholder": "Поиск проданных объявлений..." },
-    "results": { "searching": "Поиск...", "showing": "Показано {shown} из {total} проданных объявлений", "none": "Проданные объявления не найдены" },
-    "sort": { "ariaLabel": "Сортировать проданные объявления", "newest": "Недавно проданные", "oldest": "Сначала старые", "priceDesc": "Сначала дорогие", "priceAsc": "Сначала дешёвые" },
-    "badge": { "sold": "ПРОДАНО" },
-    "price": { "about": "Около {amount} в {currency}", "soldOn": "Продано {date}" },
-    "empty": { "title": "Проданные объявления не найдены", "body": "Попробуйте изменить запрос, чтобы увидеть больше результатов.", "clear": "Очистить поиск" },
-    "date": { "unknown": "Дата неизвестна", "today": "Сегодня", "yesterday": "Вчера", "daysAgo": "{count} дн. назад", "weeksAgo": "{count} нед. назад", "monthsAgo": "{count} мес. назад" }
+    "seo": {
+      "title": "Архив проданных объявлений - The Mini Exchange",
+      "description": "Просматривайте ранее проданные объявления Classic Mini. Изучайте прошлые цены на автомобили, двигатели и запчасти."
+    },
+    "header": {
+      "title": "Архив проданных объявлений",
+      "subtitle": "Просмотрите {count} проданных объявлений для анализа рынка"
+    },
+    "search": {
+      "placeholder": "Поиск проданных объявлений..."
+    },
+    "results": {
+      "searching": "Поиск...",
+      "showing": "Показано {shown} из {total} проданных объявлений",
+      "none": "Проданные объявления не найдены"
+    },
+    "sort": {
+      "ariaLabel": "Сортировать проданные объявления",
+      "newest": "Недавно проданные",
+      "oldest": "Сначала старые",
+      "priceDesc": "Сначала дорогие",
+      "priceAsc": "Сначала дешёвые"
+    },
+    "badge": {
+      "sold": "ПРОДАНО"
+    },
+    "price": {
+      "about": "Около {amount} в {currency}",
+      "soldOn": "Продано {date}",
+      "asked": "Просили {amount}",
+      "notDisclosed": "Цена продажи не раскрыта"
+    },
+    "empty": {
+      "title": "Проданные объявления не найдены",
+      "body": "Попробуйте изменить запрос, чтобы увидеть больше результатов.",
+      "clear": "Очистить поиск"
+    },
+    "date": {
+      "unknown": "Дата неизвестна",
+      "today": "Сегодня",
+      "yesterday": "Вчера",
+      "daysAgo": "{count} дн. назад",
+      "weeksAgo": "{count} нед. назад",
+      "monthsAgo": "{count} мес. назад"
+    }
   },
   "ja": {
-    "seo": { "title": "売却済み出品アーカイブ - The Mini Exchange", "description": "過去に売却されたクラシックミニの出品を閲覧。車両、エンジン、パーツの過去価格を調べられます。" },
-    "header": { "title": "売却済み出品アーカイブ", "subtitle": "市場調査向けに {count} 件の売却済み出品を閲覧" },
-    "search": { "placeholder": "売却済み出品を検索..." },
-    "results": { "searching": "検索中...", "showing": "{total} 件中 {shown} 件の売却済み出品を表示", "none": "売却済み出品が見つかりません" },
-    "sort": { "ariaLabel": "売却済み出品を並べ替え", "newest": "最近売却", "oldest": "古い順", "priceDesc": "価格が高い順", "priceAsc": "価格が安い順" },
-    "badge": { "sold": "売却済み" },
-    "price": { "about": "約 {amount}（{currency}）", "soldOn": "{date} に売却" },
-    "empty": { "title": "売却済み出品が見つかりません", "body": "検索条件を変更すると、より多くの結果が表示されます。", "clear": "検索をクリア" },
-    "date": { "unknown": "日付不明", "today": "今日", "yesterday": "昨日", "daysAgo": "{count} 日前", "weeksAgo": "{count} 週間前", "monthsAgo": "{count} か月前" }
+    "seo": {
+      "title": "売却済み出品アーカイブ - The Mini Exchange",
+      "description": "過去に売却されたクラシックミニの出品を閲覧。車両、エンジン、パーツの過去価格を調べられます。"
+    },
+    "header": {
+      "title": "売却済み出品アーカイブ",
+      "subtitle": "市場調査向けに {count} 件の売却済み出品を閲覧"
+    },
+    "search": {
+      "placeholder": "売却済み出品を検索..."
+    },
+    "results": {
+      "searching": "検索中...",
+      "showing": "{total} 件中 {shown} 件の売却済み出品を表示",
+      "none": "売却済み出品が見つかりません"
+    },
+    "sort": {
+      "ariaLabel": "売却済み出品を並べ替え",
+      "newest": "最近売却",
+      "oldest": "古い順",
+      "priceDesc": "価格が高い順",
+      "priceAsc": "価格が安い順"
+    },
+    "badge": {
+      "sold": "売却済み"
+    },
+    "price": {
+      "about": "約 {amount}（{currency}）",
+      "soldOn": "{date} に売却",
+      "asked": "希望価格 {amount}",
+      "notDisclosed": "売却価格は非公開"
+    },
+    "empty": {
+      "title": "売却済み出品が見つかりません",
+      "body": "検索条件を変更すると、より多くの結果が表示されます。",
+      "clear": "検索をクリア"
+    },
+    "date": {
+      "unknown": "日付不明",
+      "today": "今日",
+      "yesterday": "昨日",
+      "daysAgo": "{count} 日前",
+      "weeksAgo": "{count} 週間前",
+      "monthsAgo": "{count} か月前"
+    }
   },
   "zh": {
-    "seo": { "title": "已售刊登存档 - The Mini Exchange", "description": "浏览以往售出的经典 Mini 刊登。研究车辆、发动机和零件的历史价格。" },
-    "header": { "title": "已售刊登存档", "subtitle": "浏览 {count} 条已售刊登用于市场调研" },
-    "search": { "placeholder": "搜索已售刊登..." },
-    "results": { "searching": "搜索中...", "showing": "显示 {total} 条已售刊登中的 {shown} 条", "none": "未找到已售刊登" },
-    "sort": { "ariaLabel": "排序已售刊登", "newest": "最近售出", "oldest": "最早优先", "priceDesc": "价格从高到低", "priceAsc": "价格从低到高" },
-    "badge": { "sold": "已售" },
-    "price": { "about": "约 {amount}（{currency}）", "soldOn": "售于 {date}" },
-    "empty": { "title": "未找到已售刊登", "body": "尝试调整搜索条件以查看更多结果。", "clear": "清除搜索" },
-    "date": { "unknown": "日期未知", "today": "今天", "yesterday": "昨天", "daysAgo": "{count} 天前", "weeksAgo": "{count} 周前", "monthsAgo": "{count} 个月前" }
+    "seo": {
+      "title": "已售刊登存档 - The Mini Exchange",
+      "description": "浏览以往售出的经典 Mini 刊登。研究车辆、发动机和零件的历史价格。"
+    },
+    "header": {
+      "title": "已售刊登存档",
+      "subtitle": "浏览 {count} 条已售刊登用于市场调研"
+    },
+    "search": {
+      "placeholder": "搜索已售刊登..."
+    },
+    "results": {
+      "searching": "搜索中...",
+      "showing": "显示 {total} 条已售刊登中的 {shown} 条",
+      "none": "未找到已售刊登"
+    },
+    "sort": {
+      "ariaLabel": "排序已售刊登",
+      "newest": "最近售出",
+      "oldest": "最早优先",
+      "priceDesc": "价格从高到低",
+      "priceAsc": "价格从低到高"
+    },
+    "badge": {
+      "sold": "已售"
+    },
+    "price": {
+      "about": "约 {amount}（{currency}）",
+      "soldOn": "售于 {date}",
+      "asked": "要价 {amount}",
+      "notDisclosed": "成交价未公开"
+    },
+    "empty": {
+      "title": "未找到已售刊登",
+      "body": "尝试调整搜索条件以查看更多结果。",
+      "clear": "清除搜索"
+    },
+    "date": {
+      "unknown": "日期未知",
+      "today": "今天",
+      "yesterday": "昨天",
+      "daysAgo": "{count} 天前",
+      "weeksAgo": "{count} 周前",
+      "monthsAgo": "{count} 个月前"
+    }
   },
   "ko": {
-    "seo": { "title": "판매 완료 매물 아카이브 - The Mini Exchange", "description": "이전에 판매된 클래식 미니 매물을 둘러보세요. 차량, 엔진, 부품의 과거 가격을 조사할 수 있습니다." },
-    "header": { "title": "판매 완료 매물 아카이브", "subtitle": "시장 조사를 위해 {count}개의 판매 완료 매물 둘러보기" },
-    "search": { "placeholder": "판매 완료 매물 검색..." },
-    "results": { "searching": "검색 중...", "showing": "판매 완료 매물 {total}개 중 {shown}개 표시", "none": "판매 완료 매물을 찾을 수 없습니다" },
-    "sort": { "ariaLabel": "판매 완료 매물 정렬", "newest": "최근 판매순", "oldest": "오래된 순", "priceDesc": "높은 가격순", "priceAsc": "낮은 가격순" },
-    "badge": { "sold": "판매됨" },
-    "price": { "about": "약 {amount} ({currency})", "soldOn": "{date} 판매" },
-    "empty": { "title": "판매 완료 매물을 찾을 수 없습니다", "body": "검색 조건을 조정하면 더 많은 결과를 볼 수 있습니다.", "clear": "검색 지우기" },
-    "date": { "unknown": "날짜 불명", "today": "오늘", "yesterday": "어제", "daysAgo": "{count}일 전", "weeksAgo": "{count}주 전", "monthsAgo": "{count}개월 전" }
+    "seo": {
+      "title": "판매 완료 매물 아카이브 - The Mini Exchange",
+      "description": "이전에 판매된 클래식 미니 매물을 둘러보세요. 차량, 엔진, 부품의 과거 가격을 조사할 수 있습니다."
+    },
+    "header": {
+      "title": "판매 완료 매물 아카이브",
+      "subtitle": "시장 조사를 위해 {count}개의 판매 완료 매물 둘러보기"
+    },
+    "search": {
+      "placeholder": "판매 완료 매물 검색..."
+    },
+    "results": {
+      "searching": "검색 중...",
+      "showing": "판매 완료 매물 {total}개 중 {shown}개 표시",
+      "none": "판매 완료 매물을 찾을 수 없습니다"
+    },
+    "sort": {
+      "ariaLabel": "판매 완료 매물 정렬",
+      "newest": "최근 판매순",
+      "oldest": "오래된 순",
+      "priceDesc": "높은 가격순",
+      "priceAsc": "낮은 가격순"
+    },
+    "badge": {
+      "sold": "판매됨"
+    },
+    "price": {
+      "about": "약 {amount} ({currency})",
+      "soldOn": "{date} 판매",
+      "asked": "희망가 {amount}",
+      "notDisclosed": "판매 가격 비공개"
+    },
+    "empty": {
+      "title": "판매 완료 매물을 찾을 수 없습니다",
+      "body": "검색 조건을 조정하면 더 많은 결과를 볼 수 있습니다.",
+      "clear": "검색 지우기"
+    },
+    "date": {
+      "unknown": "날짜 불명",
+      "today": "오늘",
+      "yesterday": "어제",
+      "daysAgo": "{count}일 전",
+      "weeksAgo": "{count}주 전",
+      "monthsAgo": "{count}개월 전"
+    }
   }
 }
 </i18n>

--- a/server/api/__sitemap__/exchange.ts
+++ b/server/api/__sitemap__/exchange.ts
@@ -5,7 +5,7 @@
  * page routes are excluded from auto-discovery in nuxt.config, so this source is
  * the single place marketplace URLs enter the sitemap.)
  *
- * When live: every active listing, approved find, and approved wanted post.
+ * When live: every active AND sold listing, approved find, and approved wanted post.
  * The public section landing pages (/exchange, /exchange/listings, …) are static
  * routes handled by sitemap auto-discovery (gated build-time in nuxt.config's
  * `exclude`); this source only adds the dynamic detail URLs. Private surfaces
@@ -19,8 +19,14 @@ export default defineSitemapEventHandler(async () => {
 
   const service = getServiceClient();
 
-  const [listingsRes, findsRes, wantedRes] = await Promise.all([
+  const [listingsRes, soldRes, findsRes, wantedRes] = await Promise.all([
     service.from('listings').select('slug, updated_at, created_at').eq('status', 'active').limit(5000),
+    // Sold listings. Previously omitted, which left them orphaned: the detail pages are
+    // publicly readable and carry no noindex, but the only route to them was
+    // /exchange/sold — which was itself noindex AND client-rendered, so no crawler ever
+    // reached one. They're the archive's durable content (a sold price doesn't go
+    // stale the way an active listing does), so they belong in the sitemap.
+    service.from('listings').select('slug, updated_at, sold_date, created_at').eq('status', 'sold').limit(5000),
     service.from('external_listings').select('slug, updated_at, published_at').eq('status', 'approved').limit(5000),
     service
       .from('wanted_posts')
@@ -31,6 +37,7 @@ export default defineSitemapEventHandler(async () => {
   ]);
 
   if (listingsRes.error) console.error('[sitemap] exchange listings query failed:', listingsRes.error.message);
+  if (soldRes.error) console.error('[sitemap] exchange sold listings query failed:', soldRes.error.message);
   if (findsRes.error) console.error('[sitemap] exchange finds query failed:', findsRes.error.message);
   if (wantedRes.error) console.error('[sitemap] exchange wanted query failed:', wantedRes.error.message);
 
@@ -41,6 +48,17 @@ export default defineSitemapEventHandler(async () => {
       lastmod: l.updated_at || l.created_at,
       changefreq: 'weekly' as const,
       priority: 0.8,
+    }));
+
+  // Lower priority + monthly changefreq than active listings: the content is settled,
+  // so there's nothing to gain from recrawling it often.
+  const soldUrls = (soldRes.data ?? [])
+    .filter((l) => l.slug)
+    .map((l) => ({
+      loc: `/exchange/listings/${l.slug}`,
+      lastmod: l.updated_at || l.sold_date || l.created_at,
+      changefreq: 'monthly' as const,
+      priority: 0.5,
     }));
 
   const findUrls = (findsRes.data ?? [])
@@ -61,5 +79,5 @@ export default defineSitemapEventHandler(async () => {
       priority: 0.6,
     }));
 
-  return [...listingUrls, ...findUrls, ...wantedUrls];
+  return [...listingUrls, ...soldUrls, ...findUrls, ...wantedUrls];
 });


### PR DESCRIPTION
> **Stacked on #689** — targets that branch, not `main`, because it uses `useFacetedSeo()` from it. Retarget to `main` once #689 merges.

## The finding

`/exchange/sold` was `noindex, follow`. That flag was **inherited verbatim when the page was ported from TME** in 8ea75a6d — never a CMDIY decision. It was suppressing the one marketplace surface with durable organic value: live listings sell and go stale, a sold archive only accumulates. "What did a Cooper S actually go for" is a real, high-intent query nobody answers for Classic Minis.

But flipping the flag alone would have shipped an empty, misleading page. Three things had to be fixed first.

## 1. Nothing ever recorded a sale price

`confirmMarkSold()` wrote `status` and `sold_date` only. **No code path in the app ever wrote `final_price`** — `useListings.ts` sets it to `null` at creation and nothing updates it. 4 of 20 sold rows have a price, all set outside the app.

New `ExchangeListingsMarkSoldDialog` asks what it sold for, pre-filled with the asking price.

The field is **optional on purpose**. Forcing a number on a seller who won't disclose produces junk (`1`, `99999`) that quietly poisons the archive; fewer honest figures beat a complete column of guesses. Declining leaves the column null rather than writing a bogus `0`. The public-visibility warning is unmissable — a private individual is publishing what they got for their car, and must not discover that afterwards.

No migration needed: `final_price` exists, the update policy is owner-or-admin, and `sold` rows are already publicly readable.

## 2. The page was an empty shell to crawlers

It fetched in `onMounted`, so indexing it would have achieved nothing. Now SSR'd — 20 sold entries with real links in the raw HTML — and canonicalised through `useFacetedSeo` so search/sort permutations don't self-canonicalise.

Sold listings also join the sitemap. Their detail pages were publicly readable with no noindex, but the only route to them was this page, so they were **orphaned**: indexable and undiscoverable.

## 3. It was showing asking prices as sale prices

`getSoldPrice()` falls back to `listing.price` when `final_price` is null. Harmless while noindex; misleading once indexed and feeding `Offer` schema — 16 of 20 cards were affected.

- **Card:** discloses "Asked £X · Sale price not disclosed" instead of styling it as a sale price
- **Schema:** a sold listing with no disclosed price emits **no `price` at all** rather than a number we'd be inventing. Verified — `has price key: False`

## Verification

| Check | Result |
|---|---|
| `bun run test` | 4674 passing |
| `bun run build` | green |
| `/exchange/sold` SSR | 20 listing links in raw HTML |
| Price labelling | 16 "Asked / not disclosed", matching the DB exactly |
| Production robots | `index, follow, max-image-preview:large, …` (was `noindex, follow`) |
| `?sort=price_desc` | `noindex, follow`, canonical → `/exchange/sold` |
| Disclosed sale (£175, asked £200) | `offers.price: 175` — the sale, not the ask |
| Undisclosed sale | `offers` has no `price` key |
| Sitemap source | 104 URLs, 20 sold at priority 0.5 / monthly |

## Note

The archive stays thin until sellers start using the new dialog — 4 real prices today. The value compounds from here; every future sale adds one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)