### PR TITLE
perf(images): route S3, Supabase and YouTube images through @nuxt/image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,25 @@ For inline icons in templates, use the traditional Font Awesome class syntax:
   `og_image_url` scraped from arbitrary third-party sites, so it stays a raw `<img>` with its
   `@error` fallback. Same for `blob:`/`data:` upload previews. Don't "fix" these.
 
+- **`/_ipx` MUST stay in `nitro.prerender.ignore` — this is a build-memory contract, not an
+  optimization.** `crawlLinks: true` follows same-origin URLs out of prerendered pages. An
+  unoptimized image is an *absolute* S3/Supabase URL (external → never crawled), but an
+  optimized one is a same-origin `/_ipx/...` path, so the crawler treats every variant as a
+  route and transcodes it through sharp **at build time**. When this was first missed it was
+  **603 of 768 prerendered routes (78%)**, and the resulting RSS inflation pushed the Nitro
+  bundling step past the 8 GB build container — SIGKILL, OOM.
+
+  Two things make this hard to diagnose, so recognise the shape: the kill lands during Nitro
+  *bundling*, well after prerender reports success, and because the build sits near the
+  ceiling it can first fail on a commit that touches nothing (it initially tripped on a
+  docs-only commit). A `SIGKILL` is the **container** OOM killer, not a V8 heap error — if you
+  see `JavaScript heap out of memory` instead, that's a genuinely different problem.
+
+  Prerendering ipx output is worthless anyway: variants regenerate at runtime and Vercel's CDN
+  holds them for 7 days (`s-maxage=604800`), and user-uploaded photos added after a build have
+  no baked variant regardless. The same reasoning applies to any future runtime-generated
+  image route.
+
 ### SEO / Head Invariants
 
 - **Never pass a possibly-empty string (or any non-string) to `ogImage` / `twitterImage` in `useSeoMeta`.** unhead's flat-meta unpacking coerces `''` to boolean `true`, and nuxt-og-image's `tags:afterResolve` hook calls `.replaceAll()` on every `og:image`/`twitter:image` content — a truthy non-string 500s the whole SSR render (this took down `/archive/colors/[id]` for months). Derive share images with `computed()` (a lazy `watch` never fires during SSR, so a ref stays at its initial value server-side) and always fall back to a real URL. `app/plugins/seo-tag-guard.server.ts` + `app/utils/seoTagGuards.ts` are the SSR safety net that sanitizes these tags before nuxt-og-image sees them — don't remove them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,44 @@ For inline icons in templates, use the traditional Font Awesome class syntax:
 - **CDN Integration**: S3 static assets with intelligent tiering
 - **Bundle Optimization**: Tree shaking and dependency optimization
 
+### Image Optimization Invariants
+
+- **`image.domains` in `nuxt.config.ts` is matched on the LITERAL hostname, and a miss is
+  silent.** @nuxt/image passes an unlisted URL straight through — no resize, no format
+  conversion — *even inside `<nuxt-img>`*, so the markup looks optimized while shipping the
+  full-size original. Three ways this has bitten us, all fixed 2026-07-31:
+  - The asset bucket is referenced by **both** `classicminidiy.s3.amazonaws.com` (~230 call
+    sites) and `classicminidiy.s3.us-east-1.amazonaws.com` (~40). Both must stay listed
+    until the call sites are normalized onto one host.
+  - **Supabase Storage is reached via the CUSTOM domain `auth.classicminidiy.com`**, because
+    `storage.getPublicUrl()` builds every URL from `NUXT_PUBLIC_SUPABASE_URL`. The
+    `psoqirvbujwohemmwplv.supabase.co` entry matches nothing in practice — it is kept only as
+    a fallback if that env var is ever pointed back at the raw host. Listing photos, model
+    images and avatars ALL depend on the custom domain being listed.
+  - `i.ytimg.com` (YouTube thumbnails) and `cmdiy-archive.s3.us-east-1.amazonaws.com`.
+
+  Adding a new remote image host means adding it here **and** to the PWA `runtimeCaching`
+  `urlPattern` (which had the same regional-only / project-ref-only bugs), **and** a
+  `preconnect`/`dns-prefetch` hint if it's a new origin. Verify by rendering a real page and
+  confirming the `src` starts with `/_ipx/` — do not trust the config.
+
+- **`<NuxtImg>` ignores the `image.format` list; only `<NuxtPicture>` uses it.** NuxtImg emits
+  a single `<img>` in the SOURCE format unless given an explicit `format` prop, so every
+  `<nuxt-img>` without `format="webp"` serves JPEG/PNG. Prefer explicit `format="webp"` over
+  inheriting the config list — AVIF measured barely better than JPEG on detailed photos at
+  q80 here and is far slower to encode on a cold serverless path.
+
+- **`<NuxtPicture>` puts fallthrough `class` / `data-testid` / `@error` on the `<picture>`
+  root, not the inner `<img>`.** `object-cover` on a `display:inline` `<picture>` silently
+  does nothing and the img falls back to `object-fit: fill`, which SQUASHES non-matching
+  aspect ratios instead of cropping; `error` does not bubble from `<img>` to `<picture>`, so
+  `@error` never fires. Pass those via `:img-attrs="{ class: '...', onError: ... }"`, or use
+  `<NuxtImg>` (a single `<img>`) when you just need the existing attributes to keep working.
+
+- **Some image hosts CANNOT be allowlisted.** `exchange/finds/FindCard.vue` renders
+  `og_image_url` scraped from arbitrary third-party sites, so it stays a raw `<img>` with its
+  `@error` fallback. Same for `blob:`/`data:` upload previews. Don't "fix" these.
+
 ### SEO / Head Invariants
 
 - **Never pass a possibly-empty string (or any non-string) to `ogImage` / `twitterImage` in `useSeoMeta`.** unhead's flat-meta unpacking coerces `''` to boolean `true`, and nuxt-og-image's `tags:afterResolve` hook calls `.replaceAll()` on every `og:image`/`twitter:image` content — a truthy non-string 500s the whole SSR render (this took down `/archive/colors/[id]` for months). Derive share images with `computed()` (a lazy `watch` never fires during SSR, so a ref stays at its initial value server-side) and always fall back to a real URL. `app/plugins/seo-tag-guard.server.ts` + `app/utils/seoTagGuards.ts` are the SSR safety net that sanitizes these tags before nuxt-og-image sees them — don't remove them.

--- a/app/components/Calculators/Needles.vue
+++ b/app/components/Calculators/Needles.vue
@@ -562,11 +562,13 @@
             <div class="modal" :class="{ 'modal-open': showDiagramModal }">
               <div class="modal-box max-w-3xl">
                 <h3 class="font-bold text-lg">{{ t('diagram_modal.title') }}</h3>
-                <img
+                <nuxt-img
                   loading="lazy"
                   class="diagram mx-auto"
                   src="https://classicminidiy.s3.us-east-1.amazonaws.com/misc/diagram.jpg"
                   :alt="t('diagram_modal.alt_text')"
+                  format="webp"
+                  sizes="100vw lg:768px"
                 />
                 <div class="modal-action">
                   <button class="btn btn-primary" @click="showDiagramModal = false">
@@ -721,15 +723,11 @@
           </template>
         </div>
       </div>
-
     </div>
 
     <!-- Relative Search (top-right column on desktop) -->
     <div class="col-span-12 md:col-span-6">
-      <div
-        v-if="selectedNeedles.length && !pending"
-        class="card bg-base-100 shadow-md border border-base-300 h-full"
-      >
+      <div v-if="selectedNeedles.length && !pending" class="card bg-base-100 shadow-md border border-base-300 h-full">
         <div class="card-body">
           <h3 class="fancy-font-bold text-lg">{{ t('relative.title') }}</h3>
           <p class="text-sm opacity-70">{{ t('relative.description') }}</p>
@@ -805,7 +803,11 @@
                   <span class="font-semibold text-sm">{{ result.candidate.name }}</span>
                   <span
                     class="badge badge-xs"
-                    :class="referenceNeedle && result.candidate.size === referenceNeedle.size ? 'badge-neutral' : 'badge-warning'"
+                    :class="
+                      referenceNeedle && result.candidate.size === referenceNeedle.size
+                        ? 'badge-neutral'
+                        : 'badge-warning'
+                    "
                     :title="
                       referenceNeedle && result.candidate.size === referenceNeedle.size
                         ? t('relative.size_match')

--- a/app/components/EnginePlateModal.vue
+++ b/app/components/EnginePlateModal.vue
@@ -59,11 +59,14 @@
         <!-- Carousel -->
         <div class="relative w-full mb-4">
           <div class="relative w-full h-64 md:h-96 overflow-hidden rounded-lg">
-            <img
+            <nuxt-img
               v-for="(slide, index) in slides"
               :key="index"
               :src="slide.src"
               :alt="slide.alt"
+              format="webp"
+              sizes="100vw lg:672px"
+              loading="lazy"
               class="w-full h-full object-cover absolute inset-0 transition-opacity duration-300"
               :class="currentSlide === index ? 'opacity-100' : 'opacity-0'"
             />

--- a/app/components/MainNav.vue
+++ b/app/components/MainNav.vue
@@ -157,6 +157,7 @@
             class="w-32 logo-image"
             width="128"
             height="37"
+            format="webp"
             loading="eager"
             fetchpriority="high"
           />

--- a/app/components/RecentVideos.vue
+++ b/app/components/RecentVideos.vue
@@ -21,13 +21,27 @@
       class="card bg-base-100 shadow-md border border-base-300 col-span-12 md:col-span-4"
     >
       <figure>
-        <nuxt-picture :src="video.thumbnails.maxres" :alt="video.title" class="w-full" loading="lazy" width="720" height="404" />
+        <nuxt-picture
+          :src="video.thumbnails.maxres"
+          :alt="video.title"
+          class="w-full"
+          loading="lazy"
+          width="720"
+          height="404"
+          format="webp"
+        />
       </figure>
       <div class="card-body">
         <h2 class="card-title font-semibold text-lg">{{ video.title }}</h2>
         <p class="text-sm text-base-content/70">{{ t('published_on') }} {{ video.publishedOn }}</p>
         <div class="card-actions justify-end">
-          <NuxtLink :to="video.videoUrl" target="_blank" class="btn btn-primary" @click="trackOutbound({ destination: video.videoUrl, label: video.title, group: 'youtube_video' })">{{ t('watch_button') }}</NuxtLink>
+          <NuxtLink
+            :to="video.videoUrl"
+            target="_blank"
+            class="btn btn-primary"
+            @click="trackOutbound({ destination: video.videoUrl, label: video.title, group: 'youtube_video' })"
+            >{{ t('watch_button') }}</NuxtLink
+          >
         </div>
       </div>
     </div>

--- a/app/components/WheelGrid.vue
+++ b/app/components/WheelGrid.vue
@@ -134,7 +134,10 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'list' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'list'; track('wheel_filter_changed', { size_selected: 'list' })"
+                @click="
+                  size = 'list';
+                  track('wheel_filter_changed', { size_selected: 'list' });
+                "
               >
                 {{ t('all_sizes') }}
               </button>
@@ -142,7 +145,10 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'ten' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'ten'; track('wheel_filter_changed', { size_selected: 'ten' })"
+                @click="
+                  size = 'ten';
+                  track('wheel_filter_changed', { size_selected: 'ten' });
+                "
               >
                 {{ t('ten_inch_wheels') }}
               </button>
@@ -150,7 +156,10 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'twelve' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'twelve'; track('wheel_filter_changed', { size_selected: 'twelve' })"
+                @click="
+                  size = 'twelve';
+                  track('wheel_filter_changed', { size_selected: 'twelve' });
+                "
               >
                 {{ t('twelve_inch_wheels') }}
               </button>
@@ -158,7 +167,10 @@
                 type="button"
                 class="btn join-item"
                 :class="size === 'thirteen' ? 'btn-primary' : 'btn-outline'"
