### PR TITLE
feat(admin): surface the Discord roster and per-user handle

### DIFF
--- a/app/composables/useAdminDiscord.ts
+++ b/app/composables/useAdminDiscord.ts
@@ -111,19 +111,12 @@ export const DISCORD_CLASSIFICATION_BADGES: Record<DiscordClassification, string
 export const useAdminDiscord = () => {
   const supabase = useSupabase();
 
-  /**
-   * Full reconciliation roster, worst-first.
-   *
-   * NOTE: the `as never` on the RPC name is a temporary bridge — types/database.ts
-   * is raw `bun run gen:types` output and will not know these functions until
-   * migration 20260801000001 is pushed and types are regenerated. Drop the cast
-   * (here and in latestRun) on the next `bun run gen:types`.
-   */
+  /** Full reconciliation roster, worst-first. */
   const listRoster = async (): Promise<DiscordRosterRow[]> => {
-    const { data, error } = await supabase.rpc('admin_list_discord_roster' as never);
+    const { data, error } = await supabase.rpc('admin_list_discord_roster');
     if (error) throw error;
 
-    const rows = (data ?? []) as unknown as DiscordRosterRow[];
+    const rows = (data ?? []) as DiscordRosterRow[];
     const rank = (c: DiscordClassification) => {
       const i = DISCORD_CLASSIFICATION_ORDER.indexOf(c);
       return i === -1 ? DISCORD_CLASSIFICATION_ORDER.length : i;
@@ -141,9 +134,9 @@ export const useAdminDiscord = () => {
    * for an admin.
    */
   const latestRun = async (): Promise<DiscordAuditRun | null> => {
-    const { data, error } = await supabase.rpc('admin_latest_discord_audit' as never);
+    const { data, error } = await supabase.rpc('admin_latest_discord_audit');
     if (error) throw error;
-    const rows = (data ?? []) as unknown as DiscordAuditRun[];
+    const rows = (data ?? []) as DiscordAuditRun[];
     return rows[0] ?? null;
   };
 

--- a/app/composables/useAdminDiscord.ts
+++ b/app/composables/useAdminDiscord.ts
@@ -1,0 +1,151 @@
+/**
+ * useAdminDiscord — admin-only read surface over the Discord guild roster
+ * (classicminidiy-supabase migration 20260801000001_discord_roster_observability).
+ *
+ * The guild is members-only, but until the discord-audit cron shipped nothing
+ * ever READ it: the entitlement fan-out only reconciles users it already holds
+ * a discord_links row for. This composable exposes the reconciliation roster —
+ * every present guild member plus every active link absent from the guild —
+ * classified against user_has_subscription().
+ *
+ * OBSERVE ONLY. There is no enforcement RPC behind this; nothing here removes a
+ * role or kicks anyone. Acting on `unlinked` in particular would remove paying
+ * members, most of whom simply never completed the OAuth claim. See the design
+ * doc (docs/plans/2026-08-01-discord-roster-reconciliation.md §5) before wiring
+ * any action to these rows.
+ *
+ * admin_list_discord_roster enforces public.is_admin() server-side, so this is
+ * called with the logged-in admin's Supabase client. Non-admins hit 42501.
+ */
+
+/** Roster classification, mirroring the SQL CASE in discord_roster_classified(). */
+export type DiscordClassification =
+  /** Linked, entitled, holds the paid role. Nothing to do. */
+  | 'ok'
+  /** Holds the paid role with no active subscription — the actual leak. */
+  | 'role_without_entitlement'
+  /** Holds the paid role but has no discord_links row at all; the role arrived
+   *  some other way (hand-granted, or a deleted link). Unaccounted for. */
+  | 'unlinked_with_role'
+  /** Entitled and in the guild, but the paid role is missing. */
+  | 'entitled_without_role'
+  /** In the guild, no link, no role. Usually a payer who never claimed. */
+  | 'unlinked'
+  /** Linked and in the guild, not entitled, no role. Lapsed and correctly stripped. */
+  | 'unentitled_no_role'
+  /** Active link whose Discord account is not in the guild. */
+  | 'linked_absent'
+  /** Bot, moderator, or a manually exempted account. Never enforced against. */
+  | 'exempt';
+
+export interface DiscordRosterRow {
+  discord_user_id: string;
+  /** Discord @handle. Mutable — discord_user_id is the identity key. */
+  username: string;
+  /** Display name; null when the account never set one. */
+  global_name: string | null;
+  /** Per-guild nickname. */
+  nick: string | null;
+  in_guild: boolean;
+  has_paid_role: boolean;
+  exempt: boolean;
+  guild_joined_at: string | null;
+  last_seen_at: string | null;
+  /** Supabase account, when the Discord account is linked to one. */
+  user_id: string | null;
+  email: string | null;
+  link_status: string | null;
+  is_entitled: boolean;
+  classification: DiscordClassification;
+}
+
+export interface DiscordAuditRun {
+  id: number;
+  started_at: string;
+  finished_at: string | null;
+  /** False means pagination never reached a confirmed final page — the run's
+   *  roster is partial and its departures were deliberately not recorded. */
+  complete: boolean;
+  pages_fetched: number;
+  members_seen: number;
+  departed: number;
+  counts: Record<string, number>;
+  last_error: string | null;
+}
+
+/** Ordered worst-first, so the UI groups the rows that actually need attention. */
+export const DISCORD_CLASSIFICATION_ORDER: DiscordClassification[] = [
+  'role_without_entitlement',
+  'unlinked_with_role',
+  'entitled_without_role',
+  'unlinked',
+  'linked_absent',
+  'unentitled_no_role',
+  'ok',
+  'exempt',
+];
+
+export const DISCORD_CLASSIFICATION_LABELS: Record<DiscordClassification, string> = {
+  role_without_entitlement: 'Has role, not paying',
+  unlinked_with_role: 'Has role, never linked',
+  entitled_without_role: 'Paying, role missing',
+  unlinked: 'In server, not linked',
+  linked_absent: 'Linked, left the server',
+  unentitled_no_role: 'Lapsed, role removed',
+  ok: 'OK',
+  exempt: 'Exempt',
+};
+
+/** daisyUI badge modifier per classification. */
+export const DISCORD_CLASSIFICATION_BADGES: Record<DiscordClassification, string> = {
+  role_without_entitlement: 'badge-error',
+  unlinked_with_role: 'badge-error',
+  entitled_without_role: 'badge-warning',
+  unlinked: 'badge-warning',
+  linked_absent: 'badge-info',
+  unentitled_no_role: 'badge-ghost',
+  ok: 'badge-success',
+  exempt: 'badge-ghost',
+};
+
+export const useAdminDiscord = () => {
+  const supabase = useSupabase();
+
+  /**
+   * Full reconciliation roster, worst-first.
+   *
+   * NOTE: the `as never` on the RPC name is a temporary bridge — types/database.ts
+   * is raw `bun run gen:types` output and will not know these functions until
+   * migration 20260801000001 is pushed and types are regenerated. Drop the cast
+   * (here and in latestRun) on the next `bun run gen:types`.
+   */
+  const listRoster = async (): Promise<DiscordRosterRow[]> => {
+    const { data, error } = await supabase.rpc('admin_list_discord_roster' as never);
+    if (error) throw error;
+
+    const rows = (data ?? []) as unknown as DiscordRosterRow[];
+    const rank = (c: DiscordClassification) => {
+      const i = DISCORD_CLASSIFICATION_ORDER.indexOf(c);
+      return i === -1 ? DISCORD_CLASSIFICATION_ORDER.length : i;
+    };
+    return [...rows].sort(
+      (a, b) => rank(a.classification) - rank(b.classification) || a.username.localeCompare(b.username)
+    );
+  };
+
+  /**
+   * Most recent audit run, for the "last checked" stamp and staleness warning.
+   *
+   * Goes through an RPC rather than selecting discord_audit_runs directly: that
+   * table is REVOKEd from `authenticated`, so a PostgREST read would 42501 even
+   * for an admin.
+   */
+  const latestRun = async (): Promise<DiscordAuditRun | null> => {
+    const { data, error } = await supabase.rpc('admin_latest_discord_audit' as never);
+    if (error) throw error;
+    const rows = (data ?? []) as unknown as DiscordAuditRun[];
+    return rows[0] ?? null;
+  };
+
+  return { listRoster, latestRun };
+};

--- a/app/composables/useAdminDiscord.ts
+++ b/app/composables/useAdminDiscord.ts
@@ -36,7 +36,11 @@ export type DiscordClassification =
   /** Active link whose Discord account is not in the guild. */
   | 'linked_absent'
   /** Bot, moderator, or a manually exempted account. Never enforced against. */
-  | 'exempt';
+  | 'exempt'
+  /** Client-side fallback for a classification the UI doesn't recognise — the
+   *  SQL never emits this. Shown rather than hidden, so a roster change that
+   *  outpaces the frontend is visible instead of silently dropping rows. */
+  | 'unknown';
 
 export interface DiscordRosterRow {
   discord_user_id: string;
@@ -83,6 +87,7 @@ export const DISCORD_CLASSIFICATION_ORDER: DiscordClassification[] = [
   'unentitled_no_role',
   'ok',
   'exempt',
+  'unknown',
 ];
 
 export const DISCORD_CLASSIFICATION_LABELS: Record<DiscordClassification, string> = {
@@ -94,6 +99,7 @@ export const DISCORD_CLASSIFICATION_LABELS: Record<DiscordClassification, string
   unentitled_no_role: 'Lapsed, role removed',
   ok: 'OK',
   exempt: 'Exempt',
+  unknown: 'Unrecognized',
 };
 
 /** daisyUI badge modifier per classification. */
@@ -106,22 +112,73 @@ export const DISCORD_CLASSIFICATION_BADGES: Record<DiscordClassification, string
   unentitled_no_role: 'badge-ghost',
   ok: 'badge-success',
   exempt: 'badge-ghost',
+  unknown: 'badge-error',
 };
 
 export const useAdminDiscord = () => {
   const supabase = useSupabase();
+
+  /**
+   * Normalize one raw RPC row.
+   *
+   * `discord_roster_row` is a Postgres COMPOSITE type, and composites cannot
+   * express NOT NULL — so `bun run gen:types` marks every field nullable even
+   * though the SQL guarantees `discord_user_id`, `username`, and
+   * `classification` are always populated (the guild branch reads NOT NULL
+   * columns; the absent-link branch COALESCEs the handle and filters on
+   * `discord_user_id IS NOT NULL`).
+   *
+   * Rather than assert that with a cast, coerce here. A row that somehow
+   * arrives without an identity is dropped (returns null) instead of crashing
+   * the page mid-render, and an unrecognized classification degrades to a
+   * labelled unknown rather than an invisible one. This keeps the page standing
+   * if the SQL ever changes shape.
+   */
+  const normalizeRow = (raw: Record<string, unknown>): DiscordRosterRow | null => {
+    const discordUserId = typeof raw.discord_user_id === 'string' ? raw.discord_user_id : null;
+    if (!discordUserId) return null;
+
+    const classification = (
+      typeof raw.classification === 'string' &&
+      (DISCORD_CLASSIFICATION_ORDER as string[]).includes(raw.classification)
+        ? raw.classification
+        : 'unknown'
+    ) as DiscordClassification;
+
+    return {
+      discord_user_id: discordUserId,
+      username: typeof raw.username === 'string' && raw.username ? raw.username : '(unknown)',
+      global_name: typeof raw.global_name === 'string' ? raw.global_name : null,
+      nick: typeof raw.nick === 'string' ? raw.nick : null,
+      in_guild: raw.in_guild === true,
+      has_paid_role: raw.has_paid_role === true,
+      exempt: raw.exempt === true,
+      guild_joined_at: typeof raw.guild_joined_at === 'string' ? raw.guild_joined_at : null,
+      last_seen_at: typeof raw.last_seen_at === 'string' ? raw.last_seen_at : null,
+      user_id: typeof raw.user_id === 'string' ? raw.user_id : null,
+      email: typeof raw.email === 'string' ? raw.email : null,
+      link_status: typeof raw.link_status === 'string' ? raw.link_status : null,
+      is_entitled: raw.is_entitled === true,
+      classification,
+    };
+  };
 
   /** Full reconciliation roster, worst-first. */
   const listRoster = async (): Promise<DiscordRosterRow[]> => {
     const { data, error } = await supabase.rpc('admin_list_discord_roster');
     if (error) throw error;
 
-    const rows = (data ?? []) as DiscordRosterRow[];
+    const raw = (data ?? []) as unknown as Record<string, unknown>[];
+    const rows = raw.map(normalizeRow).filter((r): r is DiscordRosterRow => r !== null);
+    if (rows.length !== raw.length) {
+      console.warn(`[useAdminDiscord] dropped ${raw.length - rows.length} roster row(s) with no Discord id`);
+    }
+
     const rank = (c: DiscordClassification) => {
       const i = DISCORD_CLASSIFICATION_ORDER.indexOf(c);
       return i === -1 ? DISCORD_CLASSIFICATION_ORDER.length : i;
     };
-    return [...rows].sort(
+    return rows.sort(
       (a, b) => rank(a.classification) - rank(b.classification) || a.username.localeCompare(b.username)
     );
   };

--- a/app/composables/useAdminMembership.ts
+++ b/app/composables/useAdminMembership.ts
@@ -18,6 +18,22 @@ export interface AdminMembership {
   comp_expires_at: string | null;
   /** Admin-supplied reason on the comp row. */
   comp_note: string | null;
+  /** discord_links lifecycle: pending | active | revoked | failed, or null when
+   *  the user has never had a link row. */
+  discord_status: 'pending' | 'active' | 'revoked' | 'failed' | null;
+  /** Discord snowflake — the stable identity key. */
+  discord_user_id: string | null;
+  /** Discord @handle, captured at OAuth and refreshed daily by discord-audit. */
+  discord_username: string | null;
+  /** Discord display name; null when the account never set one. */
+  discord_global_name: string | null;
+  /** Present in the guild as of the last discord-audit run. FALSE also means
+   *  "no audit has run yet" — check the Discord roster page's last-run stamp. */
+  discord_in_guild: boolean;
+  /** Holds the paid role as of the last discord-audit run. `is_member` false
+   *  with this true is the drift case: still in the members-only server after
+   *  going free. */
+  discord_has_role: boolean;
 }
 
 export const useAdminMembership = () => {

--- a/app/pages/admin/discord.vue
+++ b/app/pages/admin/discord.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+  import {
+    DISCORD_CLASSIFICATION_BADGES,
+    DISCORD_CLASSIFICATION_LABELS,
+    DISCORD_CLASSIFICATION_ORDER,
+    type DiscordAuditRun,
+    type DiscordClassification,
+    type DiscordRosterRow,
+  } from '~/composables/useAdminDiscord';
+
+  definePageMeta({
+    layout: 'admin',
+  });
+
+  useHead({
+    title: 'Admin - Discord Roster',
+    meta: [{ name: 'robots', content: 'noindex, nofollow' }],
+  });
+
+  const { listRoster, latestRun } = useAdminDiscord();
+
+  const rows = ref<DiscordRosterRow[]>([]);
+  const run = ref<DiscordAuditRun | null>(null);
+  const loading = ref(true);
+  const errorMessage = ref('');
+  const search = ref('');
+  const activeFilter = ref<DiscordClassification | 'all'>('all');
+
+  async function load() {
+    loading.value = true;
+    errorMessage.value = '';
+    try {
+      const [roster, lastRun] = await Promise.all([listRoster(), latestRun()]);
+      rows.value = roster;
+      run.value = lastRun;
+    } catch (error: any) {
+      errorMessage.value = error?.message || 'Failed to load the Discord roster';
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  onMounted(load);
+
+  const counts = computed(() => {
+    const out: Record<string, number> = {};
+    for (const row of rows.value) out[row.classification] = (out[row.classification] ?? 0) + 1;
+    return out;
+  });
+
+  /** Only the classifications actually present, in worst-first order. */
+  const presentClassifications = computed(() =>
+    DISCORD_CLASSIFICATION_ORDER.filter((c) => (counts.value[c] ?? 0) > 0)
+  );
+
+  const filtered = computed(() => {
+    const q = search.value.trim().toLowerCase();
+    return rows.value.filter((row) => {
+      if (activeFilter.value !== 'all' && row.classification !== activeFilter.value) return false;
+      if (!q) return true;
+      return (
+        row.username.toLowerCase().includes(q) ||
+        (row.global_name ?? '').toLowerCase().includes(q) ||
+        (row.nick ?? '').toLowerCase().includes(q) ||
+        (row.email ?? '').toLowerCase().includes(q) ||
+        row.discord_user_id.includes(q)
+      );
+    });
+  });
+
+  /** Rows that represent access someone shouldn't have. */
+  const needsAttention = computed(
+    () => (counts.value.role_without_entitlement ?? 0) + (counts.value.unlinked_with_role ?? 0)
+  );
+
+  const lastRunLabel = computed(() => {
+    if (!run.value?.started_at) return null;
+    return new Date(run.value.started_at).toLocaleString();
+  });
+
+  /** An audit that hasn't landed in over 48h means the cron is wedged. */
+  const runIsStale = computed(() => {
+    if (!run.value?.started_at) return false;
+    return Date.now() - new Date(run.value.started_at).getTime() > 48 * 60 * 60 * 1000;
+  });
+
+  function badgeFor(c: DiscordClassification) {
+    return DISCORD_CLASSIFICATION_BADGES[c] ?? 'badge-ghost';
+  }
+  function labelFor(c: DiscordClassification) {
+    return DISCORD_CLASSIFICATION_LABELS[c] ?? c;
+  }
+</script>
+
+<template>
+  <div class="p-4 md:p-6">
+    <div class="flex flex-wrap items-center justify-between gap-3 mb-2">
+      <h1 class="text-2xl font-bold">Discord Roster</h1>
+      <button type="button" class="btn btn-sm btn-outline" :disabled="loading" @click="load">
+        <i class="fas fa-rotate" :class="{ 'fa-spin': loading }"></i>
+        Refresh
+      </button>
+    </div>
+
+    <p class="text-sm opacity-70 mb-4">
+      Who is actually in the members-only Discord, reconciled against paid membership. This page is
+      <strong>observe-only</strong> &mdash; nothing here removes a role or kicks anyone.
+    </p>
+
+    <div v-if="errorMessage" role="alert" class="alert alert-error mb-4">
+      <i class="fas fa-triangle-exclamation"></i>
+      <span>{{ errorMessage }}</span>
+    </div>
+
+    <!-- Audit freshness. Everything on this page is only as current as the last run. -->
+    <div v-if="!loading && !run" role="alert" class="alert alert-warning mb-4">
+      <i class="fas fa-circle-info"></i>
+      <span>
+        The Discord audit has never run, so the roster is empty. Check that the
+        <code>discord-audit</code> cron is scheduled and the bot has the Server Members Intent enabled.
+      </span>
+    </div>
+    <div v-else-if="run && !run.complete" role="alert" class="alert alert-warning mb-4">
+      <i class="fas fa-triangle-exclamation"></i>
+      <span>
+        The last audit did not complete{{ run.last_error ? `: ${run.last_error}` : '' }}. The roster below may
+        be partial &mdash; departures were deliberately not recorded.
+      </span>
+    </div>
+    <div v-else-if="runIsStale" role="alert" class="alert alert-warning mb-4">
+      <i class="fas fa-clock"></i>
+      <span>Last successful audit was {{ lastRunLabel }} &mdash; over 48 hours ago. The cron may be wedged.</span>
+    </div>
+
+    <!-- Summary -->
+    <div v-if="!loading" class="stats stats-vertical sm:stats-horizontal shadow mb-4 w-full">
+      <div class="stat">
+        <div class="stat-title">In the server</div>
+        <div class="stat-value text-2xl">{{ rows.filter((r) => r.in_guild).length }}</div>
+        <div v-if="lastRunLabel" class="stat-desc">Last checked {{ lastRunLabel }}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-title">Needs attention</div>
+        <div class="stat-value text-2xl" :class="needsAttention > 0 ? 'text-error' : ''">
+          {{ needsAttention }}
+        </div>
+        <div class="stat-desc">Holding the paid role without paying</div>
+      </div>
+      <div class="stat">
+        <div class="stat-title">Not linked</div>
+        <div class="stat-value text-2xl">{{ counts.unlinked ?? 0 }}</div>
+        <div class="stat-desc">Mostly members who never claimed &mdash; not freeloaders</div>
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="flex flex-wrap items-center gap-2 mb-4">
+      <button
+        type="button"
+        class="btn btn-xs"
+        :class="activeFilter === 'all' ? 'btn-primary' : 'btn-ghost'"
+        @click="activeFilter = 'all'"
+      >
+        All ({{ rows.length }})
+      </button>
+      <button
+        v-for="c in presentClassifications"
+        :key="c"
+        type="button"
+        class="btn btn-xs"
+        :class="activeFilter === c ? 'btn-primary' : 'btn-ghost'"
+        @click="activeFilter = c"
+      >
+        {{ labelFor(c) }} ({{ counts[c] }})
+      </button>
+      <label class="input input-sm input-bordered flex items-center gap-2 ml-auto">
+        <i class="fas fa-magnifying-glass opacity-50"></i>
+        <input v-model="search" type="search" class="grow" placeholder="Handle, name, or email" />
+      </label>
+    </div>
+
+    <div v-if="loading" class="flex justify-center py-12">
+      <i class="fas fa-spinner fa-spin text-3xl text-primary"></i>
+    </div>
+
+    <div v-else-if="filtered.length === 0" class="text-center py-12 opacity-60">
+      <i class="fab fa-discord text-3xl mb-2"></i>
+      <p>No members match.</p>
+    </div>
+
+    <div v-else class="overflow-x-auto">
+      <table class="table table-sm table-zebra">
+        <thead>
+          <tr>
+            <th>Discord</th>
+            <th>Status</th>
+            <th>Account</th>
+            <th class="text-center">Role</th>
+            <th class="text-center">Paying</th>
+            <th>Joined server</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in filtered" :key="row.discord_user_id">
+            <td>
+              <div class="font-mono text-sm">@{{ row.username }}</div>
+              <div v-if="row.global_name || row.nick" class="text-xs opacity-60">
+                {{ row.nick || row.global_name }}
+              </div>
+              <div v-if="!row.in_guild" class="text-xs opacity-60 italic">not in server</div>
+            </td>
+            <td>
+              <span class="badge badge-sm" :class="badgeFor(row.classification)">
+                {{ labelFor(row.classification) }}
+              </span>
+            </td>
+            <td>
+              <span v-if="row.email" class="text-sm">{{ row.email }}</span>
+              <span v-else class="text-xs opacity-60 italic">
+                {{ row.user_id ? 'no email' : 'no linked account' }}
+              </span>
+              <div v-if="row.link_status && row.link_status !== 'active'" class="text-xs opacity-60">
+                link: {{ row.link_status }}
+              </div>
+            </td>
+            <td class="text-center">
+              <i v-if="row.has_paid_role" class="fas fa-check text-success"></i>
+              <i v-else class="fas fa-minus opacity-30"></i>
+            </td>
+            <td class="text-center">
+              <i v-if="row.is_entitled" class="fas fa-check text-success"></i>
+              <i v-else class="fas fa-minus opacity-30"></i>
+            </td>
+            <td class="text-sm opacity-70">
+              {{ row.guild_joined_at ? new Date(row.guild_joined_at).toLocaleDateString() : '—' }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -175,6 +175,30 @@
           </div>
         </div>
 
+        <!-- Discord Roster Card -->
+        <div class="card bg-base-100 shadow-md border border-base-300 hover:shadow-2xl transition-shadow">
+          <div class="card-body">
+            <div class="flex items-center gap-3 mb-4">
+              <div class="w-12 h-12 bg-info/10 rounded-lg flex items-center justify-center">
+                <i class="fab fa-discord text-2xl text-info"></i>
+              </div>
+              <h2 class="text-xl font-bold">Discord Roster</h2>
+            </div>
+
+            <p class="opacity-70 mb-6">
+              See who is in the members-only Discord, matched to accounts by username, and spot anyone still
+              holding the paid role after going free.
+            </p>
+
+            <div class="card-actions justify-end">
+              <NuxtLink to="/admin/discord" class="btn btn-info">
+                <i class="fad fa-arrow-right mr-2"></i>
+                View Roster
+              </NuxtLink>
+            </div>
+          </div>
+        </div>
+
         <!-- Marketing Email Card (allowlisted marketing admins only) -->
         <div
           v-if="marketingAllowed === true"

--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -298,6 +298,13 @@
   const compNote = ref('');
   const compExpiry = ref(''); // YYYY-MM-DD, '' = permanent
 
+  // Still in the members-only Discord after going free. Guarded on the audit
+  // having actually observed them (has_role is FALSE both when the role is
+  // genuinely absent and when no audit has run yet).
+  const discordDrift = computed(
+    () => !!membershipData.value && !membershipData.value.is_member && membershipData.value.discord_has_role
+  );
+
   async function loadMembership(userId: string) {
     membershipLoading.value = true;
     membershipError.value = '';
@@ -826,6 +833,33 @@
             <div v-if="membershipData.has_active_comp" class="opacity-70">
               Comp {{ compExpiryLabel ? `expires ${compExpiryLabel}` : 'is permanent' }}
               <span v-if="membershipData.comp_note">&mdash; &ldquo;{{ membershipData.comp_note }}&rdquo;</span>
+            </div>
+
+            <!-- Discord linkage (20260801000001). Read-only: nothing here grants
+                 or removes a role — the audit is observe-only. -->
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="opacity-70">Discord:</span>
+              <template v-if="membershipData.discord_username">
+                <span class="font-mono">@{{ membershipData.discord_username }}</span>
+                <span v-if="membershipData.discord_global_name" class="opacity-70">
+                  ({{ membershipData.discord_global_name }})
+                </span>
+                <span v-if="membershipData.discord_in_guild" class="badge badge-outline badge-sm">in server</span>
+                <span v-if="membershipData.discord_has_role" class="badge badge-outline badge-sm">has role</span>
+              </template>
+              <span v-else-if="membershipData.discord_status === 'pending'" class="badge badge-ghost badge-sm">
+                Claim sent, not linked
+              </span>
+              <span v-else class="badge badge-ghost badge-sm">Not connected</span>
+            </div>
+
+            <!-- The leak this whole surface exists to make visible. -->
+            <div v-if="discordDrift" role="alert" class="alert alert-warning py-2">
+              <i class="fas fa-triangle-exclamation"></i>
+              <span>
+                Not a paying member but still holds the Discord role. Review on the
+                <NuxtLink to="/admin/discord" class="link">Discord roster</NuxtLink>.
+              </span>
             </div>
           </div>
 

--- a/types/database.ts
+++ b/types/database.ts
@@ -458,13 +458,99 @@ export type Database = {
           },
         ]
       }
+      discord_audit_runs: {
+        Row: {
+          complete: boolean
+          counts: Json
+          departed: number
+          finished_at: string | null
+          id: number
+          last_error: string | null
+          members_seen: number
+          pages_fetched: number
+          started_at: string
+        }
+        Insert: {
+          complete?: boolean
+          counts?: Json
+          departed?: number
+          finished_at?: string | null
+          id?: never
+          last_error?: string | null
+          members_seen?: number
+          pages_fetched?: number
+          started_at?: string
+        }
+        Update: {
+          complete?: boolean
+          counts?: Json
+          departed?: number
+          finished_at?: string | null
+          id?: never
+          last_error?: string | null
+          members_seen?: number
+          pages_fetched?: number
+          started_at?: string
+        }
+        Relationships: []
+      }
+      discord_guild_members: {
+        Row: {
+          discord_user_id: string
+          exempt: boolean
+          exempt_reason: string | null
+          first_seen_at: string
+          global_name: string | null
+          guild_joined_at: string | null
+          has_paid_role: boolean
+          is_bot: boolean
+          last_seen_at: string
+          left_at: string | null
+          nick: string | null
+          roles: string[]
+          username: string
+        }
+        Insert: {
+          discord_user_id: string
+          exempt?: boolean
+          exempt_reason?: string | null
+          first_seen_at?: string
+          global_name?: string | null
+          guild_joined_at?: string | null
+          has_paid_role?: boolean
+          is_bot?: boolean
+          last_seen_at?: string
+          left_at?: string | null
+          nick?: string | null
+          roles?: string[]
+          username: string
+        }
+        Update: {
+          discord_user_id?: string
+          exempt?: boolean
+          exempt_reason?: string | null
+          first_seen_at?: string
+          global_name?: string | null
+          guild_joined_at?: string | null
+          has_paid_role?: boolean
+          is_bot?: boolean
+          last_seen_at?: string
+          left_at?: string | null
+          nick?: string | null
+          roles?: string[]
+          username?: string
+        }
+        Relationships: []
+      }
       discord_links: {
         Row: {
           claim_issued_at: string | null
           claim_token_jti: string | null
           claimed_at: string | null
           created_at: string
+          discord_global_name: string | null
           discord_user_id: string | null
+          discord_username: string | null
           ghost_email: string
           ghost_member_id: string | null
           id: string
@@ -479,7 +565,9 @@ export type Database = {
           claim_token_jti?: string | null
           claimed_at?: string | null
           created_at?: string
+          discord_global_name?: string | null
           discord_user_id?: string | null
+          discord_username?: string | null
           ghost_email: string
           ghost_member_id?: string | null
           id?: string
@@ -494,7 +582,9 @@ export type Database = {
           claim_token_jti?: string | null
           claimed_at?: string | null
           created_at?: string
+          discord_global_name?: string | null
           discord_user_id?: string | null
+          discord_username?: string | null
           ghost_email?: string
           ghost_member_id?: string | null
           id?: string
@@ -1809,6 +1899,35 @@ export type Database = {
           },
         ]
       }
+      marketing_email_recipients: {
+        Row: {
+          email: string
+          failed: boolean
+          marketing_email_id: string
+          sent_at: string | null
+        }
+        Insert: {
+          email: string
+          failed?: boolean
+          marketing_email_id: string
+          sent_at?: string | null
+        }
+        Update: {
+          email?: string
+          failed?: boolean
+          marketing_email_id?: string
+          sent_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "marketing_email_recipients_marketing_email_id_fkey"
+            columns: ["marketing_email_id"]
+            isOneToOne: false
+            referencedRelation: "marketing_emails"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       marketing_emails: {
         Row: {
           audience_counts: Json | null
@@ -1819,6 +1938,7 @@ export type Database = {
           id: string
           preheader: string | null
           recipient_count: number
+          send_lease_expires_at: string | null
           sent_at: string | null
           sent_by: string | null
           status: string
@@ -1835,6 +1955,7 @@ export type Database = {
           id?: string
           preheader?: string | null
           recipient_count?: number
+          send_lease_expires_at?: string | null
           sent_at?: string | null
           sent_by?: string | null
           status?: string
@@ -1851,6 +1972,7 @@ export type Database = {
           id?: string
           preheader?: string | null
           recipient_count?: number
+          send_lease_expires_at?: string | null
           sent_at?: string | null
           sent_by?: string | null
           status?: string
@@ -4107,6 +4229,12 @@ export type Database = {
           active_platform: string
           comp_expires_at: string
           comp_note: string
+          discord_global_name: string
+          discord_has_role: boolean
+          discord_in_guild: boolean
+          discord_status: string
+          discord_user_id: string
+          discord_username: string
           has_active_comp: boolean
           is_member: boolean
         }[]
@@ -4114,6 +4242,30 @@ export type Database = {
       admin_increment_warning_count: {
         Args: { p_user_id: string }
         Returns: number
+      }
+      admin_latest_discord_audit: {
+        Args: never
+        Returns: {
+          complete: boolean
+          counts: Json
+          departed: number
+          finished_at: string
+          id: number
+          last_error: string
+          members_seen: number
+          pages_fetched: number
+          started_at: string
+        }[]
+      }
+      admin_list_discord_roster: {
+        Args: never
+        Returns: Database["public"]["CompositeTypes"]["discord_roster_row"][]
+        SetofOptions: {
+          from: "*"
+          to: "discord_roster_row"
+          isOneToOne: false
+          isSetofReturn: true
+        }
       }
       approve_model_version: {
         Args: { p_notes?: string; p_version_id: string }
@@ -4168,6 +4320,16 @@ export type Database = {
       count_probation_cold_outreach: {
         Args: { p_sender: string }
         Returns: number
+      }
+      discord_roster_classified: {
+        Args: never
+        Returns: Database["public"]["CompositeTypes"]["discord_roster_row"][]
+        SetofOptions: {
+          from: "*"
+          to: "discord_roster_row"
+          isOneToOne: false
+          isSetofReturn: true
+        }
       }
       find_user_id_by_email: { Args: { p_email: string }; Returns: string }
       generate_location_string: {
@@ -4673,7 +4835,22 @@ export type Database = {
       window_type_enum: "sliding" | "wind_up"
     }
     CompositeTypes: {
-      [_ in never]: never
+      discord_roster_row: {
+        discord_user_id: string | null
+        username: string | null
+        global_name: string | null
+        nick: string | null
+        in_guild: boolean | null
+        has_paid_role: boolean | null
+        exempt: boolean | null
+        guild_joined_at: string | null
+        last_seen_at: string | null
+        user_id: string | null
+        email: string | null
+        link_status: string | null
+        is_entitled: boolean | null
+        classification: string | null
+      }
     }
   }
 }


### PR DESCRIPTION
## Why

Companion to [classicminidiy-supabase#74](https://github.com/ClassicMiniDIY/classicminidiy-supabase/pull/74) (migration `20260801000001`).

The Discord is members-only, but nothing has ever reconciled who is in it against who is paying. The first audit run found 134 members, of whom only 16 are linked-and-paying — plus one account holding the paid role with no subscription at all, and 27 more holding it with no link row.

Until now the only Discord identity stored was the snowflake, so there was nothing to match against Discord's own member list by eye.

## What this adds

- **`/admin/discord`** — the reconciliation roster, grouped worst-first, filterable by classification, searchable by handle / display name / email. Shows a last-run stamp and warns when the last audit was incomplete or over 48h stale, since every figure on the page is only as current as the last run.
- **Membership modal** (`/admin/users`) — `@handle`, display name, and in-server / has-role badges per user, plus an explicit warning when a non-paying user still holds the role.
- **`useAdminDiscord`** composable over `admin_list_discord_roster()` and `admin_latest_discord_audit()`.
- **Dashboard card** linking to the roster.

## Read-only by design

Nothing here removes a role or kicks anyone. `unlinked` in particular must not be acted on: all 40 entitled-but-unlinked members had already been sent a claim email, and 30 were holding an expired token — they're paying members who never completed the OAuth round trip, not freeloaders.

## Notes

- `types/database.ts` regenerated via `bun run gen:types` now that the migration is applied; the two temporary `as never` casts are gone.
- `vue-tsc` baselined with the changes stashed — this branch adds **zero** new type errors (the repo has pre-existing ones across ~200 files).
- 26 existing membership / discord tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)