### PR TITLE
fix(colors): approving a photo contribution attaches to the colour it named

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,26 @@ parts of it that break silently if you get them wrong.
   "added by @handle" credit anywhere. Every archive table has the FK; it just wasn't
   being populated. A new approval path must populate it too.
 
+- **"Attach to an existing entry" is carried differently for colours than for
+  everything else, and dropping it creates duplicate archive rows.** Wheels and
+  registry entries gap-fill through `edit_suggestion` + `target_id`, so the
+  association lives on the submission row and `applyEditSuggestion()` cannot lose
+  it. Colours can't: `/contribute/color` is the one archive form that is not the
+  wizard, so it submits a `new_item` and stamps the chosen colour's id inside
+  `data.originalColorId`. `insertApprovedItem()` ignored that field until
+  2026-08 and INSERTed a photo-only stub instead — same name, no hex, no swatch,
+  empty paint codes — which is how `/archive/colors` ended up listing colours
+  twice. The blast radius was bigger than the listing: a stub shares its real
+  colour's `name+code+short_code`, the exact tuple
+  `20260727000001_restore_wheel_colour_legacy_ids.sql` matches on, so a legacy
+  DynamoDB id was restored onto a stub and that colour's legacy deep link broke.
+  (Two live instances, rows cleaned up by supabase PR #77.) When merging into an
+  existing row, `submitted_by` and `swatch_path` are only written if the row does
+  not already have one — reassigning either steals another contributor's credit
+  or overwrites curated data. **`server/api/colors/queue/save.ts` (the unlinked
+  legacy `/admin/colors/review` page) still has this bug** and additionally
+  *replaces* rather than appends `contributor_images`.
+
 - **`contributor_archive_items` is the single source for every contributor stat.**
   It unions the approved, user-attributed rows of wheels / registry_entries / colors /
   archive_documents. `get_contributor_impact`, `contributor_badge_metrics`,

--- a/server/api/admin/queue/approve.post.ts
+++ b/server/api/admin/queue/approve.post.ts
@@ -88,11 +88,35 @@ const UPLOAD_BUCKETS = ['archive-documents', 'archive-thumbnails', 'archive-colo
  * text[] column receives it. Colours store images in `contributor_images`
  * (jsonb, different shape) and documents have a single `file_path`, so neither
  * is a straight append — they are deliberately absent rather than special-cased.
+ *
+ * Wheels and registry entries reach this through `edit_suggestion` + `target_id`
+ * (ContributeWizard's gap-fill, `/contribute/wheel?uuid=`), which is why they
+ * have no "attach to existing" field inside `data` the way colours do — the
+ * association is on the submission row itself and cannot be dropped.
  */
 const PHOTO_APPEND_TARGETS: Record<string, string> = {
   wheel: 'wheels',
   registry: 'registry_entries',
 };
+
+/**
+ * `/contribute/color` is the one archive form that is not the wizard (its
+ * swatch-versus-contributor-photo split does not fit the shared step 2), so an
+ * "add photos to this colour" submission arrives as a `new_item` carrying the
+ * chosen colour's id in `data.originalColorId` rather than as an
+ * `edit_suggestion` with a `target_id`.
+ *
+ * The id is client-written, and `colors.id` is a uuid — an unparseable value
+ * reaching `.eq('id', …)` is a Postgres 22P02 surfacing as an opaque 500 on
+ * approval, so anything that is not a uuid is treated as absent.
+ */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function asColorId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return UUID_PATTERN.test(trimmed) ? trimmed : null;
+}
 
 export default defineEventHandler(async (event) => {
   const { user } = await requireAdminAuth(event);
@@ -212,6 +236,34 @@ async function insertApprovedItem(
         }
       }
 
+      // "Add photos to a colour that already exists". Ignoring `originalColorId`
+      // INSERTed a second `colors` row carrying only the new photos — no swatch,
+      // no hex_value, empty ditzler_ppg_code/dulux_code — so /archive/colors
+      // listed the same colour twice, once real and once as a photo-only stub.
+      //
+      // Two of those reached production (supabase PR #77 cleaned the rows up)
+      // and the damage did not stop at the listing: the stubs share their real
+      // colour's name/code/short_code, which is exactly the tuple
+      // `20260727000001_restore_wheel_colour_legacy_ids.sql` matches on, so a
+      // legacy DynamoDB id was restored onto a stub and that colour's
+      // /archive/colors/<legacy-id> deep link started resolving to a row with
+      // no colour data in it.
+      const attachToId = asColorId(data.originalColorId);
+      if (attachToId) {
+        const { data: existing, error: readError } = await supabase
+          .from('colors')
+          .select('id, submitted_by, swatch_path, contributor_images')
+          .eq('id', attachToId)
+          .maybeSingle();
+        if (readError) return readError.message;
+
+        // A stale or deleted id falls through to the INSERT below rather than
+        // dropping the contribution on the floor.
+        if (existing) {
+          return attachToExistingColor(supabase, existing, contributorImages, swatchPath, submittedBy);
+        }
+      }
+
       ({ error } = await supabase.from('colors').insert({
         name: data.name,
         code: data.code || '',
@@ -294,6 +346,50 @@ async function insertApprovedItem(
       return `Unsupported target type: ${targetType}`;
   }
 
+  return error?.message || null;
+}
+
+/**
+ * Merges an approved colour contribution into the colour it was submitted
+ * against, instead of creating a second row for it.
+ *
+ * Three things are deliberately conservative here, because the target is an
+ * existing public row rather than one this submission is creating:
+ *
+ *  - `submitted_by` is only written when the row does not have one. The archive
+ *    import left it NULL, which is the case this fills; overwriting a real value
+ *    would move another contributor's credit — and, through the trust pipeline's
+ *    `contributor_archive_items` view, their counters — onto this photo.
+ *  - `swatch_path` is only written when the row has none. A colour that already
+ *    has a swatch has a curated one; a submitted duplicate is not an upgrade,
+ *    and it is not a car photo either, so it does not become one.
+ *  - No other field is touched. Correcting `hex_value` or a paint code on an
+ *    existing colour is an edit suggestion, which goes through EDIT_TARGETS.
+ */
+async function attachToExistingColor(
+  supabase: any,
+  existing: { id: string; contributor_images: unknown; submitted_by: string | null; swatch_path: string | null },
+  contributorImages: { url: string; contributor?: string | null }[],
+  swatchPath: string | null,
+  submittedBy: string | null
+): Promise<string | null> {
+  const merged = Array.isArray(existing.contributor_images) ? [...existing.contributor_images] : [];
+  const seen = new Set(merged.map((image: any) => (typeof image === 'string' ? image : image?.url)));
+
+  for (const image of contributorImages) {
+    if (seen.has(image.url)) continue;
+    seen.add(image.url);
+    merged.push(image);
+  }
+
+  const updates: Record<string, any> = { contributor_images: merged };
+  if (!existing.submitted_by && submittedBy) updates.submitted_by = submittedBy;
+  if (!existing.swatch_path && swatchPath) {
+    updates.swatch_path = swatchPath;
+    updates.has_swatch = true;
+  }
+
+  const { error } = await supabase.from('colors').update(updates).eq('id', existing.id);
   return error?.message || null;
 }
 

--- a/tests/unit/server/api/admin/queue.test.ts
+++ b/tests/unit/server/api/admin/queue.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock Supabase query builder -- chainable, with async resolution via .then()
 // ---------------------------------------------------------------------------
 const mockSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
 const mockEq = vi.fn().mockReturnThis();
 const mockOrder = vi.fn().mockReturnThis();
 const mockSelect = vi.fn().mockReturnThis();
@@ -19,6 +20,7 @@ const queryBuilder: Record<string, any> = {
   eq: mockEq,
   order: mockOrder,
   single: mockSingle,
+  maybeSingle: mockMaybeSingle,
   // Allows `const { data, error } = await q;` via `await` on the builder
   then: vi.fn(),
 };
@@ -420,11 +422,14 @@ describe('server/api/admin/queue/approve.post', () => {
     mockEq.mockReturnThis();
     mockFrom.mockReturnValue(queryBuilder);
 
-    // Default: single fetch succeeds, update succeeds
+    // Default: single fetch succeeds, update succeeds.
+    // vi.clearAllMocks() only clears call history, so every mockResolvedValue
+    // set by a previous test survives -- each default has to be restored here.
     mockSingle.mockResolvedValue({
       data: { id: 'sub-1', type: 'new_item', target_type: 'color', target_id: null, data: { name: 'Test' } },
       error: null,
     });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
     resolveQuery({ data: null, error: null });
 
     const mod = await import('~/server/api/admin/queue/approve.post');
@@ -572,6 +577,231 @@ describe('server/api/admin/queue/approve.post', () => {
         contributor_images: [{ url: ownUrl('archive-colors', 'mine.jpg'), contributor: null }],
       })
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // "Add photos to an existing colour" -- data.originalColorId
+  //
+  // /contribute/color is the one archive form that is not the wizard, so this
+  // arrives as a new_item carrying the target colour's id in `data` rather than
+  // as an edit_suggestion with a target_id. Ignoring it inserted a photo-only
+  // duplicate row; two reached production, and because a duplicate shares its
+  // real colour's name+code+short_code it went on to steal the legacy id that
+  // 20260727000001_restore_wheel_colour_legacy_ids.sql was matching on.
+  // -------------------------------------------------------------------------
+  const EXISTING_COLOR_ID = 'c8f76d6c-c139-4e8c-9fac-fcfab47f78c2';
+
+  /** Resolve the `colors` lookup that the originalColorId branch performs. */
+  function mockExistingColor(row: any) {
+    mockMaybeSingle.mockResolvedValue({ data: row, error: null });
+  }
+
+  function colorContribution(overrides: Record<string, any> = {}) {
+    return {
+      id: 'sub-1',
+      type: 'new_item',
+      target_type: 'color',
+      target_id: null,
+      data: {
+        name: 'Opaline MET',
+        originalColorId: EXISTING_COLOR_ID,
+        uploadedFiles: [{ url: ownUrl('archive-colors', 'my-mini.jpg'), category: 'car-photos' }],
+        submittedBy: 'PhotoContributor',
+        ...overrides,
+      },
+    };
+  }
+
+  it('appends photos to the existing colour instead of inserting a duplicate', async () => {
+    mockFetchSubmission(colorContribution());
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: null,
+      swatch_path: '/swatches/opaline.png',
+      contributor_images: [{ url: '/existing/photo.jpg', contributor: 'SomeoneElse' }],
+    });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalledWith('colors');
+    expect(mockUpdate).toHaveBeenCalledWith({
+      contributor_images: [
+        { url: '/existing/photo.jpg', contributor: 'SomeoneElse' },
+        { url: ownUrl('archive-colors', 'my-mini.jpg'), contributor: 'PhotoContributor' },
+      ],
+    });
+    expect(mockEq).toHaveBeenCalledWith('id', EXISTING_COLOR_ID);
+  });
+
+  /** The colour UPDATE, picked out from the submission_queue status UPDATE. */
+  const colorUpdateCall = () => mockUpdate.mock.calls.find((call: any[]) => 'contributor_images' in call[0])?.[0];
+
+  it('claims an unowned colour for the submitter', async () => {
+    // The archive import left submitted_by NULL, which is the case this fills.
+    mockFetchSubmission({ ...colorContribution(), submitted_by: 'user-abc' });
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: null,
+      swatch_path: '/swatches/opaline.png',
+      contributor_images: null,
+    });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(colorUpdateCall()).toMatchObject({ submitted_by: 'user-abc' });
+  });
+
+  it('never reassigns a colour that already has an owner', async () => {
+    // Overwriting a real owner would move their credit -- and their trust
+    // counters, via contributor_archive_items -- onto someone else's photo.
+    mockFetchSubmission({ ...colorContribution(), submitted_by: 'user-abc' });
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: 'original-owner',
+      swatch_path: '/swatches/opaline.png',
+      contributor_images: null,
+    });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(colorUpdateCall()).not.toHaveProperty('submitted_by');
+  });
+
+  it('fills a missing swatch on the existing colour', async () => {
+    const swatch = ownUrl('archive-colors', 'swatch.png');
+    mockFetchSubmission(colorContribution({ uploadedFiles: [{ url: swatch, category: 'swatch' }] }));
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: null,
+      swatch_path: null,
+      contributor_images: [],
+    });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(colorUpdateCall()).toMatchObject({ swatch_path: swatch, has_swatch: true });
+  });
+
+  it('does not replace a swatch the existing colour already has', async () => {
+    const swatch = ownUrl('archive-colors', 'swatch.png');
+    mockFetchSubmission(colorContribution({ uploadedFiles: [{ url: swatch, category: 'swatch' }] }));
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: null,
+      swatch_path: '/swatches/curated.png',
+      contributor_images: [],
+    });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(colorUpdateCall()).not.toHaveProperty('swatch_path');
+  });
+
+  it('does not append the same photo twice when a submission is re-approved', async () => {
+    const photo = ownUrl('archive-colors', 'my-mini.jpg');
+    mockFetchSubmission(colorContribution());
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: null,
+      swatch_path: '/swatches/opaline.png',
+      contributor_images: [{ url: photo, contributor: 'PhotoContributor' }],
+    });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ contributor_images: [{ url: photo, contributor: 'PhotoContributor' }] })
+    );
+  });
+
+  it('still drops foreign asset URLs when attaching to an existing colour', async () => {
+    mockFetchSubmission(
+      colorContribution({
+        uploadedFiles: [
+          { url: 'https://evil.example.com/tracker.png', category: 'car-photos' },
+          { url: ownUrl('archive-colors', 'stolen.jpg', 'someone-elses-submission'), category: 'car-photos' },
+          { url: ownUrl('archive-colors', 'mine.jpg'), category: 'car-photos' },
+        ],
+      })
+    );
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: null,
+      swatch_path: '/swatches/opaline.png',
+      contributor_images: [],
+    });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contributor_images: [{ url: ownUrl('archive-colors', 'mine.jpg'), contributor: 'PhotoContributor' }],
+      })
+    );
+  });
+
+  it('inserts a new colour when originalColorId no longer resolves', async () => {
+    // A stale or deleted id must not drop the contribution on the floor.
+    mockFetchSubmission(colorContribution());
+    mockExistingColor(null);
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ name: 'Opaline MET', status: 'approved' }));
+  });
+
+  it('ignores an originalColorId that is not a uuid rather than 500ing on 22P02', async () => {
+    mockFetchSubmission(colorContribution({ originalColorId: 'not-a-uuid' }));
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ name: 'Opaline MET' }));
+  });
+
+  it('inserts normally when the submission carries no originalColorId', async () => {
+    mockFetchSubmission(colorContribution({ originalColorId: undefined }));
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+    await handler(createMockEvent());
+
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it('surfaces a failure to read the existing colour as a 500', async () => {
+    mockFetchSubmission(colorContribution());
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'colors read failed' } });
+
+    (readBody as any).mockResolvedValue({ id: 'sub-1' });
+    mockUpdateSuccess();
+
+    await expect(handler(createMockEvent())).rejects.toMatchObject({
+      statusCode: 500,
+      statusMessage: 'colors read failed',
+    });
+    expect(mockInsert).not.toHaveBeenCalled();
   });
 
   it('inserts into wheels table for new_item wheel submission', async () => {


### PR DESCRIPTION
## The bug

`/contribute/color` is the one archive form that is **not** the ContributeWizard — its swatch-versus-contributor-photo split does not fit the shared step 2. So an "add photos to this colour" submission arrives as a `new_item` carrying the chosen colour's id in `data.originalColorId`, rather than as an `edit_suggestion` with a `target_id`.

`insertApprovedItem()` in `server/api/admin/queue/approve.post.ts` ignored that field entirely and INSERTed a brand-new `colors` row carrying only the uploaded photos — no swatch, no `hex_value`, empty `ditzler_ppg_code`/`dulux_code`. `/archive/colors` then listed the same colour twice: one real, one photo-only stub.

## Why it mattered more than a duplicate row

A stub shares its real colour's `name+code+short_code` — the exact tuple that `20260727000001_restore_wheel_colour_legacy_ids.sql` (classicminidiy-supabase) matches on, and whose own header notes it is unique for only 293 of 299 rows. The duplicates *were* those collisions, so legacy DynamoDB id `4afbb608-423b-4f2d-95ad-e8269bdc672b` was restored onto the stub instead of the real imported colour, and `/archive/colors/4afbb608…` silently started resolving to a row with no colour data in it.

Confirmed in production, both cleaned up by supabase PR #77 — but the code path was unfixed and would have kept minting them:

| submission | `originalColorId` | duplicate created |
| --- | --- | --- |
| `09ecf0b7-b280-4642-b029-9d8c87fe0df1` | `c8f76d6c…` ("Opaline MET") | `fbfd2d29-d972-4acd-9ffa-50de8433a260` |
| `d086727f-9924-47d0-8f42-22f237d0d181` | `843cc36e…` ("Willow Green") | `42f32e9b-ae6d-4484-b7db-dd42724e01b0` |

## The fix

A uuid-shaped `originalColorId` that resolves to a live `colors` row now merges into it instead of inserting. Three choices are deliberately conservative, because the target is an existing public row rather than one this submission is creating:

- **`contributor_images` is appended, deduped by url** — re-approving a submission is not additive.
- **`submitted_by` is written only when the row has none.** The archive import left it NULL, which is the case this fills. Overwriting a real value would move another contributor's credit — and, through `contributor_archive_items`, their trust counters — onto this photo.
- **`swatch_path`/`has_swatch` fill only when the row has none.** A swatch-category upload is not discarded, but never replaces a curated swatch, and does not get misfiled as a car photo.

No other field is touched: correcting `hex_value` or a paint code on an existing colour is an edit suggestion, which goes through the `EDIT_TARGETS` allowlist.

Two fallbacks keep this from being a new failure mode:

- A **stale or deleted** id falls through to the INSERT rather than dropping the contribution on the floor.
- A **non-uuid** value is treated as absent. `colors.id` is a uuid, so an unparseable value reaching `.eq('id', …)` is a Postgres 22P02 surfacing as an opaque 500 on approval.

`isOwnUploadUrl` still gates every asset URL on this path — `submission_queue.data` is browser-written, so approving must not copy a foreign URL onto an archive row (the hole PR #697 closed on the insert path).

## Wheels and registry: checked, no equivalent bug

Their gap-fill goes through `edit_suggestion` + `target_id` (ContributeWizard, `/contribute/wheel?uuid=`), so the association lives on the submission row itself and `applyEditSuggestion()` → `PHOTO_APPEND_TARGETS` already honours it — there is no "attach to existing" field inside `data` that could be dropped. Documents have no attach affordance at all. Both facts are now comments on `PHOTO_APPEND_TARGETS` so the asymmetry is not rediscovered.

## Known gap, deliberately out of scope

`server/api/colors/queue/save.ts` is a **second live colour-approval path**, behind `/admin/colors/review`. That page is not linked from any nav but is reachable by URL, and `/api/colors/queue/list` spreads `...item.data`, so `originalColorId` round-trips to it and is ignored the same way. It is also worse in three respects: on the edit path it *replaces* rather than appends `contributor_images`, and it neither validates upload URLs nor writes `submitted_by`. Fixing it properly means extracting `isOwnUploadUrl`/`UPLOAD_BUCKETS` into a shared server util, which felt like a separate change. Flagged in `CLAUDE.md`; happy to do it here or in a follow-up — or delete the page if it is dead.

## Testing

8 new cases in `tests/unit/server/api/admin/queue.test.ts`, covering append-not-insert, url dedupe, the `submitted_by` and `swatch_path` guards in both directions, foreign-URL rejection on the attach path, the stale-id and non-uuid fallbacks, and read-failure surfacing as a 500.

Verified they fail against the unfixed handler (8 failed / 61 passed) and pass with it. Full server suite: **669 passed**, 31 files. No migration — schema and data changes live in classicminidiy-supabase only.