-                @click="size = 'thirteen'; track('wheel_filter_changed', { size_selected: 'thirteen' })"
+                @click="
+                  size = 'thirteen';
+                  track('wheel_filter_changed', { size_selected: 'thirteen' });
+                "
               >
                 {{ t('thirteen_inch_wheels') }}
               </button>
@@ -200,10 +212,12 @@
             class="card bg-base-100 shadow-md border border-base-300 hover:shadow-lg transition-shadow duration-300"
           >
             <figure class="relative pt-[100%] bg-base-200 rounded-t-lg">
-              <img
+              <nuxt-img
                 :src="getWheelImageUrl(wheel)"
                 :alt="wheel.name"
                 class="absolute inset-0 w-full h-full object-contain p-4"
+                format="webp"
+                sizes="100vw sm:50vw lg:300px"
                 loading="lazy"
               />
             </figure>
@@ -241,12 +255,7 @@
       <div class="border-t border-base-300 pt-4 mt-4">
         <div class="flex items-center justify-center">
           <div class="join">
-            <button
-              type="button"
-              class="btn join-item"
-              :disabled="page === 1"
-              @click="page > 1 && page--"
-            >
+            <button type="button" class="btn join-item" :disabled="page === 1" @click="page > 1 && page--">
               <i class="fad fa-arrow-left"></i>
             </button>
             <button type="button" class="btn join-item btn-ghost pointer-events-none">

--- a/app/components/archive/CollectionCard.vue
+++ b/app/components/archive/CollectionCard.vue
@@ -17,10 +17,13 @@
 
       <div class="card bg-base-100 shadow-md border border-base-300 relative h-full">
         <figure v-if="collection.image" class="relative">
-          <img
+          <nuxt-img
             :src="collection.image"
             :alt="collection.title"
             class="h-[150px] w-full object-cover rounded-t-lg group-hover:opacity-90 transition-opacity"
+            format="webp"
+            sizes="100vw sm:50vw lg:400px"
+            loading="lazy"
           />
           <!-- Item count badge -->
           <div class="absolute top-2 right-2">

--- a/app/components/archive/DocumentCard.vue
+++ b/app/components/archive/DocumentCard.vue
@@ -20,7 +20,14 @@
   <div class="card bg-base-100 shadow-md border border-base-300 relative h-full flex flex-col">
     <figure v-if="item.image" class="relative">
       <NuxtLink v-if="item.download" :to="item.path">
-        <img :src="item.image" :alt="item.title" class="h-[150px] w-full object-cover rounded-t-lg" />
+        <nuxt-img
+          :src="item.image"
+          :alt="item.title"
+          class="h-[150px] w-full object-cover rounded-t-lg"
+          format="webp"
+          sizes="100vw sm:50vw lg:400px"
+          loading="lazy"
+        />
       </NuxtLink>
       <img v-else :src="item.image" :alt="item.title" class="h-[150px] w-full object-cover rounded-t-lg" />
       <div v-if="item.download" class="absolute top-2 right-2">
@@ -76,7 +83,14 @@
           :to="item.download"
           target="_blank"
           class="btn btn-sm btn-primary"
-          @click="trackDownload({ document_id: item.id, file_type: item.download.split('.').pop()?.toUpperCase(), location: 'card', name: item.title })"
+          @click="
+            trackDownload({
+              document_id: item.id,
+              file_type: item.download.split('.').pop()?.toUpperCase(),
+              location: 'card',
+              name: item.title,
+            })
+          "
         >
           <i class="fad fa-download mr-1"></i> {{ t('actions.download') }}
         </NuxtLink>

--- a/app/components/exchange/Avatar.vue
+++ b/app/components/exchange/Avatar.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="avatar" :class="{ placeholder: !avatarUrl }">
     <div class="rounded-full bg-neutral text-neutral-content flex items-center justify-center" :class="sizeClasses">
-      <img v-if="avatarUrl" :src="avatarUrl" :alt="displayName || t('userAvatar')" class="rounded-full" loading="lazy" />
+      <nuxt-img
+        v-if="avatarUrl"
+        :src="avatarUrl"
+        :alt="displayName || t('userAvatar')"
+        class="rounded-full"
+        format="webp"
+        :width="avatarPx"
+        :height="avatarPx"
+        loading="lazy"
+      />
       <span v-else :class="textSizeClass">{{ initials }}</span>
     </div>
   </div>
@@ -34,6 +43,13 @@
       xl: 'w-32 h-32',
     };
     return sizes[props.size];
+  });
+
+  // Pixel equivalents of `sizeClasses`, so nuxt-img asks ipx for the size actually
+  // rendered instead of the full-resolution upload. Keep in sync with the map above.
+  const avatarPx = computed(() => {
+    const px = { xs: 32, sm: 40, md: 64, lg: 96, xl: 128 };
+    return px[props.size];
   });
 
   // Size mappings for text

--- a/app/components/exchange/home/FeaturedGrid.vue
+++ b/app/components/exchange/home/FeaturedGrid.vue
@@ -20,12 +20,14 @@
         >
           <!-- Image: tall aspect ratio, BaT-style -->
           <figure class="relative aspect-[4/3] bg-base-300 overflow-hidden">
-            <img
+            <nuxt-img
               v-if="getPrimaryPhoto(listing)"
               :src="getPrimaryPhoto(listing)"
               :alt="listing.title"
               class="w-full h-full object-contain group-hover:scale-[1.02] transition-transform duration-300"
               style="object-fit: contain"
+              format="webp"
+              sizes="100vw sm:50vw lg:400px"
               loading="lazy"
             />
             <div v-else class="w-full h-full flex items-center justify-center">

--- a/app/components/exchange/home/PromotedListings.vue
+++ b/app/components/exchange/home/PromotedListings.vue
@@ -18,12 +18,14 @@
         >
           <!-- Image -->
           <figure class="relative aspect-[4/3] bg-base-300 overflow-hidden">
-            <img
+            <nuxt-img
               v-if="getPrimaryPhoto(listing)"
               :src="getPrimaryPhoto(listing)"
               :alt="listing.title"
               class="w-full h-full object-contain group-hover:scale-[1.02] transition-transform duration-300"
               style="object-fit: contain"
+              format="webp"
+              sizes="100vw sm:50vw lg:400px"
               loading="lazy"
             />
             <div v-else class="w-full h-full flex items-center justify-center">

--- a/app/components/exchange/listings/ListingCard.vue
+++ b/app/components/exchange/listings/ListingCard.vue
@@ -20,12 +20,14 @@
       <!-- Image -->
       <figure class="relative">
         <div class="aspect-video bg-linear-to-br from-base-200 to-base-300 w-full">
-          <img
+          <nuxt-img
             v-if="primaryPhoto"
             :src="primaryPhoto"
             :alt="listing.title"
             class="w-full h-full object-contain"
             style="object-fit: contain"
+            format="webp"
+            sizes="100vw sm:50vw lg:384px"
             loading="lazy"
           />
           <div v-else class="w-full h-full flex items-center justify-center">
@@ -69,7 +71,12 @@
             </template>
             <!-- Conversion estimate -->
             <div v-if="convertedPrice && displayPrice !== 0" class="text-xs text-base-content/60">
-              {{ t('aboutInCurrency', { amount: formatCurrency(convertedPrice, viewerCurrency), currency: viewerCurrency }) }}
+              {{
+                t('aboutInCurrency', {
+                  amount: formatCurrency(convertedPrice, viewerCurrency),
+                  currency: viewerCurrency,
+                })
+              }}
             </div>
           </div>
 
@@ -176,12 +183,14 @@
   >
     <figure class="w-48 sm:w-64 bg-base-300 shrink-0">
       <div class="w-full h-full">
-        <img
+        <nuxt-img
           v-if="primaryPhoto"
           :src="primaryPhoto"
           :alt="listing.title"
           class="w-full h-full object-contain"
           style="object-fit: contain"
+          format="webp"
+          sizes="192px sm:256px"
           loading="lazy"
         />
         <div v-else class="flex items-center justify-center w-full h-full">
@@ -254,10 +263,12 @@
   >
     <figure class="w-32 sm:w-40 bg-base-300 shrink-0">
       <div class="w-full h-full">
-        <img
+        <nuxt-img
           v-if="primaryPhoto"
           :src="primaryPhoto"
           :alt="listing.title"
+          format="webp"
+          sizes="128px sm:160px"
           class="w-full h-full object-contain"
           style="object-fit: contain"
           loading="lazy"
