### PR TITLE
fix(images): stop pinning the ipx provider — it 404s every local image on Vercel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,33 @@ For inline icons in templates, use the traditional Font Awesome class syntax:
 
 - **There is deliberately NO FAQPage JSON-LD, and no visible FAQ block, on the technical pages.** Google requires FAQ markup to match content that is *visible* on the page, and a visible Q&A section was judged to add nothing for human readers on pages that are already spec tables. Shipping the schema without its on-page counterpart is a structured-data policy violation, so the project ships **neither**: `app/utils/geo/generateFaqs.ts` now feeds only `server/plugins/llms-faq.ts` → **`/llms-full.txt`**, which is the legitimate machine-readable channel (it isn't the page, so it isn't cloaking). Both halves or neither — don't re-add FAQPage schema without rendering the questions.
 
+### Image Optimization Invariants
+
+- **Never set `image.provider` in `nuxt.config.ts`.** Leaving it unset (`'auto'`) is
+  load-bearing: `@nuxt/image` resolves the provider from `std-env`'s deployment detection —
+  Vercel's native optimizer in production, `ipx` locally. Pinning it to `'ipx'` broke every
+  LOCAL image under `public/` in production with `[404] [IPX_FILE_NOT_FOUND]`
+  (upstream: nuxt/image#1281): ipx resolves local paths with a **filesystem** read, but on
+  Vercel `public/` ships to the CDN static output and is absent from the serverless function's
+  filesystem. Remote images were unaffected — those are network fetches, which is why the bug
+  looked selective. Verify a provider change by building with `VERCEL=1 NITRO_PRESET=vercel`
+  and confirming `.vercel/output/config.json` has an `images` key and the HTML emits
+  `/_vercel/image?url=…`, not `/_ipx/…`.
+
+- **It hid behind the prerenderer for months.** Nitro's `crawlLinks` was baking the
+  `/_ipx/...` variants into static output (603 of them), so the CDN answered and the runtime
+  handler was never asked. Adding `/_ipx` to `nitro.prerender.ignore` to fix the build OOM
+  removed that crutch and surfaced the real misconfiguration — the homepage mascot, the
+  app-promo screenshots and the giveaway carousel all 404'd at once. Both facts are one
+  contract: with the Vercel provider there is no `/_ipx` to prerender, and sharp leaves the
+  build and the runtime entirely.
+
+- **`image.screens` is the allowlist.** It is emitted into the Vercel build-output image
+  config as `images.sizes`, and Vercel serves ONLY those widths. `@nuxt/image` snaps requested
+  widths to the list, so a `sizes` expression that overstates the slot silently pulls a much
+  larger variant. State the real CSS width — the giveaway card is in a `max-w-md` column, so
+  `sizes="448px"` yields 640/1024 candidates where `sm:100vw md:448px` reached for 1280/1536.
+
 ### Security Invariants
 
 Load-bearing contracts — don't "fix" these without understanding why they're this way:

--- a/app/components/GiveawayCard.vue
+++ b/app/components/GiveawayCard.vue
@@ -172,7 +172,11 @@
         <!-- `img-attrs`, not plain class/@error: NuxtPicture's fallthrough attrs
              land on the <picture> root, where `object-cover` is meaningless
              (it's display:inline) and where an img `error` never arrives —
-             error doesn't bubble. Both have to be aimed at the <img> itself. -->
+             error doesn't bubble. Both have to be aimed at the <img> itself.
+
+             `sizes="448px"`: the card lives in a `max-w-md` column, so the image
+             is never wider than 448 CSS px at any breakpoint. `100vw` overstated
+             it on a phone and pulled a needlessly large variant. -->
         <nuxt-picture
           :src="image.src"
           :alt="image.alt"
@@ -180,7 +184,7 @@
           :width="renderSize.width"
           :height="renderSize.height"
           format="webp"
-          sizes="sm:100vw md:448px"
+          sizes="448px"
           class="block w-full h-full"
           :img-attrs="{
             class: 'w-full h-full object-cover',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -349,8 +349,28 @@ export default defineNuxtConfig({
 
   // Image optimization configuration
   image: {
-    // Provider options
-    provider: 'ipx',
+    // NO explicit `provider` — this is deliberate. @nuxt/image auto-selects per
+    // environment: Vercel's native optimizer in production, ipx locally.
+    //
+    // It used to be pinned to `provider: 'ipx'`, and that silently broke every
+    // LOCAL image under `public/` in production with
+    // `[404] [IPX_FILE_NOT_FOUND]` (upstream: nuxt/image#1281). ipx resolves
+    // local paths with a FILESYSTEM read, but on Vercel `public/` is deployed to
+    // the CDN static output and is NOT present in the serverless function's
+    // filesystem. Remote images were unaffected — those are network fetches.
+    //
+    // It hid for a long time because Nitro's `crawlLinks` prerenderer was baking
+    // the `/_ipx/...` variants into static output (603 of them), so the CDN
+    // served them and the runtime handler was never asked. Adding `/_ipx` to
+    // `nitro.prerender.ignore` to fix the build OOM removed that crutch and
+    // exposed the real misconfiguration: the homepage mascot, the app-promo
+    // screenshots and the giveaway carousel all 404'd at once.
+    //
+    // Vercel's optimizer fetches the source over HTTP instead, so `public/`
+    // files work the same as remote ones. It also takes sharp out of both the
+    // build and the runtime, which is what made the OOM possible in the first
+    // place. `domains` below is emitted into the Vercel build-output image
+    // config as the remote allowlist, so it stays load-bearing.
     // Domains allowed for external images.
     //
     // The main asset bucket is referenced by BOTH its regional and bare virtual-hosted


### PR DESCRIPTION
**Production is currently serving 404s for every image under `public/`** — the homepage mascot, the app-promo screenshots, the hero promos, and the giveaway carousel. Remote S3/Supabase images are fine.

## Root cause

ipx resolves local paths with a **filesystem read**. On Vercel, `public/` is deployed to the CDN static output and is **not present in the serverless function's filesystem**, so the read fails:

```
{"error":{"message":"[404] [IPX_FILE_NOT_FOUND] File not found: /brand/mascot-mini.jpg"}}
```

Upstream: [nuxt/image#1281](https://github.com/nuxt/image/issues/1281). Remote images never take that path — they're network fetches — which is why the breakage looked selective rather than total.

Measured against prod:

| | ipx | raw |
|---|---|---|
| `/brand/mascot-mini.jpg` | **404** | 200 |
| `/app-promo/screenshot-home.jpeg` | **404** | 200 |
| `/hero-promos/giveaway.png` | **404** | 200 |
| `/giveaways/…/rear-turbo-kit-01.jpg` | **404** | 200 |
| S3 remote (control) | 200 | — |

## Why it surfaced now

It didn't regress — it was exposed. Nitro's `crawlLinks` had been baking the `/_ipx/...` variants into static output (603 of them), so the CDN answered and the runtime handler was never asked. Adding `/_ipx` to `nitro.prerender.ignore` in `564313d4` to fix the build OOM was correct, and it removed that accidental crutch.

So the two are one story: the prerendering that was blowing the build's memory budget was also the only reason local-file ipx appeared to work.

## The fix

`provider: 'ipx'` was overriding `@nuxt/image`'s per-environment detection. `detectProvider()` resolves from `std-env`'s deployment provider, so unsetting it gives **Vercel's native optimizer in production** (which fetches the source over HTTP, so `public/` behaves like any remote origin) and **ipx locally**.

It also takes sharp out of both the build and the runtime — with no `/_ipx` routes there is nothing for the crawler to prerender, which removes the OOM class at the source rather than working around it.

## Verification

Built with `VERCEL=1 NITRO_PRESET=vercel` to exercise the real detection path:

- `.vercel/output/config.json` gains an `images` key — `sizes: [320,640,768,1024,1280,1536]`, `formats: ['image/webp','image/avif']`, all 7 `domains` carried over
- Emitted URLs are `/_vercel/image?url=…&w=…&q=80`, with **zero** `/_ipx` references
- Local dev still falls back to ipx and serves 200s, so the change is production-only

**Checked the width allowlist specifically**, since Vercel serves only the widths in `images.sizes` and rejects others: every width requested across the whole build (`320, 640, 768, 1024, 1280, 1536`) is in the list — `@nuxt/image` snaps to it.

## Also: narrowed the carousel's `sizes`

That allowlist behaviour has a sharp edge — a `sizes` expression that overstates the slot silently pulls a much larger variant. The giveaway card sits in a `max-w-md` column and is never wider than 448 CSS px, but `sm:100vw md:448px` was reaching for 1280/1536. Now `sizes="448px"` → 640/1024 candidates.

## Follow-up for you

Vercel Image Optimization bills per **source** image transformed, and the recent allowlist PR routed S3 + Supabase + YouTube through the optimizer — so user-uploaded listing photos now count against that quota. Worth checking usage against your plan's included allowance after this lands; variants of an already-transformed source are free, so the cost scales with distinct source images, not traffic.

`CLAUDE.md` gains an "Image Optimization Invariants" section recording all of the above — chiefly *never set `image.provider`*, and that `image.screens` is the width allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)