### PR TITLE
chore(icons): remove @nuxt/icon and the unused Iconify collections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,18 @@ straight into `:class`, so it must be `'fas fa-circle-check'`, never `'i-fa6-sol
 - `app/components/Breadcrumb.vue` uses the string as a sentinel value and renders
   `<i class="fas fa-house">` explicitly.
 
+Both exceptions are **pure string manipulation** — they emit an FA class for the Kit to swap and
+never resolve Iconify icon *data*. That is why the `@iconify-json/*` collections could be dropped
+along with `@nuxt/icon` (the transition-only module for the TME merge) once the last `<Icon>` tag
+was converted. Nothing in `app/` renders `<Icon>` or needs an Iconify collection; don't re-add one
+to "support" these two files.
+
+**Gotcha:** `@nuxt/icon` and `@iconify-json/carbon` are still physically present in
+`node_modules` as transitive deps of `nuxtseo-layer-devtools` → `@nuxt/ui` (the `@nuxtjs/seo`
+devtools layer). Their presence on disk is **not** evidence the site uses them — the module is not
+in `nuxt.config.ts`'s `modules` array, so it never runs, and `@nuxt/ui` being reachable in
+`node_modules` still does not mean `<U*>` components exist here.
+
 #### Inline Icons
 
 For inline icons in templates, use the traditional Font Awesome class syntax:

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "@aws-sdk/s3-request-presigner": "^3.1090.0",
         "@fontsource/outfit": "^5.3.0",
         "@langchain/langgraph-sdk": "^1.9.27",
-        "@nuxt/icon": "^2.3.1",
         "@nuxt/scripts": "^1.3.1",
         "@nuxtjs/mcp-toolkit": "^0.18.0",
         "@nuxtjs/seo": "^5.3.2",
@@ -55,11 +54,6 @@
         "vuedraggable": "^4.1.0",
       },
       "devDependencies": {
-        "@iconify-json/fa6-brands": "^1.2.6",
-        "@iconify-json/fa6-regular": "^1.2.4",
-        "@iconify-json/fa6-solid": "^1.2.4",
-        "@iconify-json/heroicons": "^1.2.3",
-        "@iconify-json/lucide": "^1.2.118",
         "@nuxt/image": "^2.0.0",
         "@nuxtjs/fontaine": "^0.5.0",
         "@nuxtjs/i18n": "^10.4.1",
@@ -485,17 +479,7 @@
 
     "@iconify-json/carbon": ["@iconify-json/carbon@1.2.23", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-7apXetbRmEiWDXIQyikFJZyq7pCVBKHYRzmeLdtT7wWoHYdWHwnFcBAzpuLoSh+ZEAfXZapSWEe8iuS6dUqf+Q=="],
 
-    "@iconify-json/fa6-brands": ["@iconify-json/fa6-brands@1.2.6", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-twL3X4KWcxAhbc1vz/mIDsVr+CAItk1/EIfxKUVQtpv6O4eydk5KNYqTZWdvJNHGInUgd6vKg21aWfVgb5DXEg=="],
-
-    "@iconify-json/fa6-regular": ["@iconify-json/fa6-regular@1.2.4", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-fnUS/MLj3ZAp29oRsC8/aY8Wau7NIg7VesTz3jCcE6VJBzcz95Yxp/Dl5yHvkP+aQxrNw5Lj3nrOXB4nQh+oNA=="],
-
-    "@iconify-json/fa6-solid": ["@iconify-json/fa6-solid@1.2.4", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-LmDNNdJVyvF5mPm1yxWvL8KjCc/E8LzoqnF1LNTVpyY2ZJRUlGOWuPIThdbuFBF2IovgttkIyumhyqfmlHdwKg=="],
-
-    "@iconify-json/heroicons": ["@iconify-json/heroicons@1.2.3", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-n+vmCEgTesRsOpp5AB5ILB6srsgsYK+bieoQBNlafvoEhjVXLq8nIGN4B0v/s4DUfa0dOrjwE/cKJgIKdJXOEg=="],
-
-    "@iconify-json/lucide": ["@iconify-json/lucide@1.2.118", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-JBnK4YOq6K/lA0JP//27QxFxJ4120TjvfXAzGZZIGjCcXcRRRFxl1rcV7+IWdcVCe90KXdqVaAwLaLf6G3HELw=="],
-
-    "@iconify/collections": ["@iconify/collections@1.0.711", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-atGUurchVFc/O3fHhpDCrPAe30TLEbWBDkuM5ZXjr0720rLpVNTqydyvMxQS3lt5kvIwrYgHqLInZ1F26y9n5A=="],
+    "@iconify/collections": ["@iconify/collections@1.0.696", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-k06LxE/f1o3Tuj/n+ugiCyyq6CGxUG+k8o5ZZbOgVBHvpHiAWDDvZvdOSLNC8zeISRJhhiD04FkDKP7zk63fxQ=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -647,7 +631,7 @@
 
     "@nuxt/fonts": ["@nuxt/fonts@0.14.0", "", { "dependencies": { "@nuxt/devtools-kit": "^3.2.1", "@nuxt/kit": "^4.2.2", "consola": "^3.4.2", "defu": "^6.1.4", "fontless": "^0.2.1", "h3": "^1.15.5", "magic-regexp": "^0.10.0", "ofetch": "^1.5.1", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "ufo": "^1.6.3", "unifont": "^0.7.4", "unplugin": "^3.0.0", "unstorage": "^1.17.4" } }, "sha512-4uXQl9fa5F4ibdgU8zomoOcyMdnwgdem+Pi8JEqeDYI5yPR32Kam6HnuRr47dTb97CstaepAvXPWQUUHMtjsFQ=="],
 
-    "@nuxt/icon": ["@nuxt/icon@2.3.1", "", { "dependencies": { "@iconify/collections": "^1.0.702", "@iconify/types": "^2.0.0", "@iconify/utils": "^3.1.3", "@iconify/vue": "^5.0.1", "@nuxt/devtools-kit": "^3.2.4", "@nuxt/kit": "^4.4.8", "consola": "^3.4.2", "local-pkg": "^1.2.1", "mlly": "^1.8.2", "ohash": "^2.0.11", "picomatch": "^4.0.4", "std-env": "^4.1.0", "tinyglobby": "^0.2.17", "ufo": "^1.6.4" } }, "sha512-ebx7Zp08eR0Mw3zFAh3aT+t5zC4RoI0Xf0wLEfbv23LIPUQ9fvxYpofNiNZdG9m96Fvc3pQu6v+NaCRbRYRRog=="],
+    "@nuxt/icon": ["@nuxt/icon@2.2.3", "", { "dependencies": { "@iconify/collections": "^1.0.691", "@iconify/types": "^2.0.0", "@iconify/utils": "^3.1.3", "@iconify/vue": "^5.0.1", "@nuxt/devtools-kit": "^3.2.4", "@nuxt/kit": "^4.4.6", "consola": "^3.4.2", "local-pkg": "^1.2.1", "mlly": "^1.8.2", "ohash": "^2.0.11", "picomatch": "^4.0.4", "std-env": "^4.1.0", "tinyglobby": "^0.2.17", "ufo": "^1.6.4" } }, "sha512-2HWDoMRWGSOWl7fu8wvvLTjoiaEwM7tSDww+6n4yVrNzKJFNAOLpYB9UevEf0CrK32q2JuA7TZnVpdwiPPdQSQ=="],
 
     "@nuxt/image": ["@nuxt/image@2.0.0", "", { "dependencies": { "@nuxt/kit": "^4.2.0", "consola": "^3.4.2", "defu": "^6.1.4", "h3": "^1.15.4", "image-meta": "^0.2.2", "knitwork": "^1.2.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "std-env": "^3.10.0", "ufo": "^1.6.1" }, "optionalDependencies": { "ipx": "^3.1.1" } }, "sha512-otHi6gAoYXKLrp8m27ZjX1PjxOPaltQ4OiUs/BhkW995mF/vXf8SWQTw68fww+Uric0v+XgoVrP9icDi+yT6zw=="],
 
@@ -3597,9 +3581,11 @@
 
     "@nuxt/fonts/unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
 
-    "@nuxt/icon/@nuxt/kit": ["@nuxt/kit@4.5.0", "", { "dependencies": { "c12": "^3.3.4", "consola": "^3.4.2", "defu": "^6.1.7", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.1.0", "ignore": "^7.0.6", "jiti": "^2.7.0", "klona": "^2.0.6", "mlly": "^1.8.2", "nostics": "^1.1.4", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.1", "rc9": "^3.0.1", "scule": "^1.3.0", "semver": "^7.8.5", "tinyglobby": "^0.2.17", "ufo": "^1.6.4", "unctx": "^3.0.0", "untyped": "^2.0.0" } }, "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng=="],
+    "@nuxt/icon/@nuxt/kit": ["@nuxt/kit@4.4.8", "", { "dependencies": { "c12": "^3.3.4", "consola": "^3.4.2", "defu": "^6.1.7", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.8", "ignore": "^7.0.5", "jiti": "^2.7.0", "klona": "^2.0.6", "mlly": "^1.8.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.1", "rc9": "^3.0.1", "scule": "^1.3.0", "semver": "^7.8.1", "tinyglobby": "^0.2.17", "ufo": "^1.6.4", "unctx": "^2.5.0", "untyped": "^2.0.0" } }, "sha512-ZUlZ5iYfyfJFDPluhn6ZxFWcsuxWbLnZBc8w3MAROcQ4lYfZ+qFpALBLSNlpc0zhOa++33EE+5PEbOAdVIY+dw=="],
 
-    "@nuxt/icon/std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+    "@nuxt/icon/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "@nuxt/icon/std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "@nuxt/icon/ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
@@ -3650,8 +3636,6 @@
     "@nuxt/telemetry/rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
     "@nuxt/telemetry/std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
-
-    "@nuxt/ui/@nuxt/icon": ["@nuxt/icon@2.2.3", "", { "dependencies": { "@iconify/collections": "^1.0.691", "@iconify/types": "^2.0.0", "@iconify/utils": "^3.1.3", "@iconify/vue": "^5.0.1", "@nuxt/devtools-kit": "^3.2.4", "@nuxt/kit": "^4.4.6", "consola": "^3.4.2", "local-pkg": "^1.2.1", "mlly": "^1.8.2", "ohash": "^2.0.11", "picomatch": "^4.0.4", "std-env": "^4.1.0", "tinyglobby": "^0.2.17", "ufo": "^1.6.4" } }, "sha512-2HWDoMRWGSOWl7fu8wvvLTjoiaEwM7tSDww+6n4yVrNzKJFNAOLpYB9UevEf0CrK32q2JuA7TZnVpdwiPPdQSQ=="],
 
     "@nuxt/ui/@nuxt/kit": ["@nuxt/kit@4.4.8", "", { "dependencies": { "c12": "^3.3.4", "consola": "^3.4.2", "defu": "^6.1.7", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.8", "ignore": "^7.0.5", "jiti": "^2.7.0", "klona": "^2.0.6", "mlly": "^1.8.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.1", "rc9": "^3.0.1", "scule": "^1.3.0", "semver": "^7.8.1", "tinyglobby": "^0.2.17", "ufo": "^1.6.4", "unctx": "^2.5.0", "untyped": "^2.0.0" } }, "sha512-ZUlZ5iYfyfJFDPluhn6ZxFWcsuxWbLnZBc8w3MAROcQ4lYfZ+qFpALBLSNlpc0zhOa++33EE+5PEbOAdVIY+dw=="],
 
@@ -4711,9 +4695,13 @@
 
     "@nuxt/icon/@nuxt/kit/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
+    "@nuxt/icon/@nuxt/kit/exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "@nuxt/icon/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
     "@nuxt/icon/@nuxt/kit/rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
-    "@nuxt/icon/@nuxt/kit/unctx": ["unctx@3.0.0", "", { "peerDependencies": { "magic-string": ">=0.30.21", "oxc-parser": ">=0.140.0", "rolldown": "^1.1.5", "unplugin": "^3.3.0" }, "optionalPeers": ["magic-string", "oxc-parser", "rolldown", "unplugin"] }, "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA=="],
+    "@nuxt/icon/@nuxt/kit/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "@nuxt/kit/mlly/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -4782,12 +4770,6 @@
     "@nuxt/scripts/oxc-walker/magic-regexp": ["magic-regexp@0.11.0", "", { "dependencies": { "magic-string": "^0.30.21", "regexp-tree": "^0.1.27", "type-level-regexp": "~0.1.17", "unplugin": "^3.0.0" } }, "sha512-LG77Z/gVnwz7oaDpD4heX6ryl+lcr4l1B2gnP4MMvt2pGhGC1Dfj7dl1pXpP4ih+VQFLuAadeKVa+lARAzfW+Q=="],
 
     "@nuxt/telemetry/rc9/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
-    "@nuxt/ui/@nuxt/icon/@iconify/collections": ["@iconify/collections@1.0.696", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-k06LxE/f1o3Tuj/n+ugiCyyq6CGxUG+k8o5ZZbOgVBHvpHiAWDDvZvdOSLNC8zeISRJhhiD04FkDKP7zk63fxQ=="],
-
-    "@nuxt/ui/@nuxt/icon/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "@nuxt/ui/@nuxt/icon/std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "@nuxt/ui/@nuxt/kit/c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
 
@@ -5968,8 +5950,6 @@
     "@nuxt/fonts/magic-regexp/unplugin/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "@nuxt/icon/@nuxt/kit/c12/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
-
-    "@nuxt/icon/@nuxt/kit/c12/exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
     "@nuxt/icon/@nuxt/kit/c12/giget": ["giget@3.2.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A=="],
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -299,14 +299,6 @@ export default defineNuxtConfig({
     // Do NOT also list those sub-modules here (double-registration / version skew).
     '@nuxtjs/seo',
     '@nuxt/image',
-    // TRANSITION-ONLY (tme-merge): @nuxt/icon renders The Mini Exchange's
-    // ~700 <Icon name="i-heroicons-*"> tags so migrated marketplace components
-    // work unchanged the moment they're copied in. Icons get converted to the
-    // site-standard Font Awesome 6 (<i class="fas fa-*">) per-component across
-    // stages 3-7; this module + @iconify-json/heroicons are removed before
-    // cutover so CMDIY stays FA6-exclusive. Coexists with the FA Kit (FA
-    // converts <i> tags; @nuxt/icon renders <Icon>).
-    '@nuxt/icon',
     'nuxt-llms',
     '@nuxtjs/i18n',
     '@nuxtjs/mcp-toolkit',

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/s3-presigned-post": "^3.1090.0",
     "@aws-sdk/s3-request-presigner": "^3.1090.0",
     "@fontsource/outfit": "^5.3.0",
-    "@nuxt/icon": "^2.3.1",
     "@vueuse/core": "^14.3.0",
     "bad-words": "^4.1.3",
     "browser-image-compression": "^2.0.2",
@@ -97,11 +96,6 @@
     "vue-cookie-law": "^1.13.3"
   },
   "devDependencies": {
-    "@iconify-json/fa6-brands": "^1.2.6",
-    "@iconify-json/fa6-regular": "^1.2.4",
-    "@iconify-json/fa6-solid": "^1.2.4",
-    "@iconify-json/heroicons": "^1.2.3",
-    "@iconify-json/lucide": "^1.2.118",
     "@nuxt/image": "^2.0.0",
     "@nuxtjs/fontaine": "^0.5.0",
     "@nuxtjs/i18n": "^10.4.1",


### PR DESCRIPTION
## What

Removes the `@nuxt/icon` module and the five unused Iconify collections, completing a cleanup the config itself scoped as temporary.

`nuxt.config.ts` registered `@nuxt/icon` with a comment marking it **TRANSITION-ONLY (tme-merge)** — it existed to render The Mini Exchange's ~700 `<Icon name="i-heroicons-*">` tags so migrated marketplace components worked unchanged, with the module and `@iconify-json/heroicons` to be *"removed before cutover so CMDIY stays FA6-exclusive."* The conversion finished and the marketplace cutover completed 2026-07-13; the cleanup never happened.

Removed:
- `'@nuxt/icon'` from the `modules` array, plus the now-obsolete transition comment
- `@nuxt/icon` from `dependencies`
- `@iconify-json/heroicons` and `@iconify-json/lucide` — precisely the libraries the FA6-exclusive rule forbids
- `@iconify-json/fa6-solid`, `@iconify-json/fa6-regular`, `@iconify-json/fa6-brands` — see verification below

## Why the fa6 collections went too

These were flagged to keep, pending verification. Verified they are unreferenced:

- `app/pages/models/index.vue` regex-parses `^i-fa6-(solid|regular|brands)-(.+)$` and returns a **class string**, bound as `<i :class="faIcon(cat.icon)">`
- `app/components/Breadcrumb.vue` compares against `'i-fa6-solid-house'` as a **sentinel** and renders `<i class="fas fa-house">` explicitly

Both are pure string manipulation producing an FA class for the Kit to swap — neither resolves Iconify icon *data*. `@nuxt/icon` was their only consumer. The OG image template (`OgImage/ModelCard.takumi.vue`) uses no icons either. **Neither file is modified by this PR.**

Repo-wide greps: zero `<Icon>`/`<NuxtIcon>` tags, zero `i-heroicons-*`/`i-lucide-*` strings in source. (`useToast.ts#normalizeIcon` maps legacy `i-heroicons-` strings to FA classes defensively — string-only, no package dependency, left in place.)

## Bundle delta

| | main | this PR | delta |
|---|---|---|---|
| Nitro total | 46.4 MB | **42.6 MB** | **−3.8 MB** |
| gzip | 16.7 MB | **15.7 MB** | **−1.0 MB** |
| `.output/server` | 51,456 KB | 47,548 KB | −3,908 KB |
| `.output/public/_nuxt` | 22,104 KB | 22,072 KB | −32 KB |

The server bundle loses six `icons*.mjs` chunks (~3.9 MB) plus the bundled `@iconify/vue` and `@iconify/utils` runtime. Client `_nuxt` is essentially unchanged — expected, since nothing rendered `<Icon>`. After the build, `find .output -iname "*icon*"` (excluding favicons) returns nothing.

## Verification

- `bun install` from a **clean** `node_modules` — confirms the collections are genuinely gone, not just un-pruned
- `bun run build` succeeds; error and warning counts are **identical to a baseline build of `main`** (1 error / 4 postcss warnings). The `/contribute/wheels` "Archive document not found" prerender error is pre-existing on `main`
- `bun run test -- --exclude '**/.claude/**'` — **148 files / 4674 tests pass**
- Dev-server smoke test on `/`, `/technical`, `/models`, `/exchange`: every `<i>` tag carries a valid FA prefix, **zero** elements left in Iconify form, zero stray `<icon>`/`.iconify` elements. `/models` category icons (couch, car, gears, bolt, gauge, …) and the breadcrumb `fas fa-house` both render. Only console error is the pre-existing `/api/exchange-rates` 404

## Note

`@nuxt/icon` and `@iconify-json/carbon` remain in `node_modules` as **transitive** deps of `nuxtseo-layer-devtools` → `@nuxt/ui` (the `@nuxtjs/seo` devtools layer). The module is no longer in `modules`, so it never runs. Documented this gotcha in `CLAUDE.md` so their presence on disk isn't later mistaken for the site using them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)