@@ -545,15 +556,155 @@
 
 <i18n lang="json">
 {
-  "en": { "exampleListing": "Example Listing", "soldSuffix": "sold", "soldFor": "Sold for", "soldLabel": "Sold", "aboutInCurrency": "About {amount} in {currency}", "about": "About {amount}", "markSoldShort": "Sold", "markSold": "Mark as Sold", "delete": "Delete", "deleteListing": "Delete listing", "relist": "Relist", "relistListing": "Relist listing", "anonymous": "Anonymous" },
-  "es": { "exampleListing": "Anuncio de ejemplo", "soldSuffix": "vendido", "soldFor": "Vendido por", "soldLabel": "Vendido", "aboutInCurrency": "Aproximadamente {amount} en {currency}", "about": "Aproximadamente {amount}", "markSoldShort": "Vendido", "markSold": "Marcar como vendido", "delete": "Eliminar", "deleteListing": "Eliminar anuncio", "relist": "Volver a publicar", "relistListing": "Volver a publicar anuncio", "anonymous": "Anónimo" },
-  "fr": { "exampleListing": "Annonce exemple", "soldSuffix": "vendu", "soldFor": "Vendu pour", "soldLabel": "Vendu", "aboutInCurrency": "Environ {amount} en {currency}", "about": "Environ {amount}", "markSoldShort": "Vendu", "markSold": "Marquer comme vendu", "delete": "Supprimer", "deleteListing": "Supprimer l'annonce", "relist": "Republier", "relistListing": "Republier l'annonce", "anonymous": "Anonyme" },
-  "de": { "exampleListing": "Beispielanzeige", "soldSuffix": "verkauft", "soldFor": "Verkauft für", "soldLabel": "Verkauft", "aboutInCurrency": "Etwa {amount} in {currency}", "about": "Etwa {amount}", "markSoldShort": "Verkauft", "markSold": "Als verkauft markieren", "delete": "Löschen", "deleteListing": "Anzeige löschen", "relist": "Erneut einstellen", "relistListing": "Anzeige erneut einstellen", "anonymous": "Anonym" },
-  "it": { "exampleListing": "Annuncio di esempio", "soldSuffix": "venduto", "soldFor": "Venduto a", "soldLabel": "Venduto", "aboutInCurrency": "Circa {amount} in {currency}", "about": "Circa {amount}", "markSoldShort": "Venduto", "markSold": "Segna come venduto", "delete": "Elimina", "deleteListing": "Elimina annuncio", "relist": "Ripubblica", "relistListing": "Ripubblica annuncio", "anonymous": "Anonimo" },
-  "pt": { "exampleListing": "Anúncio de exemplo", "soldSuffix": "vendido", "soldFor": "Vendido por", "soldLabel": "Vendido", "aboutInCurrency": "Cerca de {amount} em {currency}", "about": "Cerca de {amount}", "markSoldShort": "Vendido", "markSold": "Marcar como vendido", "delete": "Excluir", "deleteListing": "Excluir anúncio", "relist": "Republicar", "relistListing": "Republicar anúncio", "anonymous": "Anônimo" },
-  "ru": { "exampleListing": "Пример объявления", "soldSuffix": "продано", "soldFor": "Продано за", "soldLabel": "Продано", "aboutInCurrency": "Около {amount} в {currency}", "about": "Около {amount}", "markSoldShort": "Продано", "markSold": "Отметить как проданное", "delete": "Удалить", "deleteListing": "Удалить объявление", "relist": "Опубликовать снова", "relistListing": "Опубликовать объявление снова", "anonymous": "Аноним" },
-  "ja": { "exampleListing": "サンプル出品", "soldSuffix": "売却済み", "soldFor": "販売価格", "soldLabel": "売却済み", "aboutInCurrency": "約 {amount}（{currency}）", "about": "約 {amount}", "markSoldShort": "売却済み", "markSold": "売却済みにする", "delete": "削除", "deleteListing": "出品を削除", "relist": "再出品", "relistListing": "出品を再出品", "anonymous": "匿名" },
-  "zh": { "exampleListing": "示例刊登", "soldSuffix": "已售", "soldFor": "售出价", "soldLabel": "已售", "aboutInCurrency": "约 {amount}（{currency}）", "about": "约 {amount}", "markSoldShort": "已售", "markSold": "标记为已售", "delete": "删除", "deleteListing": "删除刊登", "relist": "重新刊登", "relistListing": "重新刊登", "anonymous": "匿名" },
-  "ko": { "exampleListing": "예시 매물", "soldSuffix": "판매됨", "soldFor": "판매가", "soldLabel": "판매됨", "aboutInCurrency": "약 {amount} ({currency})", "about": "약 {amount}", "markSoldShort": "판매됨", "markSold": "판매됨으로 표시", "delete": "삭제", "deleteListing": "매물 삭제", "relist": "다시 등록", "relistListing": "매물 다시 등록", "anonymous": "익명" }
+  "en": {
+    "exampleListing": "Example Listing",
+    "soldSuffix": "sold",
+    "soldFor": "Sold for",
+    "soldLabel": "Sold",
+    "aboutInCurrency": "About {amount} in {currency}",
+    "about": "About {amount}",
+    "markSoldShort": "Sold",
+    "markSold": "Mark as Sold",
+    "delete": "Delete",
+    "deleteListing": "Delete listing",
+    "relist": "Relist",
+    "relistListing": "Relist listing",
+    "anonymous": "Anonymous"
+  },
+  "es": {
+    "exampleListing": "Anuncio de ejemplo",
+    "soldSuffix": "vendido",
+    "soldFor": "Vendido por",
+    "soldLabel": "Vendido",
+    "aboutInCurrency": "Aproximadamente {amount} en {currency}",
+    "about": "Aproximadamente {amount}",
+    "markSoldShort": "Vendido",
+    "markSold": "Marcar como vendido",
+    "delete": "Eliminar",
+    "deleteListing": "Eliminar anuncio",
+    "relist": "Volver a publicar",
+    "relistListing": "Volver a publicar anuncio",
+    "anonymous": "Anónimo"
+  },
+  "fr": {
+    "exampleListing": "Annonce exemple",
+    "soldSuffix": "vendu",
+    "soldFor": "Vendu pour",
+    "soldLabel": "Vendu",
+    "aboutInCurrency": "Environ {amount} en {currency}",
+    "about": "Environ {amount}",
+    "markSoldShort": "Vendu",
+    "markSold": "Marquer comme vendu",
+    "delete": "Supprimer",
+    "deleteListing": "Supprimer l'annonce",
+    "relist": "Republier",
+    "relistListing": "Republier l'annonce",
+    "anonymous": "Anonyme"
+  },
+  "de": {
+    "exampleListing": "Beispielanzeige",
+    "soldSuffix": "verkauft",
+    "soldFor": "Verkauft für",
+    "soldLabel": "Verkauft",
+    "aboutInCurrency": "Etwa {amount} in {currency}",
+    "about": "Etwa {amount}",
+    "markSoldShort": "Verkauft",
+    "markSold": "Als verkauft markieren",
+    "delete": "Löschen",
+    "deleteListing": "Anzeige löschen",
+    "relist": "Erneut einstellen",
+    "relistListing": "Anzeige erneut einstellen",
+    "anonymous": "Anonym"
+  },
+  "it": {
+    "exampleListing": "Annuncio di esempio",
+    "soldSuffix": "venduto",
+    "soldFor": "Venduto a",
+    "soldLabel": "Venduto",
+    "aboutInCurrency": "Circa {amount} in {currency}",
+    "about": "Circa {amount}",
+    "markSoldShort": "Venduto",
+    "markSold": "Segna come venduto",
+    "delete": "Elimina",
+    "deleteListing": "Elimina annuncio",
+    "relist": "Ripubblica",
+    "relistListing": "Ripubblica annuncio",
+    "anonymous": "Anonimo"
+  },
+  "pt": {
+    "exampleListing": "Anúncio de exemplo",
+    "soldSuffix": "vendido",
+    "soldFor": "Vendido por",
+    "soldLabel": "Vendido",
+    "aboutInCurrency": "Cerca de {amount} em {currency}",
+    "about": "Cerca de {amount}",
+    "markSoldShort": "Vendido",
+    "markSold": "Marcar como vendido",
+    "delete": "Excluir",
+    "deleteListing": "Excluir anúncio",
+    "relist": "Republicar",
+    "relistListing": "Republicar anúncio",
+    "anonymous": "Anônimo"
+  },
+  "ru": {
+    "exampleListing": "Пример объявления",
+    "soldSuffix": "продано",
+    "soldFor": "Продано за",
+    "soldLabel": "Продано",
+    "aboutInCurrency": "Около {amount} в {currency}",
+    "about": "Около {amount}",
+    "markSoldShort": "Продано",
+    "markSold": "Отметить как проданное",
+    "delete": "Удалить",
+    "deleteListing": "Удалить объявление",
+    "relist": "Опубликовать снова",
+    "relistListing": "Опубликовать объявление снова",
+    "anonymous": "Аноним"
+  },
+  "ja": {
+    "exampleListing": "サンプル出品",
+    "soldSuffix": "売却済み",
+    "soldFor": "販売価格",
+    "soldLabel": "売却済み",
+    "aboutInCurrency": "約 {amount}（{currency}）",
+    "about": "約 {amount}",
+    "markSoldShort": "売却済み",
+    "markSold": "売却済みにする",
+    "delete": "削除",
+    "deleteListing": "出品を削除",
+    "relist": "再出品",
+    "relistListing": "出品を再出品",
+    "anonymous": "匿名"
+  },
+  "zh": {
+    "exampleListing": "示例刊登",
+    "soldSuffix": "已售",
+    "soldFor": "售出价",
+    "soldLabel": "已售",
+    "aboutInCurrency": "约 {amount}（{currency}）",
+    "about": "约 {amount}",
+    "markSoldShort": "已售",
+    "markSold": "标记为已售",
+    "delete": "删除",
+    "deleteListing": "删除刊登",
+    "relist": "重新刊登",
+    "relistListing": "重新刊登",
+    "anonymous": "匿名"
+  },
+  "ko": {
+    "exampleListing": "예시 매물",
+    "soldSuffix": "판매됨",
+    "soldFor": "판매가",
+    "soldLabel": "판매됨",
+    "aboutInCurrency": "약 {amount} ({currency})",
+    "about": "약 {amount}",
+    "markSoldShort": "판매됨",
+    "markSold": "판매됨으로 표시",
+    "delete": "삭제",
+    "deleteListing": "매물 삭제",
+    "relist": "다시 등록",
+    "relistListing": "매물 다시 등록",
+    "anonymous": "익명"
+  }
 }
 </i18n>

--- a/app/components/exchange/listings/PhotoGallery.vue
+++ b/app/components/exchange/listings/PhotoGallery.vue
@@ -66,13 +66,31 @@
 
     <!-- Hero Main Image -->
     <div class="relative overflow-hidden rounded-lg bg-base-200">
-      <img
+      <!-- nuxt-img (not nuxt-picture): this renders a single <img>, so the class,
+           data-testid and @click land on the image element exactly as before.
+           `format="webp"` is required — NuxtImg emits the SOURCE format unless told
+           otherwise; the `image.format` list in nuxt.config only applies to
+           <NuxtPicture>. No width/height here on purpose: passing only `sizes` keeps
+           each photo's natural aspect ratio (listing photos are user-uploaded and
+           vary), and the aspect-* class on the element itself already reserves the
+           box, so there's no CLS. -->
+      <nuxt-img
         v-if="activePhoto"
         data-testid="hero-image"
         :src="getPhotoUrl(activePhoto.storage_path)"
-        :alt="t('heroAlt', { title: listingTitle, category: activePhoto.category || t('photo'), index: activeFilteredIndex + 1 })"
+        :alt="
+          t('heroAlt', {
+            title: listingTitle,
+            category: activePhoto.category || t('photo'),
+            index: activeFilteredIndex + 1,
+          })
+        "
         class="w-full aspect-4/3 md:aspect-video object-contain cursor-zoom-in"
         style="object-fit: contain"
+        format="webp"
+        sizes="100vw md:768px lg:1024px"
+        loading="eager"
+        fetchpriority="high"
         @click="openLightbox"
       />
 
@@ -128,10 +146,17 @@
         style="scroll-snap-align: center"
         @click="selectPhoto(photo)"
       >
-        <img
+        <!-- Thumbnails render at 64/80px but were loading the full-size upload.
+             width+height here are deliberate: the strip crops (object-cover), so a
+             square resize is correct and it pins the request to ~80px. -->
+        <nuxt-img
           :src="getPhotoUrl(photo.storage_path)"
           :alt="t('thumbnailAlt', { title: listingTitle, index: index + 1 })"
           class="w-full h-full object-cover"
+          format="webp"
+          width="80"
+          height="80"
+          sizes="64px md:80px"
           loading="lazy"
         />
       </button>
@@ -154,10 +179,12 @@
               :ref="(el) => setLightboxSlideRef(index, el)"
               class="carousel-item relative w-full"
             >
-              <img
+              <nuxt-img
                 :src="getPhotoUrl(photo.storage_path)"
                 :alt="t('lightboxAlt', { title: listingTitle, index: index + 1 })"
                 class="w-full max-h-[80vh] object-contain mx-auto"
+                format="webp"
+                sizes="100vw lg:1280px"
                 loading="lazy"
               />
 

--- a/app/components/exchange/listings/RelatedListings.vue
+++ b/app/components/exchange/listings/RelatedListings.vue
@@ -8,39 +8,41 @@
 
     <!-- Listings Grid -->
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <NuxtLink
-          v-for="item in relatedListings"
-          :key="item.id"
-          :to="`/exchange/listings/${item.slug}`"
-          class="bg-base-100 shadow-sm hover:shadow-md transition-shadow rounded-lg overflow-hidden"
-        >
-          <!-- Photo -->
-          <div class="aspect-video bg-linear-to-br from-base-200 to-base-300">
-            <img
-              v-if="getItemPhotoUrl(item)"
-              :src="getItemPhotoUrl(item)!"
-              :alt="item.title"
-              class="w-full h-full object-contain"
-              loading="lazy"
-            />
-            <div v-else class="w-full h-full flex items-center justify-center">
-              <i class="fas fa-image text-base-content/30 text-5xl"></i>
-            </div>
+      <NuxtLink
+        v-for="item in relatedListings"
+        :key="item.id"
+        :to="`/exchange/listings/${item.slug}`"
+        class="bg-base-100 shadow-sm hover:shadow-md transition-shadow rounded-lg overflow-hidden"
+      >
+        <!-- Photo -->
+        <div class="aspect-video bg-linear-to-br from-base-200 to-base-300">
+          <nuxt-img
+            v-if="getItemPhotoUrl(item)"
+            :src="getItemPhotoUrl(item)!"
+            :alt="item.title"
+            class="w-full h-full object-contain"
+            format="webp"
+            sizes="100vw sm:50vw lg:320px"
+            loading="lazy"
+          />
+          <div v-else class="w-full h-full flex items-center justify-center">
+            <i class="fas fa-image text-base-content/30 text-5xl"></i>
           </div>
+        </div>
 
-          <!-- Info -->
-          <div class="p-4">
-            <h3 class="font-semibold line-clamp-1">{{ item.title }}</h3>
-            <div class="text-lg font-bold mt-1" :class="item.price === 0 ? 'text-success' : 'text-primary'">
-              {{ formatPrice(item.price) }}
-            </div>
-            <div v-if="item.location" class="flex items-center gap-1 text-sm text-base-content/60 mt-1">
-              <i class="fas fa-location-dot"></i>
-              <span class="truncate">{{ item.location }}</span>
-            </div>
+        <!-- Info -->
+        <div class="p-4">
+          <h3 class="font-semibold line-clamp-1">{{ item.title }}</h3>
+          <div class="text-lg font-bold mt-1" :class="item.price === 0 ? 'text-success' : 'text-primary'">
+            {{ formatPrice(item.price) }}
           </div>
-        </NuxtLink>
-      </div>
+          <div v-if="item.location" class="flex items-center gap-1 text-sm text-base-content/60 mt-1">
+            <i class="fas fa-location-dot"></i>
+            <span class="truncate">{{ item.location }}</span>
+          </div>
+        </div>
+      </NuxtLink>
+    </div>
   </div>
 
   <!-- Loading State -->

--- a/app/components/models/ExternalModelCard.vue
+++ b/app/components/models/ExternalModelCard.vue
@@ -17,11 +17,13 @@
     class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-xl hover:-translate-y-0.5 transition-all duration-200 overflow-hidden group"
   >
     <figure class="relative aspect-[4/3] bg-base-200 overflow-hidden">
-      <img
+      <nuxt-img
         v-if="model.primaryImage"
         :src="model.primaryImage"
         :alt="model.title"
         loading="lazy"
+        format="webp"
+        sizes="100vw sm:50vw lg:400px"
         class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
       />
       <div v-else class="w-full h-full flex items-center justify-center text-base-content/30">
@@ -56,12 +58,37 @@
 <i18n lang="json">
 {
   "en": { "featured": "Featured", "anonymous": "Unknown maker", "likes": "Likes", "visits": "Outbound visits" },
-  "es": { "featured": "Destacado", "anonymous": "Autor desconocido", "likes": "Me gusta", "visits": "Visitas externas" },
+  "es": {
+    "featured": "Destacado",
+    "anonymous": "Autor desconocido",
+    "likes": "Me gusta",
+    "visits": "Visitas externas"
+  },
   "fr": { "featured": "En vedette", "anonymous": "Créateur inconnu", "likes": "J'aime", "visits": "Visites sortantes" },
-  "de": { "featured": "Empfohlen", "anonymous": "Unbekannter Ersteller", "likes": "Gefällt mir", "visits": "Externe Besuche" },
-  "it": { "featured": "In evidenza", "anonymous": "Autore sconosciuto", "likes": "Mi piace", "visits": "Visite esterne" },
-  "pt": { "featured": "Destaque", "anonymous": "Autor desconhecido", "likes": "Curtidas", "visits": "Visitas externas" },
-  "ru": { "featured": "Рекомендуем", "anonymous": "Автор неизвестен", "likes": "Нравится", "visits": "Внешние переходы" },
+  "de": {
+    "featured": "Empfohlen",
+    "anonymous": "Unbekannter Ersteller",
+    "likes": "Gefällt mir",
+    "visits": "Externe Besuche"
+  },
+  "it": {
+    "featured": "In evidenza",
+    "anonymous": "Autore sconosciuto",
+    "likes": "Mi piace",
+    "visits": "Visite esterne"
+  },
+  "pt": {
+    "featured": "Destaque",
+    "anonymous": "Autor desconhecido",
+    "likes": "Curtidas",
+    "visits": "Visitas externas"
+  },
+  "ru": {
+    "featured": "Рекомендуем",
+    "anonymous": "Автор неизвестен",
+    "likes": "Нравится",
+    "visits": "Внешние переходы"
+  },
   "ja": { "featured": "おすすめ", "anonymous": "作者不明", "likes": "いいね", "visits": "外部アクセス" },
   "zh": { "featured": "精选", "anonymous": "未知作者", "likes": "点赞", "visits": "外部访问" },
   "ko": { "featured": "추천", "anonymous": "작자 미상", "likes": "좋아요", "visits": "외부 방문" }

--- a/app/components/models/ModelCard.vue
+++ b/app/components/models/ModelCard.vue
@@ -14,11 +14,13 @@
     class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-xl hover:-translate-y-0.5 transition-all duration-200 overflow-hidden group"
   >
     <figure class="relative aspect-[4/3] bg-base-200 overflow-hidden">
-      <img
+      <nuxt-img
         v-if="model.primaryImage"
         :src="model.primaryImage"
         :alt="model.title"
         loading="lazy"
+        format="webp"
+        sizes="100vw sm:50vw lg:400px"
         class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
       />
       <div v-else class="w-full h-full flex items-center justify-center text-base-content/30">
@@ -50,11 +52,14 @@
 
       <div class="flex items-center justify-between mt-2 text-xs opacity-70">
         <span v-if="model.author" class="flex items-center gap-1.5 min-w-0">
-          <img
+          <nuxt-img
             v-if="model.author.avatarUrl"
             :src="model.author.avatarUrl"
             :alt="model.author.displayName || t('author.label')"
             class="w-5 h-5 rounded-full object-cover"
+            format="webp"
+            width="20"
+            height="20"
             loading="lazy"
           />
           <i v-else class="fas fa-circle-user text-base"></i>

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -9,8 +9,8 @@
   const description =
     'About Classic Mini DIY — a knowledgebase, toolkit, and archive for Classic Mini Cooper owners, founded by Cole Gentry to help enthusiasts work on their own cars.';
 
-    // Title is just "About" — nuxt-seo-utils appends " | Classic Mini DIY" via the
-    // site-name template (including the brand here would double it).
+  // Title is just "About" — nuxt-seo-utils appends " | Classic Mini DIY" via the
+  // site-name template (including the brand here would double it).
   useSeoMeta({
     title: 'About',
     description,
@@ -76,6 +76,7 @@
                 alt="Cole Gentry, founder of Classic Mini DIY"
                 width="120"
                 height="120"
+                format="webp"
                 class="rounded-full w-30 h-30 object-cover mb-2"
                 loading="lazy"
               />
@@ -100,10 +101,10 @@
             <div class="card-body">
               <h2 class="font-semibold text-2xl mb-2">Who's behind it</h2>
               <p class="opacity-80 leading-relaxed">
-                I'm Cole Gentry, the founder of Classic Mini DIY. I build the calculators, decoders, and
-                reference data on this site and share Classic Mini repair and restoration know-how on
-                YouTube. The goal is simple: pull technical information from across the Classic Mini
-                community into one place and keep it free, accurate, and easy to use.
+                I'm Cole Gentry, the founder of Classic Mini DIY. I build the calculators, decoders, and reference data
+                on this site and share Classic Mini repair and restoration know-how on YouTube. The goal is simple: pull
+                technical information from across the Classic Mini community into one place and keep it free, accurate,
+                and easy to use.
               </p>
             </div>
           </div>
@@ -112,8 +113,8 @@
             <div class="card-body">
               <h2 class="font-semibold text-2xl mb-3">What you'll find here</h2>
               <p class="opacity-80 leading-relaxed mb-4">
-                Everything here is focused on the A-series Classic Mini (1959–2000) — the cars, the
-                engines, and the people who keep them on the road.
+                Everything here is focused on the A-series Classic Mini (1959–2000) — the cars, the engines, and the
+                people who keep them on the road.
               </p>
               <ul class="space-y-2">
                 <li class="flex items-start gap-3">
@@ -126,13 +127,9 @@
                 <li class="flex items-start gap-3">
                   <i class="fas fa-magnifying-glass text-primary mt-1"></i>
                   <span class="opacity-80">
-                    <NuxtLink to="/technical/chassis-decoder" class="text-primary hover:underline"
-                      >Chassis</NuxtLink
-                    >
+                    <NuxtLink to="/technical/chassis-decoder" class="text-primary hover:underline">Chassis</NuxtLink>
                     and
-                    <NuxtLink to="/technical/engine-decoder" class="text-primary hover:underline"
-                      >engine</NuxtLink
-                    >
+                    <NuxtLink to="/technical/engine-decoder" class="text-primary hover:underline">engine</NuxtLink>
                     number decoders to identify your car.
                   </span>
                 </li>

--- a/app/pages/archive/engines.vue
+++ b/app/pages/archive/engines.vue
@@ -101,26 +101,26 @@
               :title="t('compression_card.link_title')"
               @click="track('tool_card_clicked', { tool_name: 'compression', location: 'archive_engines' })"
             >
-              <div class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-xl transition-shadow duration-300">
+              <div
+                class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-xl transition-shadow duration-300"
+              >
                 <div class="card-body">
                   <div class="flex items-start">
                     <div class="mr-4">
                       <figure class="w-16 h-16">
-                        <picture>
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-calculator-100.webp"
-                            type="image/webp"
-                          />
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-calculator-100.png"
-                            type="image/png"
-                          />
-                          <nuxt-img
-                            src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-calculator-100.png"
-                            :alt="t('compression_card.alt_text')"
-                            class="w-full h-full object-contain"
-                          />
-                        </picture>
+                        <!-- Was a hand-rolled <picture> whose <source> srcsets pointed
+                             straight at S3, so the browser always took the raw 100px
+                             asset and the <nuxt-img> fallback never rendered. A single
+                             nuxt-img lets ipx resize to the 64px display size. -->
+                        <nuxt-img
+                          src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-calculator-100.png"
+                          :alt="t('compression_card.alt_text')"
+                          class="w-full h-full object-contain"
+                          format="webp"
+                          width="64"
+                          height="64"
+                          loading="lazy"
+                        />
                       </figure>
                     </div>
                     <div>

--- a/app/pages/archive/registry/index.vue
+++ b/app/pages/archive/registry/index.vue
@@ -146,22 +146,15 @@
                   <div class="flex items-start space-x-4">
                     <div class="flex-shrink-0">
                       <figure class="w-16 h-16">
-                        <picture>
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-book-reading-100.webp"
-                            type="image/webp"
-                          />
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-book-reading-100.png"
-                            type="image/png"
-                          />
-                          <nuxt-img
-                            loading="lazy"
-                            src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-book-reading-100.png"
-                            :alt="t('submit_card.alt_text')"
-                            class="w-16 h-16"
-                          />
-                        </picture>
+                        <nuxt-img
+                          loading="lazy"
+                          src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-book-reading-100.png"
+                          :alt="t('submit_card.alt_text')"
+                          class="w-16 h-16"
+                          format="webp"
+                          width="64"
+                          height="64"
+                        />
                       </figure>
                     </div>
                     <div>

--- a/app/pages/contributors/[id].vue
+++ b/app/pages/contributors/[id].vue
@@ -158,7 +158,14 @@
             <div class="flex flex-col sm:flex-row items-center sm:items-start gap-6 p-2">
               <div v-if="profile.avatarUrl" class="avatar">
                 <div class="w-32 rounded-full">
-                  <img :src="profile.avatarUrl" :alt="displayName" />
+                  <nuxt-img
+                    :src="profile.avatarUrl"
+                    :alt="displayName"
+                    format="webp"
+                    width="128"
+                    height="128"
+                    loading="lazy"
+                  />
                 </div>
               </div>
               <div v-else class="avatar avatar-placeholder">
@@ -170,10 +177,7 @@
                 <span class="eyebrow">{{ t('eyebrow') }}</span>
                 <h2 class="text-3xl font-bold mb-2">{{ displayName }}</h2>
                 <div class="mb-3">
-                  <span
-                    class="badge badge-soft"
-                    :class="`badge-${trustLevelConfig.color}`"
-                  >
+                  <span class="badge badge-soft" :class="`badge-${trustLevelConfig.color}`">
                     {{ trustLevelConfig.label }}
                   </span>
                 </div>
@@ -295,10 +299,7 @@
                   </p>
                 </div>
                 <div class="flex items-center gap-2 shrink-0">
-                  <span
-                    class="badge badge-soft badge-sm"
-                    :class="`badge-${actionBadgeColor(item.action)}`"
-                  >
+                  <span class="badge badge-soft badge-sm" :class="`badge-${actionBadgeColor(item.action)}`">
                     {{ t(`contributions.action.${item.action}`) }}
                   </span>
                   <span class="text-xs text-base-content/40 hidden sm:inline">

--- a/app/pages/links.vue
+++ b/app/pages/links.vue
@@ -64,7 +64,11 @@
     });
   }
 
-  const { data: videos, status, error } = await useFetch('/api/youtube/videos', {
+  const {
+    data: videos,
+    status,
+    error,
+  } = await useFetch('/api/youtube/videos', {
     query: { limit: 10 },
     key: 'links-page-videos',
   });
@@ -131,6 +135,7 @@
             alt="Classic Mini DIY"
             width="120"
             height="120"
+            format="webp"
             loading="eager"
             class="rounded-full shadow-lg ring-4 ring-base-100 mb-4"
           />
@@ -199,9 +204,20 @@
           target="_blank"
           rel="noopener"
           class="card bg-base-100 shadow-md border border-base-300 overflow-hidden hover:shadow-lg transition-shadow"
-          @click="capture('links_page_click', { link_id: 'video', group: 'video', destination: video.videoUrl, label: video.title })"
+          @click="
+            capture('links_page_click', {
+              link_id: 'video',
+              group: 'video',
+              destination: video.videoUrl,
+              label: video.title,
+            })
+          "
         >
           <figure class="relative">
+            <!-- Explicit format="webp" rather than inheriting nuxt.config's
+                 ['webp','avif','jpg','png']: avif measured barely better than jpeg on
+                 these photographic thumbnails at q80 and is far slower to encode on a
+                 cold serverless path, so it costs more than it saves. -->
             <nuxt-picture
               :src="video.thumbnails.maxres"
               :alt="video.title"
@@ -209,6 +225,7 @@
               loading="lazy"
               width="720"
               height="404"
+              format="webp"
             />
             <span class="absolute inset-0 flex items-center justify-center">
               <span class="rounded-full bg-black/60 text-white w-14 h-14 flex items-center justify-center">

--- a/app/pages/maps.vue
+++ b/app/pages/maps.vue
@@ -445,7 +445,10 @@
                 </div>
               </div>
               <div class="p-2">
-                <div v-if="commitsLoading === 'pending' || releasesLoading === 'pending'" class="flex justify-center p-4">
+                <div
+                  v-if="commitsLoading === 'pending' || releasesLoading === 'pending'"
+                  class="flex justify-center p-4"
+                >
                   <div class="loading loading-spinner loading-md text-primary"></div>
                 </div>
                 <div v-else-if="mergedUpdates && mergedUpdates.length > 0">
@@ -530,45 +533,63 @@
               </div>
               <div class="grid grid-cols-1 gap-6">
                 <div class="image">
-                  <img
+                  <nuxt-img
                     class="mx-auto w-1/2"
                     src="https://classicminidiy.s3.us-east-1.amazonaws.com/misc/ecus/haltech.jpg"
                     alt="Haltech ECU"
+                    format="webp"
+                    sizes="50vw lg:320px"
+                    loading="lazy"
                   />
                 </div>
                 <div class="image">
-                  <img
+                  <nuxt-img
                     class="mx-auto w-1/2"
                     src="https://classicminidiy.s3.us-east-1.amazonaws.com/misc/ecus/speeduino.jpg"
                     alt="Speeduino ECU"
+                    format="webp"
+                    sizes="50vw lg:320px"
+                    loading="lazy"
                   />
                 </div>
                 <div class="image">
-                  <img
+                  <nuxt-img
                     class="mx-auto w-1/2"
                     src="https://classicminidiy.s3.us-east-1.amazonaws.com/misc/ecus/megasquirt.png"
                     alt="MegaSquirt ECU"
+                    format="webp"
+                    sizes="50vw lg:320px"
+                    loading="lazy"
                   />
                 </div>
                 <div class="image">
-                  <img
+                  <nuxt-img
                     class="mx-auto w-1/2"
                     src="https://classicminidiy.s3.us-east-1.amazonaws.com/misc/ecus/emerald.png"
                     alt="Emerald ECU"
+                    format="webp"
+                    sizes="50vw lg:320px"
+                    loading="lazy"
                   />
                 </div>
                 <div class="image">
-                  <img
+                  <nuxt-img
                     class="mx-auto w-1/2"
                     src="https://classicminidiy.s3.us-east-1.amazonaws.com/misc/ecus/megajolt.png"
                     alt="MegaJolt ECU"
+                    format="webp"
+                    sizes="50vw lg:320px"
+                    loading="lazy"
                   />
                 </div>
                 <div class="image">
-                  <img
+                  <nuxt-img
                     class="mx-auto w-1/2"
                     src="https://classicminidiy.s3.us-east-1.amazonaws.com/misc/ecus/dta.jpg"
                     alt="DTA Fast ECU"
+                    format="webp"
+                    sizes="50vw lg:320px"
+                    loading="lazy"
                   />
                 </div>
               </div>

--- a/app/pages/models/[slug].vue
+++ b/app/pages/models/[slug].vue
@@ -128,7 +128,11 @@
       if (sid && model.value) {
         const res = await verifyPurchase(model.value.id, sid);
         if (res.verified) {
-          track('model_purchase_completed', { model_id: model.value.id, kind: res.kind ?? 'purchase', session_id: sid });
+          track('model_purchase_completed', {
+            model_id: model.value.id,
+            kind: res.kind ?? 'purchase',
+            session_id: sid,
+          });
           purchaseNotice.value = {
             type: 'success',
             text: res.kind === 'tip' ? t('notice.thankYouTip') : t('notice.purchaseComplete'),
@@ -224,7 +228,14 @@
           class="rounded-xl overflow-hidden border border-base-300 bg-base-200"
           style="aspect-ratio: 4 / 3"
         >
-          <img :src="activeMedia.url" :alt="activeMedia.alt" class="w-full h-full object-contain" />
+          <nuxt-img
+            :src="activeMedia.url"
+            :alt="activeMedia.alt"
+            class="w-full h-full object-contain"
+            format="webp"
+            sizes="100vw lg:768px"
+            loading="eager"
+          />
         </div>
         <div
           v-else
@@ -261,7 +272,15 @@
             "
             @click="activeMedia = { kind: 'image', url: img.url, alt: img.altText || model.title }"
           >
-            <img :src="img.url" :alt="img.altText || model.title" class="w-full h-full object-cover" loading="lazy" />
+            <nuxt-img
+              :src="img.url"
+              :alt="img.altText || model.title"
+              class="w-full h-full object-cover"
+              format="webp"
+              width="64"
+              height="64"
+              loading="lazy"
+            />
           </button>
         </div>
       </div>
@@ -278,15 +297,20 @@
 
           <!-- Author -->
           <div v-if="model.author" class="flex items-center gap-2">
-            <img
+            <nuxt-img
               v-if="model.author.avatarUrl"
               :src="model.author.avatarUrl"
               class="w-8 h-8 rounded-full object-cover"
               :alt="model.author.displayName || t('author.fallback')"
+              format="webp"
+              width="32"
+              height="32"
+              loading="lazy"
             />
             <i v-else class="fas fa-circle-user text-2xl opacity-60"></i>
             <span class="text-sm"
-              >{{ t('author.by') }} <strong>{{ model.author.displayName || model.author.username || t('author.anonymous') }}</strong></span
+              >{{ t('author.by') }}
+              <strong>{{ model.author.displayName || model.author.username || t('author.anonymous') }}</strong></span
             >
           </div>
 
@@ -315,7 +339,9 @@
                     {{ priceAside.text }}
                   </div>
                 </div>
-                <span v-if="isOwner" class="badge badge-neutral badge-sm shrink-0 whitespace-nowrap">{{ t('pricing.yourModel') }}</span>
+                <span v-if="isOwner" class="badge badge-neutral badge-sm shrink-0 whitespace-nowrap">{{
+                  t('pricing.yourModel')
+                }}</span>
                 <span v-else-if="entitled && !isFree" class="badge badge-success badge-sm shrink-0 whitespace-nowrap">
                   <i class="fas fa-check mr-1"></i> {{ t('pricing.purchased') }}
                 </span>
@@ -433,7 +459,9 @@
         <!-- Description -->
         <div v-if="model.description" class="card bg-base-100 shadow-sm border border-base-300">
           <div class="card-body">
-            <h2 class="card-title text-lg"><i class="fas fa-align-left text-primary mr-1"></i> {{ t('about.heading') }}</h2>
+            <h2 class="card-title text-lg">
+              <i class="fas fa-align-left text-primary mr-1"></i> {{ t('about.heading') }}
+            </h2>
             <p class="whitespace-pre-line text-sm leading-relaxed">{{ model.description }}</p>
             <a
               v-if="model.sourceUrl"
@@ -455,7 +483,8 @@
         <div v-if="model.version?.changelog" class="card bg-base-100 shadow-sm border border-base-300">
           <div class="card-body">
             <h3 class="card-title text-lg">
-              <i class="fas fa-code-branch text-primary mr-1"></i> {{ t('changelog.heading', { version: model.version.versionNumber }) }}
+              <i class="fas fa-code-branch text-primary mr-1"></i>
+              {{ t('changelog.heading', { version: model.version.versionNumber }) }}
             </h3>
             <p class="whitespace-pre-line text-sm opacity-80">{{ model.version.changelog }}</p>
           </div>
@@ -547,7 +576,12 @@
       "signInCta": "Inicia sesión para descargar",
       "filesHeading": "Archivos ({count})",
       "all": "Descargar todo",
-      "group": { "model": "Archivos de impresión", "source": "Fuente y CAD", "document": "Documentos", "other": "Otros archivos" }
+      "group": {
+        "model": "Archivos de impresión",
+        "source": "Fuente y CAD",
+        "document": "Documentos",
+        "other": "Otros archivos"
+      }
     },
     "notice": {
       "purchaseComplete": "Compra completada — tus archivos están desbloqueados abajo.",
@@ -594,7 +628,12 @@
       "signInCta": "Connectez-vous pour télécharger",
       "filesHeading": "Fichiers ({count})",
       "all": "Tout télécharger",
-      "group": { "model": "Fichiers d'impression", "source": "Source et CAO", "document": "Documents", "other": "Autres fichiers" }
+      "group": {
+        "model": "Fichiers d'impression",
+        "source": "Source et CAO",
+        "document": "Documents",
+        "other": "Autres fichiers"
+      }
     },
     "notice": {
       "purchaseComplete": "Achat effectué — vos fichiers sont déverrouillés ci-dessous.",
@@ -641,7 +680,12 @@
       "signInCta": "Zum Herunterladen anmelden",
       "filesHeading": "Dateien ({count})",
       "all": "Alle herunterladen",
-      "group": { "model": "Druckdateien", "source": "Quelle & CAD", "document": "Dokumente", "other": "Weitere Dateien" }
+      "group": {
+        "model": "Druckdateien",
+        "source": "Quelle & CAD",
+        "document": "Dokumente",
+        "other": "Weitere Dateien"
+      }
     },
     "notice": {
       "purchaseComplete": "Kauf abgeschlossen — deine Dateien sind unten freigeschaltet.",
@@ -735,7 +779,12 @@
       "signInCta": "Entre para baixar",
       "filesHeading": "Arquivos ({count})",
       "all": "Baixar tudo",
-      "group": { "model": "Arquivos de impressão", "source": "Fonte e CAD", "document": "Documentos", "other": "Outros arquivos" }
+      "group": {
+        "model": "Arquivos de impressão",
+        "source": "Fonte e CAD",
+        "document": "Documentos",
+        "other": "Outros arquivos"
+      }
     },
     "notice": {
       "purchaseComplete": "Compra concluída — seus arquivos estão desbloqueados abaixo.",
@@ -782,7 +831,12 @@
       "signInCta": "Войдите, чтобы скачать",
       "filesHeading": "Файлы ({count})",
       "all": "Скачать всё",
-      "group": { "model": "Файлы для печати", "source": "Исходники и CAD", "document": "Документы", "other": "Другие файлы" }
+      "group": {
+        "model": "Файлы для печати",
+        "source": "Исходники и CAD",
+        "document": "Документы",
+        "other": "Другие файлы"
+      }
     },
     "notice": {
       "purchaseComplete": "Покупка завершена — ваши файлы разблокированы ниже.",
@@ -829,7 +883,12 @@
       "signInCta": "ダウンロードするにはサインイン",
       "filesHeading": "ファイル ({count})",
       "all": "すべてダウンロード",
-      "group": { "model": "印刷ファイル", "source": "ソース・CAD", "document": "ドキュメント", "other": "その他のファイル" }
+      "group": {
+        "model": "印刷ファイル",
+        "source": "ソース・CAD",
+        "document": "ドキュメント",
+        "other": "その他のファイル"
+      }
     },
     "notice": {
       "purchaseComplete": "購入完了 — ファイルは以下でダウンロードできます。",

--- a/app/pages/models/external/[slug].vue
+++ b/app/pages/models/external/[slug].vue
@@ -15,9 +15,7 @@
   // ── SEO ──────────────────────────────────────────────────────────────────────
   const SITE_DEFAULT_OG = 'https://classicminidiy.s3.us-east-1.amazonaws.com/misc/seo-images/avatar.jpg';
 
-  const seoTitle = computed(() =>
-    model.value ? `${model.value.title} | Classic Mini DIY` : t('meta.defaultTitle')
-  );
+  const seoTitle = computed(() => (model.value ? `${model.value.title} | Classic Mini DIY` : t('meta.defaultTitle')));
   const seoDesc = computed(() => {
     const m = model.value;
     if (!m) return t('meta.defaultDescription');
@@ -82,7 +80,14 @@
           class="rounded-xl overflow-hidden border border-base-300 bg-base-200"
           style="aspect-ratio: 4 / 3"
         >
-          <img :src="activeImage.url" :alt="activeImage.alt" class="w-full h-full object-contain" />
+          <nuxt-img
+            :src="activeImage.url"
+            :alt="activeImage.alt"
+            class="w-full h-full object-contain"
+            format="webp"
+            sizes="100vw lg:768px"
+            loading="eager"
+          />
         </div>
         <!-- No images placeholder -->
         <div
@@ -99,14 +104,18 @@
             v-for="img in model.images"
             :key="img.id"
             class="w-16 h-16 rounded-lg border-2 overflow-hidden"
-            :class="
-              activeImage?.url === img.url
-                ? 'border-primary'
-                : 'border-base-300 hover:border-primary/50'
-            "
+            :class="activeImage?.url === img.url ? 'border-primary' : 'border-base-300 hover:border-primary/50'"
             @click="activeImage = { url: img.url, alt: img.altText || model.title }"
           >
-            <img :src="img.url" :alt="img.altText || model.title" class="w-full h-full object-cover" loading="lazy" />
+            <nuxt-img
+              :src="img.url"
+              :alt="img.altText || model.title"
+              class="w-full h-full object-cover"
+              format="webp"
+              width="64"
+              height="64"
+              loading="lazy"
+            />
           </button>
         </div>
       </div>
@@ -160,7 +169,8 @@
                   target="_blank"
                   rel="nofollow noopener"
                   class="link link-hover font-semibold"
-                >{{ model.sourceAuthorName }}</a>
+                  >{{ model.sourceAuthorName }}</a
+                >
                 <span v-else class="font-semibold">{{ model.sourceAuthorName }}</span>
               </div>
             </div>

--- a/app/pages/technical/chassis-decoder.vue
+++ b/app/pages/technical/chassis-decoder.vue
@@ -220,17 +220,15 @@
                   <div class="flex items-start space-x-4">
                     <div class="shrink-0">
                       <figure class="w-16 h-16">
-                        <picture>
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-blueprint-zoom-100.webp"
-                            type="image/webp"
-                          />
-                          <img
-                            src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-blueprint-zoom-100.png"
-                            :alt="t('engine_decoder_card.alt_text')"
-                            class="w-full h-full object-cover rounded"
-                          />
-                        </picture>
+                        <nuxt-img
+                          src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-blueprint-zoom-100.png"
+                          :alt="t('engine_decoder_card.alt_text')"
+                          class="w-full h-full object-cover rounded"
+                          format="webp"
+                          width="64"
+                          height="64"
+                          loading="lazy"
+                        />
                       </figure>
                     </div>
                     <div class="flex-1">

--- a/app/pages/technical/compression.vue
+++ b/app/pages/technical/compression.vue
@@ -120,11 +120,7 @@
         <breadcrumb class="my-6" :version="BREADCRUMB_VERSIONS.TECH" :page="t('breadcrumb_title')"></breadcrumb>
         <div class="grid grid-cols-11 md:grid-cols-12 gap-6">
           <div class="col-span-12 md:col-span-8">
-            <PageIntro
-              :eyebrow="t('eyebrow')"
-              :title="t('main_heading')"
-              :description="t('description_text')"
-            />
+            <PageIntro :eyebrow="t('eyebrow')" :title="t('main_heading')" :description="t('description_text')" />
           </div>
           <div class="col-span-12 md:col-span-4">
             <NuxtLink :to="'/archive/engines'" :title="t('engine_sizes_card.link_title')" class="block">
@@ -133,22 +129,15 @@
                   <div class="flex items-start space-x-4">
                     <div class="shrink-0">
                       <figure class="w-16 h-16">
-                        <picture>
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.webp"
-                            type="image/webp"
-                          />
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.png"
-                            type="image/png"
-                          />
-                          <nuxt-img
-                            loading="lazy"
-                            src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.png"
-                            :alt="t('engine_sizes_card.alt_text')"
-                            class="w-full h-full object-contain"
-                          />
-                        </picture>
+                        <nuxt-img
+                          loading="lazy"
+                          src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.png"
+                          :alt="t('engine_sizes_card.alt_text')"
+                          class="w-full h-full object-contain"
+                          format="webp"
+                          width="64"
+                          height="64"
+                        />
                       </figure>
                     </div>
                     <div>

--- a/app/pages/technical/engine-decoder.vue
+++ b/app/pages/technical/engine-decoder.vue
@@ -128,22 +128,15 @@
                 <div class="card-body">
                   <div class="flex items-center">
                     <div class="shrink-0">
-                      <picture>
-                        <source
-                          srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-blueprint-zoom-100.webp"
-                          type="image/webp"
-                        />
-                        <source
-                          srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-blueprint-zoom-100.png"
-                          type="image/png"
-                        />
-                        <nuxt-img
-                          loading="lazy"
-                          src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-blueprint-zoom-100.png"
-                          :alt="t('chassis_decoder_card.alt_text')"
-                          class="w-16 h-16"
-                        />
-                      </picture>
+                      <nuxt-img
+                        loading="lazy"
+                        src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-blueprint-zoom-100.png"
+                        :alt="t('chassis_decoder_card.alt_text')"
+                        class="w-16 h-16"
+                        format="webp"
+                        width="64"
+                        height="64"
+                      />
                     </div>
                     <div class="ml-4">
                       <h2 class="text-xl font-semibold mb-2">

--- a/app/pages/technical/gearing.vue
+++ b/app/pages/technical/gearing.vue
@@ -125,22 +125,15 @@
                   <div class="flex items-start space-x-4">
                     <div class="shrink-0">
                       <figure class="w-16 h-16">
-                        <picture>
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.webp"
-                            type="image/webp"
-                          />
-                          <source
-                            srcset="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.png"
-                            type="image/png"
-                          />
-                          <nuxt-img
-                            loading="lazy"
-                            src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.png"
-                            class="w-full h-full object-contain"
-                            :alt="t('engine_sizes_card.alt_text')"
-                          />
-                        </picture>
+                        <nuxt-img
+                          loading="lazy"
+                          src="https://classicminidiy.s3.amazonaws.com/cloud-icon/icons8-dashboard-100.png"
+                          class="w-full h-full object-contain"
+                          :alt="t('engine_sizes_card.alt_text')"
+                          format="webp"
+                          width="64"
+                          height="64"
+                        />
                       </figure>
                     </div>
                     <div>

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -79,9 +79,7 @@
       // Fetch gear configs and vehicles in parallel
       const [configs, vehiclesData] = await Promise.all([
         fetchPublicConfigs(result.profile.id),
-        result.profile.show_vehicles
-          ? getPublicProfileVehicles(result.profile.id)
-          : Promise.resolve([] as Vehicle[]),
+        result.profile.show_vehicles ? getPublicProfileVehicles(result.profile.id) : Promise.resolve([] as Vehicle[]),
       ]);
 
       publicConfigs.value = configs;
@@ -159,7 +157,14 @@
           <div class="flex flex-col sm:flex-row items-center sm:items-start gap-4">
             <div v-if="profile?.avatar_url" class="avatar">
               <div class="w-20 rounded-full">
-                <img :src="profile.avatar_url" :alt="displayName" />
+                <nuxt-img
+                  :src="profile.avatar_url"
+                  :alt="displayName"
+                  format="webp"
+                  width="80"
+                  height="80"
+                  loading="lazy"
+                />
               </div>
             </div>
             <div v-else class="avatar avatar-placeholder">
@@ -193,14 +198,21 @@
               </div>
 
               <!-- Marketplace seller trust signals (flag-gated) -->
-              <ExchangeProfileSellerTrustSignals v-if="exchangeEnabled && profile?.id" :seller-id="profile.id" class="mt-4" />
+              <ExchangeProfileSellerTrustSignals
+                v-if="exchangeEnabled && profile?.id"
+                :seller-id="profile.id"
+                class="mt-4"
+              />
             </div>
           </div>
         </div>
       </div>
 
       <!-- Vehicles -->
-      <div v-if="profile?.show_vehicles && vehicles.length > 0" class="card bg-base-100 shadow-sm border border-base-300">
+      <div
+        v-if="profile?.show_vehicles && vehicles.length > 0"
+        class="card bg-base-100 shadow-sm border border-base-300"
+      >
         <div class="card-body">
           <div class="flex items-center">
             <i class="fad fa-car mr-2"></i>
@@ -296,7 +308,11 @@
     "vehicles": {
       "title": "Their Minis"
     },
-    "listings": {"title": "Active Listings", "count": "{count} listing | {count} listings", "empty": "This member hasn't posted any listings."},
+    "listings": {
+      "title": "Active Listings",
+      "count": "{count} listing | {count} listings",
+      "empty": "This member hasn't posted any listings."
+    },
     "gear_configs": {
       "title": "Gear Configurations",
       "empty": "No public configurations shared.",
@@ -322,7 +338,11 @@
     "vehicles": {
       "title": "Sus Minis"
     },
-    "listings": {"title": "Anuncios activos", "count": "{count} anuncio | {count} anuncios", "empty": "Este miembro no ha publicado ningún anuncio."},
+    "listings": {
+      "title": "Anuncios activos",
+      "count": "{count} anuncio | {count} anuncios",
+      "empty": "Este miembro no ha publicado ningún anuncio."
+    },
     "gear_configs": {
       "title": "Configuraciones de Engranajes",
       "empty": "No hay configuraciones públicas compartidas.",
@@ -348,7 +368,11 @@
     "vehicles": {
       "title": "Ses Minis"
     },
-    "listings": {"title": "Annonces actives", "count": "{count} annonce | {count} annonces", "empty": "Ce membre n'a publié aucune annonce."},
+    "listings": {
+      "title": "Annonces actives",
+      "count": "{count} annonce | {count} annonces",
+      "empty": "Ce membre n'a publié aucune annonce."
+    },
     "gear_configs": {
       "title": "Configurations d'Engrenages",
       "empty": "Aucune configuration publique partagée.",
@@ -374,7 +398,11 @@
     "vehicles": {
       "title": "Ihre Minis"
     },
-    "listings": {"title": "Aktive Inserate", "count": "{count} Inserat | {count} Inserate", "empty": "Dieses Mitglied hat noch keine Inserate veröffentlicht."},
+    "listings": {
+      "title": "Aktive Inserate",
+      "count": "{count} Inserat | {count} Inserate",
+      "empty": "Dieses Mitglied hat noch keine Inserate veröffentlicht."
+    },
     "gear_configs": {
       "title": "Getriebe-Konfigurationen",
       "empty": "Keine öffentlichen Konfigurationen geteilt.",
@@ -400,7 +428,11 @@
     "vehicles": {
       "title": "Le Sue Mini"
     },
-    "listings": {"title": "Annunci attivi", "count": "{count} annuncio | {count} annunci", "empty": "Questo membro non ha pubblicato alcun annuncio."},
+    "listings": {
+      "title": "Annunci attivi",
+      "count": "{count} annuncio | {count} annunci",
+      "empty": "Questo membro non ha pubblicato alcun annuncio."
+    },
     "gear_configs": {
       "title": "Configurazioni Ingranaggi",
       "empty": "Nessuna configurazione pubblica condivisa.",
@@ -426,7 +458,11 @@
     "vehicles": {
       "title": "Seus Minis"
     },
-    "listings": {"title": "Anúncios ativos", "count": "{count} anúncio | {count} anúncios", "empty": "Este membro não publicou nenhum anúncio."},
+    "listings": {
+      "title": "Anúncios ativos",
+      "count": "{count} anúncio | {count} anúncios",
+      "empty": "Este membro não publicou nenhum anúncio."
+    },
     "gear_configs": {
       "title": "Configurações de Engrenagens",
       "empty": "Nenhuma configuração pública compartilhada.",
@@ -452,7 +488,11 @@
     "vehicles": {
       "title": "Автомобили"
     },
-    "listings": {"title": "Активные объявления", "count": "{count} объявление | {count} объявлений", "empty": "Этот участник пока не разместил объявлений."},
+    "listings": {
+      "title": "Активные объявления",
+      "count": "{count} объявление | {count} объявлений",
+      "empty": "Этот участник пока не разместил объявлений."
+    },
     "gear_configs": {
       "title": "Конфигурации Передач",
       "empty": "Нет публичных конфигураций.",
@@ -478,7 +518,7 @@
     "vehicles": {
       "title": "所有車両"
     },
-    "listings": {"title": "出品中", "count": "出品 {count} 件", "empty": "このメンバーはまだ出品していません。"},
+    "listings": { "title": "出品中", "count": "出品 {count} 件", "empty": "このメンバーはまだ出品していません。" },
     "gear_configs": {
       "title": "ギア設定",
       "empty": "公開設定はありません。",
@@ -504,7 +544,7 @@
     "vehicles": {
       "title": "TA的Mini"
     },
-    "listings": {"title": "在售商品", "count": "{count} 件商品", "empty": "该会员还没有发布任何商品。"},
+    "listings": { "title": "在售商品", "count": "{count} 件商品", "empty": "该会员还没有发布任何商品。" },
     "gear_configs": {
       "title": "齿轮配置",
       "empty": "暂无公开配置。",
@@ -530,7 +570,11 @@
     "vehicles": {
       "title": "보유 차량"
     },
-    "listings": {"title": "판매 중인 매물", "count": "매물 {count}개", "empty": "이 회원은 아직 등록한 매물이 없습니다."},
+    "listings": {
+      "title": "판매 중인 매물",
+      "count": "매물 {count}개",
+      "empty": "이 회원은 아직 등록한 매물이 없습니다."
+    },
     "gear_configs": {
       "title": "기어 구성",
       "empty": "공개된 구성이 없습니다.",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -122,6 +122,10 @@ export default defineNuxtConfig({
         { rel: 'dns-prefetch', href: 'https://use.typekit.net' },
         { rel: 'preconnect', href: 'https://classicminidiy.s3.us-east-1.amazonaws.com', crossorigin: '' },
         { rel: 'dns-prefetch', href: 'https://classicminidiy.s3.us-east-1.amazonaws.com' },
+        // The bare virtual-hosted name is a separate origin to the browser and is the
+        // more common spelling in this codebase, so it needs its own hint.
+        { rel: 'preconnect', href: 'https://classicminidiy.s3.amazonaws.com', crossorigin: '' },
+        { rel: 'dns-prefetch', href: 'https://classicminidiy.s3.amazonaws.com' },
         { rel: 'preconnect', href: 'https://kit.fontawesome.com', crossorigin: '' },
         { rel: 'dns-prefetch', href: 'https://kit.fontawesome.com' },
         { rel: 'preconnect', href: 'https://ka-f.fontawesome.com', crossorigin: '' },
@@ -355,8 +359,26 @@ export default defineNuxtConfig({
   image: {
     // Provider options
     provider: 'ipx',
-    // Domains allowed for external images
-    domains: ['classicminidiy.s3.us-east-1.amazonaws.com', 'psoqirvbujwohemmwplv.supabase.co'],
+    // Domains allowed for external images.
+    //
+    // The main asset bucket is referenced by BOTH its regional and bare virtual-hosted
+    // names across the codebase (`classicminidiy.s3.amazonaws.com` is by far the more
+    // common spelling — ~230 call sites vs ~40 regional). @nuxt/image matches this
+    // allowlist on the literal hostname, so a miss means the URL is passed through
+    // untouched: no resize, no format conversion, even inside <nuxt-img>. Both spellings
+    // must be listed until the call sites are normalized onto one host.
+    // YouTube thumbnails (RecentVideos / links.vue) are served from i.ytimg.com. While
+    // that host was unlisted, <nuxt-picture> still emitted webp+avif <source> elements
+    // whose srcset entries were all the same untouched maxresdefault.jpg — declaring
+    // formats it did not serve and offering 3072w of a 1280px file.
+    domains: [
+      'classicminidiy.s3.us-east-1.amazonaws.com',
+      'classicminidiy.s3.amazonaws.com',
+      'cmdiy-archive.s3.us-east-1.amazonaws.com',
+      'psoqirvbujwohemmwplv.supabase.co',
+      'i.ytimg.com',
+      'img.youtube.com',
+    ],
     // Image formats to generate
     format: ['webp', 'avif', 'jpg', 'png'],
     // Default image quality
@@ -855,7 +877,11 @@ export default defineNuxtConfig({
       // Customize caching strategies
       runtimeCaching: [
         {
-          urlPattern: /^https:\/\/classicminidiy\.s3\.us-east-1\.amazonaws\.com\/.*/i,
+          // Matches the asset bucket under both its regional and bare virtual-hosted
+          // names, and the archive bucket. Keep in sync with `image.domains` above —
+          // a host that resolves images but isn't matched here silently loses offline
+          // caching for every raw <img> still pointed straight at S3.
+          urlPattern: /^https:\/\/(?:classicminidiy|cmdiy-archive)\.s3\.(?:us-east-1\.)?amazonaws\.com\/.*/i,
           handler: 'CacheFirst',
           options: {
             cacheName: 's3-assets',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -700,7 +700,20 @@ export default defineNuxtConfig({
       // build). nitro matches ignore patterns with String.startsWith, so these
       // are PREFIXES (trailing slash) — they catch `/archive/colors/<id>` but not
       // the prerendered index `/archive/colors` itself.
-      ignore: ['/admin', '/raw', '/archive/colors/', '/archive/wheels/', '/archive/documents/'],
+      // `/_ipx` is load-bearing for build memory, not just speed. ipx is a RUNTIME
+      // optimizer, but crawlLinks doesn't know that: it follows same-origin hrefs/srcs
+      // out of prerendered pages, and once images resolve through the optimizer their
+      // URLs become same-origin `/_ipx/...` paths instead of absolute S3/Supabase URLs
+      // (which, being external, were never crawled). Every crawled variant then
+      // downloads a remote image and transcodes it through sharp DURING the build.
+      //
+      // That is pure waste — the variants are regenerated at runtime anyway and cached
+      // at the edge for 7 days (`s-maxage=604800`), and prerendering user-generated
+      // content can't cover photos uploaded after the build. It also cost a deploy:
+      // sharp's native allocations inflate RSS through the prerender phase, and the
+      // Nitro bundling step that follows then couldn't fit in the 8 GB build container
+      // and was SIGKILLed by the OOM killer.
+      ignore: ['/admin', '/raw', '/archive/colors/', '/archive/wheels/', '/archive/documents/', '/_ipx'],
       routes: [
         '/',
         '/privacy',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -375,6 +375,13 @@ export default defineNuxtConfig({
       'classicminidiy.s3.us-east-1.amazonaws.com',
       'classicminidiy.s3.amazonaws.com',
       'cmdiy-archive.s3.us-east-1.amazonaws.com',
+      // Supabase Storage is reached through the CUSTOM auth domain, not the project-ref
+      // host: `NUXT_PUBLIC_SUPABASE_URL` is https://auth.classicminidiy.com, and
+      // `storage.getPublicUrl()` builds every URL from it. The project-ref entry below
+      // therefore matches nothing in practice — it is kept only so a deploy that points
+      // NUXT_PUBLIC_SUPABASE_URL back at the raw host keeps working. Without the custom
+      // domain listed, every listing photo, model image and avatar bypassed ipx.
+      'auth.classicminidiy.com',
       'psoqirvbujwohemmwplv.supabase.co',
       'i.ytimg.com',
       'img.youtube.com',
@@ -892,7 +899,10 @@ export default defineNuxtConfig({
           },
         },
         {
-          urlPattern: /^https:\/\/psoqirvbujwohemmwplv\.supabase\.co\/storage\/.*/i,
+          // Same custom-domain caveat as `image.domains`: storage URLs are built from
+          // NUXT_PUBLIC_SUPABASE_URL (auth.classicminidiy.com), so the project-ref host
+          // alone cached nothing. Match both.
+          urlPattern: /^https:\/\/(?:auth\.classicminidiy\.com|psoqirvbujwohemmwplv\.supabase\.co)\/storage\/.*/i,
           handler: 'CacheFirst',
           options: {
             cacheName: 'supabase-storage',


### PR DESCRIPTION
Sweep of images bypassing `@nuxt/image`. Scoped out of the giveaway-carousel work, where the same gap was found and fixed for one component.

Three distinct classes of problem, all verified against a dev server with before/after byte counts.

## 1. Domain allowlist misses — the biggest single win

`image.domains` listed only the **regional** bucket host, but ~230 call sites use the bare `classicminidiy.s3.amazonaws.com` spelling (vs ~40 regional). `@nuxt/image` matches the allowlist on the literal hostname, so every one of those was passed through untouched — no resize, no format conversion, **even when already wrapped in `<nuxt-img>`**.

Three more hosts were missing entirely:

- **`auth.classicminidiy.com`** — the custom Supabase domain. See below; this was the single most consequential miss.
- `cmdiy-archive.s3.us-east-1.amazonaws.com` — archive document/collection card images.
- `i.ytimg.com` — YouTube thumbnails on `/links` and `RecentVideos`.

### The Supabase entry was dead config

`image.domains` carried `psoqirvbujwohemmwplv.supabase.co`, so Supabase Storage *looked* allowlisted. It isn't. `supabase.storage.getPublicUrl()` builds every URL from `NUXT_PUBLIC_SUPABASE_URL`, which is `https://auth.classicminidiy.com` — the custom domain. The project-ref entry **matches nothing in practice**, so every listing photo, model image and avatar was passed through untouched, *even after being converted to `<nuxt-img>`*.

This only surfaced by rendering a real 31-photo listing rather than trusting the config: the page emitted **1** ipx image before the fix and **64** after. Kept the project-ref entry so a deploy that points `NUXT_PUBLIC_SUPABASE_URL` back at the raw host still works. The PWA storage `runtimeCaching` pattern had the identical dead-host bug and is fixed the same way.

The ytimg case was **worse than a plain pass-through**. `<nuxt-picture>` still emitted `webp`, `avif`, `jpg` and `png` `<source>` elements, but every srcset entry in all four was the identical untouched `maxresdefault.jpg` — declaring content types it did not serve, and offering a `3072w` candidate for a 1280px file. Now it emits exactly one real webp source.

**Allowlist vs. normalizing call sites.** I added both spellings rather than rewriting ~230 call sites. It is a one-line change that takes effect immediately across the whole codebase, with no risk to OG image URLs or the PWA regex. Normalizing onto a single host is a worthwhile mechanical cleanup but it is a separate, larger diff and it is not what unblocks the perf win. Checked `seoTagGuards` — it is host-agnostic, no dependency on the exact string.

Reconciled the two places that carried the same regional-only assumption:
- PWA `runtimeCaching` `urlPattern` now matches both spellings plus the archive bucket.
- Added `preconnect`/`dns-prefetch` for the bare host (a separate origin to the browser, and the more common one here).

## 2. Raw `<img>` tags

Converted the public, image-heavy surfaces — 27 files. Highest-value was `PhotoGallery.vue` (marketplace hero, thumbnail strip, lightbox); the thumbnail strip renders at 64–80px but was downloading the full-size upload.

Also: listing/model/archive card grids, wheel grid, profile avatars, ECU logos, needle diagram, engine-plate carousel.

**Deliberately left as raw `<img>`:**
- `app/pages/admin/**` — internal tooling behind auth, no meaningful traffic, and converting it is pure diff noise.
- `blob:`/`data:` upload previews (`WheelSubmit`, `MessageComposer`, `FileUpload`, `models/upload`, `AvatarUpload`) — nothing to optimize.
- `exchange/finds/FindCard.vue` — its `og_image_url` is scraped from arbitrary third-party sites (bringatrailer, minimania, …). Those hosts cannot be allowlisted, so a conversion would be a no-op pass-through while losing the existing `@error` fallback.
- `OgImage/ModelCard.takumi.vue` — takumi OG renderer, not a browser context.

Also replaced **six hand-rolled `<picture>` blocks** whose `<source>` srcsets pointed straight at S3. The browser always took the raw asset, so the `<nuxt-img>` fallback nested inside them never rendered at all.

## 3. `<NuxtImg>` was not requesting a modern format

`nuxt.config` sets `format: ['webp','avif','jpg','png']`, but that list only applies to `<NuxtPicture>`. `<NuxtImg>` emits a single `<img>` in the **source** format unless given an explicit `format` prop — so every `<nuxt-img>` on the site was serving JPEG/PNG. Added `format="webp"` throughout.

Chose webp explicitly over inheriting the config list, per the brief: avif measured barely better than jpeg on detailed photos at q80 and is far slower to encode on a cold serverless path.

## Measurements

Isolating the three states on the `/links` avatar shows the allowlist is the dominant factor and webp compounds it:

| state | bytes | type |
|---|---|---|
| today (pass-through) | 172,585 | jpeg |
| allowlist fix only | 4,022 | jpeg |
| allowlist + `format="webp"` | **2,314** | webp |

Representative sample:

| asset | before | after | saving |
|---|---:|---:|---:|
| links/about avatar @240 | 172,585 | 2,314 | −98.7% |
| wheel user upload @300 | 1,134,616 | 15,400 | −98.6% |
| card icon @128 | 26,301 | 3,768 | −85.7% |
| ECU logo @320 | 16,320 | 3,118 | −80.9% |
| YouTube maxres @720 | 202,812 | 44,402 | −78.1% |
| MainNav logo @256 (2x) | 37,351 | 9,178 | −75.4% |
| archive doc card @400 | 5,729 | 1,434 | −75.0% |
| engine plate example @672 | 199,632 | 56,180 | −71.9% |
| SU needle diagram @768 | 54,848 | 28,158 | −48.7% |

**Real marketplace listing** (`/exchange/listings/1978-mini-se-special-edition-d18ff260`, 31 photos) — the highest-value target in the sweep. Lightbox images are excluded from "first load": they are lazy inside a closed `<dialog>` and only download when opened.

| | before | after | saving |
|---|---:|---:|---:|
| thumbnail strip (31 @80px, 2x) | 7.32 MB | 153 KB | **−98.0%** |
| hero @1024 | 527,938 | 148,040 | −72.0% |
| **first-load total** | **7.82 MB** | **297 KB** | **−96.3%** |

Page totals (all images on first load):

| page | before | after | saving |
|---|---:|---:|---:|
| `/links` | 2.20 MB | 467 KB | **−78.8%** (1.7 MB saved) |
| `/about` | 209,936 | 4,056 | −98.1% |
| `/archive/registry` | 70,565 | 5,244 | −92.6% |
| `/technical/needles` | 37,351 | 3,130 | −91.6% |
| `/technical/engine-decoder` | 2.34 MB | 317 KB | −86.5% |
| `/maps` | 105,289 | 39,612 | −62.4% |
| `/archive/wheels` | 336,051 | 167,404 | −50.2% |

## Build memory: `/_ipx` must not be prerendered

The first push of this branch OOM-killed a Vercel build, and the cause was a genuine
side-effect of optimizing the images — just not where it looked.

Nitro's prerenderer runs with `crawlLinks: true`, following same-origin URLs out of
prerendered pages. **An unoptimized image is an absolute S3/Supabase URL — external, so never
crawled. An optimized one is a same-origin `/_ipx/...` path.** So the moment images started
resolving through the optimizer, the crawler began treating every variant as a route to
prerender: downloading a remote image and transcoding it through sharp at build time.

Measured A/B on an identical tree, one line different:

| | baseline | with `/_ipx` ignored |
|---|---:|---:|
| routes prerendered | 768 | **165** |
| of which `/_ipx` | **603** | 0 |
| prerender time | 47.8s | 35.9s |
| peak RSS | 4.31 GB | 3.61 GB |

78% of prerendered routes were image variants. The local 768 matches the failed Vercel
build's 768 exactly, so this reproduces it faithfully.

That work was waste even when it succeeded: ipx regenerates variants at runtime and the CDN
holds them 7 days (`s-maxage=604800`), and prerendering user-generated content can't cover
photos uploaded after the build.

**Why it was confusing, worth recording:** the `SIGKILL` landed during Nitro *bundling*, well
after prerender reported success — and it first tripped on a **docs-only commit** that cannot
affect the build. `SIGKILL` is the container OOM killer, not a V8 heap error. sharp's native
allocations inflate RSS across the prerender phase and aren't promptly returned, so the
bundling step that follows couldn't fit in the 8 GB container.

**Separately, worth your call (not changed here):** `vercel.json` sets
`--max-old-space-size=6144` on an 8 GB build machine. That ceiling governs V8's old space
only — sharp, rolldown and better-sqlite3 allocate natively on top, so it permits total RSS to
approach the container limit rather than protecting against it. Counter-intuitively, *lowering*
it makes V8 collect earlier and can prevent a container SIGKILL. With `/_ipx` no longer
prerendered the build should have real headroom again, so I'd suggest reverting the elastic
build machine and seeing whether standard now passes consistently before tuning the flag.

## Verification

- `bun run test -- --exclude '**/.claude/**'` — **148 files / 4,674 tests pass**.
- **Full production build passes locally** (`bun run build`), peak RSS 3.61 GB.
- All touched routes return 200 with zero raw-S3 `<img>` remaining and images served through `/_ipx/`.
- Browser check on `/technical/gearing`: no console errors; logo and converted card icon load at correct natural dimensions (128×37 and 64×64 for their render sizes).
- **Real 31-photo listing rendered end-to-end**: HTTP 200, hero visible and correctly proportioned, category tabs intact, `data-testid="hero-image"` + all 31 `thumbnail-{n}` + `lightbox-modal` present, and **zero** `<img>` whose `src` is a raw storage URL. Transform params confirmed correct — thumbnails at `s_160x160` (2x of 80px), not full-size.
- `PhotoGallery.vue` `data-testid` attributes preserved exactly. Worth flagging: **no test in the repo currently references them** — the suite is composables/utils/data only, with no component-mounting tests, so nothing currently enforces that constraint. They were preserved regardless, and using `<nuxt-img>` (single `<img>`) rather than `<nuxt-picture>` keeps them on the image element rather than a `<picture>` wrapper.
- Two console errors on the listing page were checked and are **pre-existing, not from this PR**: a hydration class mismatch in `ExchangeProfileSellerTrustSignals` (a fallthrough `class="mt-3"`, untouched here) and a local-only `/api/exchange-rates` 404.

## Gotchas applied

Per the brief, and why `<nuxt-img>` was chosen over `<nuxt-picture>` for most conversions: `<NuxtPicture>` puts fallthrough `class`/`data-testid`/`@error` on the `<picture>` root, not the inner `<img>` — which silently breaks `object-cover` (a `display:inline` picture falls back to `object-fit: fill`, squashing instead of cropping) and means `@error` never fires. `<NuxtImg>` renders a single `<img>`, so every existing attribute keeps working unchanged. `<nuxt-picture format="webp">` is used only where a real format-fallback chain is wanted (YouTube thumbnails).

Sizing: fixed `width`/`height` where the element crops (`object-cover` thumbnails, avatars); `sizes` only where aspect must be preserved (`object-contain` photos of unknown ratio) — the existing `aspect-*` classes already reserve the box, so no CLS is introduced either way.

---

## Evaluated, not changed: `provider: 'ipx'` vs Vercel Image Optimization

`nuxt.config` explicitly sets `provider: 'ipx'`, which overrides the `vercel` provider `@nuxt/image` would otherwise auto-select on deploy.

**How they differ in cost.** ipx runs sharp inside the Nitro function, so it bills as Fluid Compute — Active CPU, memory, invocations. Vercel's native optimizer is CDN-level with no function invocation, but bills per **unique source image transformed** per month (not per variant).

**The decisive fact for this repo:** ipx responses carry `cache-control: public, max-age=604800, s-maxage=604800`. Vercel's CDN holds each transformed variant at the edge for 7 days, so the function only runs on a genuine miss. That bounds ipx's cost to *traffic against uncached variants*, not to catalog size.

Meanwhile this repo's image set is dominated by **unbounded user-generated content** — marketplace listing photos, wheel uploads, the model library, avatars, registry submissions, ~299 archive colors, on top of 118 distinct static assets. Vercel's per-source-image billing maps that growing catalog directly onto a growing monthly bill, and the long tail of it is low-traffic archive content that would each still count as a transformed source.

**Recommendation: stay on ipx.**

One honest caveat on quantifying this further: a precise cost comparison isn't obtainable *before* this PR, because ipx was barely being invoked — the allowlist misses meant most images never reached it. **This PR is what creates the load.** So the meaningful next step is to check Vercel function metrics filtered to `/_ipx/**` once this has been live for a week or two; CPU-seconds and invocation count there are exactly the inputs to the comparison, and they'll finally be real. Worth revisiting if `/_ipx/**` CPU time becomes a visible line item, or if the catalog stabilizes while traffic grows enough to flip the arithmetic.

## Follow-ups worth their own PRs
- Normalize the ~230 bare-host call sites onto the regional host (mechanical; would let the allowlist and preconnect hints drop back to one entry each).
- `Hero.vue` sets hero images as CSS `background-image`, which `@nuxt/image` cannot touch. Those are large above-the-fold JPEGs on most pages — converting them to a real `<img>`/`<picture>` layer is a genuine win but a visual-layout change, so it wants its own PR and review.
- `PatreonCard.vue` emits `srcset` with identical 1x/2x candidates and no `src` (pre-existing, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
