### PR TITLE
fix(colors): close the second approval path that also minted duplicate colours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,9 +455,21 @@ parts of it that break silently if you get them wrong.
   (Two live instances, rows cleaned up by supabase PR #77.) When merging into an
   existing row, `submitted_by` and `swatch_path` are only written if the row does
   not already have one — reassigning either steals another contributor's credit
-  or overwrites curated data. **`server/api/colors/queue/save.ts` (the unlinked
-  legacy `/admin/colors/review` page) still has this bug** and additionally
-  *replaces* rather than appends `contributor_images`.
+  or overwrites curated data.
+
+- **TWO routes approve colours, and their shared decisions live in
+  `server/utils/archiveApprovals.ts` so they cannot drift again.**
+  `server/api/admin/queue/approve.post.ts` is the admin inbox and the path
+  submissions actually flow through; `server/api/colors/queue/save.ts` is the
+  older `/admin/colors/review` page, unlinked from every nav but reachable by
+  URL — and `/api/colors/queue/list` spreads `...item.data`, so the SAME
+  submissions are approvable from it. They had drifted on all four decisions
+  that matter: honouring `originalColorId`, appending rather than replacing
+  `contributor_images`, pinning asset URLs to this submission's own uploads
+  (`isOwnUploadUrl` — `submission_queue.data` is browser-written), and writing
+  `submitted_by`. Anything both routes must decide identically belongs in that
+  util, not copied into one of them. If you add a third approval surface, it
+  imports from there too.
 
 - **`contributor_archive_items` is the single source for every contributor stat.**
   It unions the approved, user-attributed rows of wheels / registry_entries / colors /

--- a/server/api/admin/queue/approve.post.ts
+++ b/server/api/admin/queue/approve.post.ts
@@ -1,6 +1,12 @@
 import { getServiceClient } from '../../../utils/supabase';
 import { requireAdminAuth } from '../../../utils/adminAuth';
 import { toDateOrNull } from '../../../utils/sanitize';
+import {
+  attachToExistingColor,
+  collectColorAssets,
+  isOwnUploadUrl,
+  resolveColorTarget,
+} from '../../../utils/archiveApprovals';
 
 /**
  * Where each submission target_type writes, and which of that table's columns a
@@ -80,9 +86,6 @@ const EDIT_TARGETS: Record<string, { table: string; columns: string[] }> = {
   },
 };
 
-/** Buckets server/api/archive/upload.ts is allowed to write to. */
-const UPLOAD_BUCKETS = ['archive-documents', 'archive-thumbnails', 'archive-colors', 'archive-wheels'] as const;
-
 /**
  * Which targets accept a photo-only addition, and the table whose `photos`
  * text[] column receives it. Colours store images in `contributor_images`
@@ -98,25 +101,6 @@ const PHOTO_APPEND_TARGETS: Record<string, string> = {
   wheel: 'wheels',
   registry: 'registry_entries',
 };
-
-/**
- * `/contribute/color` is the one archive form that is not the wizard (its
- * swatch-versus-contributor-photo split does not fit the shared step 2), so an
- * "add photos to this colour" submission arrives as a `new_item` carrying the
- * chosen colour's id in `data.originalColorId` rather than as an
- * `edit_suggestion` with a `target_id`.
- *
- * The id is client-written, and `colors.id` is a uuid — an unparseable value
- * reaching `.eq('id', …)` is a Postgres 22P02 surfacing as an opaque 500 on
- * approval, so anything that is not a uuid is treated as absent.
- */
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function asColorId(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const trimmed = value.trim();
-  return UUID_PATTERN.test(trimmed) ? trimmed : null;
-}
 
 export default defineEventHandler(async (event) => {
   const { user } = await requireAdminAuth(event);
@@ -216,52 +200,14 @@ async function insertApprovedItem(
 
   switch (targetType) {
     case 'color': {
-      // Map uploaded files to swatch_path and contributor_images based on category
-      let swatchPath = ownUrls([data.imageSwatch ?? data.swatch_path])[0] ?? null;
-      const contributorImages: { url: string; contributor?: string }[] = ownUrls(
-        data.images || data.contributor_images
-      ).map((url) => ({ url, contributor: data.submittedBy || data.legacy_submitted_by || null }));
-      const uploadedFiles = Array.isArray(data.uploadedFiles) ? data.uploadedFiles : [];
+      const { swatchPath, contributorImages } = collectColorAssets(data, submissionId);
 
-      for (const file of uploadedFiles) {
-        const fileObj = typeof file === 'string' ? { url: file, category: 'general' } : file;
-        if (!isOwnUploadUrl(fileObj?.url, submissionId)) continue;
-        if (fileObj.category === 'swatch' && !swatchPath) {
-          swatchPath = fileObj.url;
-        } else if (fileObj.category === 'car-photos' || fileObj.category === 'general') {
-          contributorImages.push({
-            url: fileObj.url,
-            contributor: data.submittedBy || data.legacy_submitted_by || null,
-          });
-        }
-      }
-
-      // "Add photos to a colour that already exists". Ignoring `originalColorId`
-      // INSERTed a second `colors` row carrying only the new photos — no swatch,
-      // no hex_value, empty ditzler_ppg_code/dulux_code — so /archive/colors
-      // listed the same colour twice, once real and once as a photo-only stub.
-      //
-      // Two of those reached production (supabase PR #77 cleaned the rows up)
-      // and the damage did not stop at the listing: the stubs share their real
-      // colour's name/code/short_code, which is exactly the tuple
-      // `20260727000001_restore_wheel_colour_legacy_ids.sql` matches on, so a
-      // legacy DynamoDB id was restored onto a stub and that colour's
-      // /archive/colors/<legacy-id> deep link started resolving to a row with
-      // no colour data in it.
-      const attachToId = asColorId(data.originalColorId);
-      if (attachToId) {
-        const { data: existing, error: readError } = await supabase
-          .from('colors')
-          .select('id, submitted_by, swatch_path, contributor_images')
-          .eq('id', attachToId)
-          .maybeSingle();
-        if (readError) return readError.message;
-
-        // A stale or deleted id falls through to the INSERT below rather than
-        // dropping the contribution on the floor.
-        if (existing) {
-          return attachToExistingColor(supabase, existing, contributorImages, swatchPath, submittedBy);
-        }
+      // "Add photos to a colour that already exists" — see attachToExistingColor
+      // for what this used to do instead and what it cost.
+      const { existing, error: readError } = await resolveColorTarget(supabase, data.originalColorId);
+      if (readError) return readError;
+      if (existing) {
+        return attachToExistingColor(supabase, existing, contributorImages, swatchPath, submittedBy);
       }
 
       ({ error } = await supabase.from('colors').insert({
@@ -347,73 +293,6 @@ async function insertApprovedItem(
   }
 
   return error?.message || null;
-}
-
-/**
- * Merges an approved colour contribution into the colour it was submitted
- * against, instead of creating a second row for it.
- *
- * Three things are deliberately conservative here, because the target is an
- * existing public row rather than one this submission is creating:
- *
- *  - `submitted_by` is only written when the row does not have one. The archive
- *    import left it NULL, which is the case this fills; overwriting a real value
- *    would move another contributor's credit — and, through the trust pipeline's
- *    `contributor_archive_items` view, their counters — onto this photo.
- *  - `swatch_path` is only written when the row has none. A colour that already
- *    has a swatch has a curated one; a submitted duplicate is not an upgrade,
- *    and it is not a car photo either, so it does not become one.
- *  - No other field is touched. Correcting `hex_value` or a paint code on an
- *    existing colour is an edit suggestion, which goes through EDIT_TARGETS.
- */
-async function attachToExistingColor(
-  supabase: any,
-  existing: { id: string; contributor_images: unknown; submitted_by: string | null; swatch_path: string | null },
-  contributorImages: { url: string; contributor?: string | null }[],
-  swatchPath: string | null,
-  submittedBy: string | null
-): Promise<string | null> {
-  const merged = Array.isArray(existing.contributor_images) ? [...existing.contributor_images] : [];
-  const seen = new Set(merged.map((image: any) => (typeof image === 'string' ? image : image?.url)));
-
-  for (const image of contributorImages) {
-    if (seen.has(image.url)) continue;
-    seen.add(image.url);
-    merged.push(image);
-  }
-
-  const updates: Record<string, any> = { contributor_images: merged };
-  if (!existing.submitted_by && submittedBy) updates.submitted_by = submittedBy;
-  if (!existing.swatch_path && swatchPath) {
-    updates.swatch_path = swatchPath;
-    updates.has_swatch = true;
-  }
-
-  const { error } = await supabase.from('colors').update(updates).eq('id', existing.id);
-  return error?.message || null;
-}
-
-/**
- * True only for URLs this app minted for THIS submission.
- *
- * The upload route writes files to
- * `<supabaseUrl>/storage/v1/object/public/<bucket>/uploads/<submissionId>/<name>`,
- * so pinning the whole prefix — origin, storage path, bucket allowlist and the
- * submission id — means a payload cannot smuggle in an external URL, another
- * bucket, or a file uploaded against somebody else's submission.
- *
- * `supabaseUrl` comes from runtimeConfig rather than a literal because Storage
- * is served from the custom domain (auth.classicminidiy.com); hardcoding the
- * project-ref host would reject every real upload.
- */
-function isOwnUploadUrl(url: unknown, submissionId: string): boolean {
-  if (typeof url !== 'string') return false;
-  const base = (useRuntimeConfig().public.supabaseUrl as string)?.replace(/\/$/, '');
-  if (!base) return false;
-
-  return UPLOAD_BUCKETS.some((bucket) =>
-    url.startsWith(`${base}/storage/v1/object/public/${bucket}/uploads/${submissionId}/`)
-  );
 }
 
 async function applyEditSuggestion(

--- a/server/api/colors/queue/save.ts
+++ b/server/api/colors/queue/save.ts
@@ -1,6 +1,25 @@
 import { getServiceClient } from '../../../utils/supabase';
 import { requireAdminAuth } from '../../../utils/adminAuth';
+import { attachToExistingColor, collectColorAssets, resolveColorTarget } from '../../../utils/archiveApprovals';
+import type { Json } from '~~/types/database';
 
+/**
+ * The older colour approval surface, behind `/admin/colors/review`.
+ *
+ * That page is not linked from any nav — the unified admin inbox
+ * (`/admin/inbox` → `server/api/admin/queue/approve.post.ts`) replaced it — but
+ * it is reachable by URL and `/api/colors/queue/list` spreads `...item.data`,
+ * so the very same submissions can be approved from here. It therefore has to
+ * make the same decisions as the inbox, and until 2026-08 it made four
+ * different ones: it ignored `originalColorId` (minting the duplicate colours
+ * supabase PR #77 had to fold), it REPLACED `contributor_images` on the edit
+ * path instead of appending, it never validated that an asset URL came from
+ * this submission's own uploads, and it never wrote `submitted_by` — so an
+ * approval here credited nobody and moved no trust counter.
+ *
+ * The shared decisions now live in `server/utils/archiveApprovals.ts` so the
+ * two routes cannot drift again.
+ */
 export default defineEventHandler(async (event) => {
   const { user } = await requireAdminAuth(event);
   const body = await readBody(event);
@@ -19,7 +38,7 @@ export default defineEventHandler(async (event) => {
   // Fetch the original submission to determine type and target
   const { data: submission, error: fetchError } = await supabase
     .from('submission_queue')
-    .select('type, target_id, data')
+    .select('type, target_id, data, submitted_by')
     .eq('id', uuid)
     .single();
 
@@ -27,19 +46,15 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'Submission not found' });
   }
 
-  // Map uploaded files to swatch_path and contributor_images based on category
-  const uploadedFiles = details.uploadedFiles || submission.data?.uploadedFiles || [];
-  let swatchPath = details.imageSwatch || details.swatch_path || null;
-  const contributorImages: { url: string; contributor?: string }[] = details.images || details.contributor_images || [];
-
-  for (const file of uploadedFiles) {
-    const fileObj = typeof file === 'string' ? { url: file, category: 'general' } : file;
-    if (fileObj.category === 'swatch' && !swatchPath) {
-      swatchPath = fileObj.url;
-    } else if (fileObj.category === 'car-photos' || fileObj.category === 'general') {
-      contributorImages.push({ url: fileObj.url, contributor: details.submittedBy || null });
-    }
-  }
+  // `details` is the admin-reviewed copy of the submission's `data`, posted back
+  // by the browser, so its asset URLs are no more trustworthy than the original
+  // payload's — collectColorAssets pins every one of them to this submission's
+  // own uploads. `uploadedFiles` falls back to the stored row because the review
+  // table only round-trips the fields it renders.
+  const { swatchPath, contributorImages } = collectColorAssets(
+    { ...details, uploadedFiles: details.uploadedFiles || (submission.data as any)?.uploadedFiles },
+    uuid
+  );
 
   const colorData = {
     name: details.name,
@@ -48,23 +63,51 @@ export default defineEventHandler(async (event) => {
     ditzler_ppg_code: details.ditzlerPpgCode || details.ditzler_ppg_code || '',
     dulux_code: details.duluxCode || details.dulux_code || '',
     hex_value: details.primaryColor || details.hex_value || details.hexValue || '',
-    has_swatch: !!swatchPath || details.hasSwatch || details.has_swatch || false,
-    swatch_path: swatchPath,
-    contributor_images: contributorImages,
-    status: 'approved',
   };
 
-  if (submission.type === 'edit_suggestion' && submission.target_id) {
-    // UPDATE the existing color instead of inserting a new one
-    const { error: colorError } = await supabase.from('colors').update(colorData).eq('id', submission.target_id);
+  // "Add photos to a colour that already exists" arrives two ways: as a
+  // new_item stamped with data.originalColorId (the /contribute/color form), or
+  // as an edit_suggestion carrying target_id. Both mean "merge into that row",
+  // and neither may create a second colour.
+  const attachTo = submission.type === 'edit_suggestion' ? submission.target_id : details.originalColorId;
+  const { existing, error: readError } = await resolveColorTarget(supabase, attachTo);
+  if (readError) {
+    throw createError({ statusCode: 500, statusMessage: readError });
+  }
 
-    if (colorError) {
-      throw createError({ statusCode: 500, statusMessage: colorError.message });
+  if (existing) {
+    // An edit_suggestion is a review of the fields too, so those are applied on
+    // top of the photo merge. A new_item never rewrites an existing colour's
+    // fields -- see attachToExistingColor.
+    const attachError = await attachToExistingColor(
+      supabase,
+      existing,
+      contributorImages,
+      swatchPath,
+      submission.submitted_by
+    );
+    if (attachError) {
+      throw createError({ statusCode: 500, statusMessage: attachError });
+    }
+
+    if (submission.type === 'edit_suggestion') {
+      const { error: fieldError } = await supabase.from('colors').update(colorData).eq('id', existing.id);
+      if (fieldError) {
+        throw createError({ statusCode: 500, statusMessage: fieldError.message });
+      }
     }
   } else {
-    // INSERT a new color for new_item submissions
+    // INSERT a new color for new_item submissions (and for an edit_suggestion
+    // whose target has since been deleted, which would otherwise write nothing).
     const { error: colorError } = await supabase.from('colors').insert({
       ...colorData,
+      has_swatch: !!swatchPath || details.hasSwatch || details.has_swatch || false,
+      swatch_path: swatchPath,
+      // `contributor_images` is a jsonb column, typed as `Json` by the generated
+      // client; the array of {url, contributor} satisfies it structurally.
+      contributor_images: contributorImages as unknown as Json,
+      status: 'approved',
+      submitted_by: submission.submitted_by,
       legacy_submitted_by: details.submittedBy || details.legacy_submitted_by || null,
       legacy_submitted_by_email: details.submittedByEmail || details.legacy_submitted_by_email || null,
     });

--- a/server/utils/archiveApprovals.ts
+++ b/server/utils/archiveApprovals.ts
@@ -1,0 +1,212 @@
+/**
+ * The parts of colour approval that BOTH approval routes have to agree on.
+ *
+ * Two surfaces approve colour submissions and write to the same `colors` table:
+ *
+ *  - `server/api/admin/queue/approve.post.ts` — the unified admin inbox, the
+ *    one contributors' submissions actually flow through today.
+ *  - `server/api/colors/queue/save.ts` — the older `/admin/colors/review` page.
+ *    It is not linked from any nav but is reachable by URL, and
+ *    `/api/colors/queue/list` spreads `...item.data`, so the same submissions
+ *    are approvable from it.
+ *
+ * They drifted, and the drift was invisible until it had already written to a
+ * public row: only one of them honoured `originalColorId`, so approving the
+ * same submission from the other door minted a duplicate colour. Anything both
+ * routes must decide the same way lives here rather than being copied.
+ */
+
+/** Buckets `server/api/archive/upload.ts` is allowed to write to. */
+export const UPLOAD_BUCKETS = ['archive-documents', 'archive-thumbnails', 'archive-colors', 'archive-wheels'] as const;
+
+/**
+ * True only for URLs this app minted for THIS submission.
+ *
+ * The upload route writes files to
+ * `<supabaseUrl>/storage/v1/object/public/<bucket>/uploads/<submissionId>/<name>`,
+ * so pinning the whole prefix — origin, storage path, bucket allowlist and the
+ * submission id — means a payload cannot smuggle in an external URL, another
+ * bucket, or a file uploaded against somebody else's submission.
+ *
+ * This matters because `submission_queue.data` is written by the BROWSER and the
+ * INSERT policy only checks `auth.uid() = submitted_by`, never the payload — so
+ * every asset URL in it is attacker-controlled until checked here.
+ *
+ * `supabaseUrl` comes from runtimeConfig rather than a literal because Storage
+ * is served from the custom domain (auth.classicminidiy.com); hardcoding the
+ * project-ref host would reject every real upload.
+ */
+export function isOwnUploadUrl(url: unknown, submissionId: string): boolean {
+  if (typeof url !== 'string') return false;
+  const base = (useRuntimeConfig().public.supabaseUrl as string)?.replace(/\/$/, '');
+  if (!base) return false;
+
+  return UPLOAD_BUCKETS.some((bucket) =>
+    url.startsWith(`${base}/storage/v1/object/public/${bucket}/uploads/${submissionId}/`)
+  );
+}
+
+/**
+ * `/contribute/color` is the one archive form that is not the wizard (its
+ * swatch-versus-contributor-photo split does not fit the shared step 2), so an
+ * "add photos to this colour" submission arrives as a `new_item` carrying the
+ * chosen colour's id in `data.originalColorId` rather than as an
+ * `edit_suggestion` with a `target_id`.
+ *
+ * The id is client-written, and `colors.id` is a uuid — an unparseable value
+ * reaching `.eq('id', …)` is a Postgres 22P02 surfacing as an opaque 500 on
+ * approval, so anything that is not a uuid is treated as absent.
+ */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function asColorId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return UUID_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+export interface ContributorImage {
+  url: string;
+  contributor?: string | null;
+}
+
+/**
+ * Sorts a colour submission's own uploads into the swatch slot and the
+ * contributor gallery, dropping anything that did not come from this
+ * submission's uploads.
+ *
+ * `category` is stamped by `/contribute/color` at upload time
+ * (`?category=swatch` vs `?category=car-photos`); a bare string or a missing
+ * category is treated as a gallery photo, which is what the pre-wizard payloads
+ * look like.
+ */
+export function collectColorAssets(
+  data: any,
+  submissionId: string
+): { swatchPath: string | null; contributorImages: ContributorImage[] } {
+  const contributor = data?.submittedBy || data?.legacy_submitted_by || null;
+
+  const ownUrls = (values: unknown): string[] =>
+    (Array.isArray(values) ? values : [])
+      .map((v: any) => (typeof v === 'string' ? v : (v?.url ?? v?.src)))
+      .filter((url: unknown): url is string => typeof url === 'string')
+      .filter((url) => isOwnUploadUrl(url, submissionId));
+
+  let swatchPath = ownUrls([data?.imageSwatch ?? data?.swatch_path])[0] ?? null;
+  const contributorImages: ContributorImage[] = ownUrls(data?.images || data?.contributor_images).map((url) => ({
+    url,
+    contributor,
+  }));
+
+  const uploadedFiles = Array.isArray(data?.uploadedFiles) ? data.uploadedFiles : [];
+  for (const file of uploadedFiles) {
+    const fileObj = typeof file === 'string' ? { url: file, category: 'general' } : file;
+    if (!isOwnUploadUrl(fileObj?.url, submissionId)) continue;
+    if (fileObj.category === 'swatch' && !swatchPath) {
+      swatchPath = fileObj.url;
+    } else if (fileObj.category === 'car-photos' || fileObj.category === 'general') {
+      contributorImages.push({ url: fileObj.url, contributor });
+    }
+  }
+
+  return { swatchPath, contributorImages };
+}
+
+/**
+ * Appends to a colour's contributor gallery, deduped by url.
+ *
+ * Append rather than replace: the gallery accumulates across contributors, so
+ * writing a single submission's photos over it drops everyone else's. Dedupe by
+ * url so re-approving a submission is not additive.
+ */
+export function mergeContributorImages(existing: unknown, incoming: ContributorImage[]): ContributorImage[] {
+  const merged = Array.isArray(existing) ? [...existing] : [];
+  const seen = new Set(merged.map((image: any) => (typeof image === 'string' ? image : image?.url)));
+
+  for (const image of incoming) {
+    if (seen.has(image.url)) continue;
+    seen.add(image.url);
+    merged.push(image);
+  }
+
+  return merged;
+}
+
+export interface ExistingColor {
+  id: string;
+  contributor_images: unknown;
+  submitted_by: string | null;
+  swatch_path: string | null;
+}
+
+/**
+ * Merges an approved colour contribution into the colour it was submitted
+ * against, instead of creating a second row for it.
+ *
+ * Ignoring `originalColorId` INSERTed a photo-only stub — same name, no
+ * hex_value, no swatch, empty paint codes — so `/archive/colors` listed the
+ * colour twice. The blast radius went past the listing: a stub shares its real
+ * colour's `name+code+short_code`, the exact tuple
+ * `20260727000001_restore_wheel_colour_legacy_ids.sql` matches on, so a legacy
+ * DynamoDB id was restored onto a stub and that colour's legacy deep link
+ * started resolving to a row with no colour data in it. Two instances reached
+ * production; supabase PR #77 cleaned the rows up.
+ *
+ * Three things are deliberately conservative here, because the target is an
+ * existing public row rather than one this submission is creating:
+ *
+ *  - `submitted_by` is only written when the row does not have one. The archive
+ *    import left it NULL, which is the case this fills; overwriting a real value
+ *    would move another contributor's credit — and, through the trust
+ *    pipeline's `contributor_archive_items` view, their counters — onto this
+ *    photo.
+ *  - `swatch_path` is only written when the row has none. A colour that already
+ *    has a swatch has a curated one; a submitted duplicate is not an upgrade,
+ *    and it is not a car photo either, so it does not become one.
+ *  - No other field is touched. Correcting `hex_value` or a paint code on an
+ *    existing colour is an edit suggestion, which goes through the approve
+ *    route's `EDIT_TARGETS` allowlist.
+ */
+export async function attachToExistingColor(
+  supabase: any,
+  existing: ExistingColor,
+  contributorImages: ContributorImage[],
+  swatchPath: string | null,
+  submittedBy: string | null
+): Promise<string | null> {
+  const updates: Record<string, any> = {
+    contributor_images: mergeContributorImages(existing.contributor_images, contributorImages),
+  };
+
+  if (!existing.submitted_by && submittedBy) updates.submitted_by = submittedBy;
+  if (!existing.swatch_path && swatchPath) {
+    updates.swatch_path = swatchPath;
+    updates.has_swatch = true;
+  }
+
+  const { error } = await supabase.from('colors').update(updates).eq('id', existing.id);
+  return error?.message || null;
+}
+
+/** The columns `attachToExistingColor` needs in order to decide what to write. */
+export const EXISTING_COLOR_COLUMNS = 'id, submitted_by, swatch_path, contributor_images';
+
+/**
+ * Resolves `data.originalColorId` to the row it names, or null when the
+ * submission is not an "add to an existing colour" one.
+ *
+ * A stale or deleted id resolves to null so the caller falls through to its
+ * INSERT rather than dropping the contribution on the floor.
+ */
+export async function resolveColorTarget(
+  supabase: any,
+  originalColorId: unknown
+): Promise<{ existing: ExistingColor | null; error: string | null }> {
+  const id = asColorId(originalColorId);
+  if (!id) return { existing: null, error: null };
+
+  const { data, error } = await supabase.from('colors').select(EXISTING_COLOR_COLUMNS).eq('id', id).maybeSingle();
+
+  if (error) return { existing: null, error: error.message };
+  return { existing: (data as ExistingColor) || null, error: null };
+}

--- a/server/utils/archiveApprovals.ts
+++ b/server/utils/archiveApprovals.ts
@@ -100,11 +100,19 @@ export function collectColorAssets(
 
   const uploadedFiles = Array.isArray(data?.uploadedFiles) ? data.uploadedFiles : [];
   for (const file of uploadedFiles) {
-    const fileObj = typeof file === 'string' ? { url: file, category: 'general' } : file;
+    const fileObj = typeof file === 'string' ? { url: file } : file;
     if (!isOwnUploadUrl(fileObj?.url, submissionId)) continue;
-    if (fileObj.category === 'swatch' && !swatchPath) {
+
+    // Default the category for OBJECT entries too, not just bare strings.
+    // `server/api/archive/upload.ts` stamps 'general' when the caller sends no
+    // `?category=`, but `submission_queue.data` is browser-written, so
+    // `{ url, category: undefined }` is reachable — and matching neither arm of
+    // the branch below silently dropped a legitimate own-upload photo.
+    const category = fileObj?.category || 'general';
+
+    if (category === 'swatch' && !swatchPath) {
       swatchPath = fileObj.url;
-    } else if (fileObj.category === 'car-photos' || fileObj.category === 'general') {
+    } else if (category === 'car-photos' || category === 'general') {
       contributorImages.push({ url: fileObj.url, contributor });
     }
   }

--- a/tests/unit/server/api/colors/queue-save.test.ts
+++ b/tests/unit/server/api/colors/queue-save.test.ts
@@ -1,0 +1,322 @@
+/** @vitest-environment node */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock Supabase query builder -- chainable, with async resolution via .then()
+// ---------------------------------------------------------------------------
+const mockSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+const mockEq = vi.fn().mockReturnThis();
+const mockSelect = vi.fn().mockReturnThis();
+const mockInsert = vi.fn().mockReturnThis();
+const mockUpdate = vi.fn().mockReturnThis();
+
+const queryBuilder: Record<string, any> = {
+  select: mockSelect,
+  insert: mockInsert,
+  update: mockUpdate,
+  eq: mockEq,
+  single: mockSingle,
+  maybeSingle: mockMaybeSingle,
+  then: vi.fn(),
+};
+
+const mockFrom = vi.fn(() => queryBuilder);
+const mockSupabase = { from: mockFrom };
+
+const mockRequireAdminAuth = vi.fn().mockResolvedValue({ user: { id: 'admin-123' } });
+
+vi.stubGlobal('defineEventHandler', (handler: Function) => handler);
+vi.stubGlobal('createError', (opts: any) => {
+  const e: any = new Error(opts.statusMessage || opts.message);
+  e.statusCode = opts.statusCode;
+  e.statusMessage = opts.statusMessage;
+  return e;
+});
+vi.stubGlobal('readBody', vi.fn().mockResolvedValue({}));
+vi.stubGlobal(
+  'useRuntimeConfig',
+  vi.fn(() => ({
+    public: { supabaseUrl: 'https://test.supabase.co', supabaseKey: 'test-key' },
+    SUPABASE_SERVICE_KEY: 'test-service-key',
+  }))
+);
+
+vi.mock('~/server/utils/supabase', () => ({
+  getServiceClient: vi.fn(() => mockSupabase),
+}));
+
+vi.mock('~/server/utils/adminAuth', () => ({
+  requireAdminAuth: mockRequireAdminAuth,
+}));
+
+function createMockEvent() {
+  return { node: { req: {} } } as any;
+}
+
+function resolveQuery(result: { data?: any; error?: any }) {
+  queryBuilder.then = vi.fn((resolve: any) => resolve({ data: result.data ?? null, error: result.error ?? null }));
+}
+
+// ===========================================================================
+//  server/api/colors/queue/save
+//
+//  The older /admin/colors/review approval surface. It is not linked from any
+//  nav, but it is reachable by URL and /api/colors/queue/list spreads
+//  ...item.data, so the same submissions are approvable from it -- which is why
+//  it has to make the same four decisions the admin inbox makes. Before
+//  2026-08 it made none of them: it ignored originalColorId (minting the
+//  duplicate colours supabase PR #77 folded), replaced contributor_images
+//  instead of appending, never validated upload URLs, and never wrote
+//  submitted_by.
+// ===========================================================================
+
+describe('server/api/colors/queue/save', () => {
+  let handler: Function;
+
+  const SUBMISSION_ID = 'sub-legacy-1';
+  const EXISTING_COLOR_ID = '843cc36e-cf46-4085-a22b-8a563f2dde63';
+
+  /** Real uploads look exactly like this -- see server/api/archive/upload.ts. */
+  const ownUrl = (name: string, submissionId = SUBMISSION_ID) =>
+    `https://test.supabase.co/storage/v1/object/public/archive-colors/uploads/${submissionId}/${name}`;
+
+  function mockSubmission(submission: any) {
+    mockSingle.mockResolvedValue({ data: submission, error: null });
+  }
+
+  function mockExistingColor(row: any) {
+    mockMaybeSingle.mockResolvedValue({ data: row, error: null });
+  }
+
+  /** The colour write, picked out from the submission_queue status update. */
+  const colorImageUpdate = () => mockUpdate.mock.calls.find((call: any[]) => 'contributor_images' in call[0])?.[0];
+  const colorFieldUpdate = () => mockUpdate.mock.calls.find((call: any[]) => 'hex_value' in call[0])?.[0];
+
+  const details = (overrides: Record<string, any> = {}) => ({
+    name: 'Willow Green',
+    code: 'WG',
+    primaryColor: '#8DB600',
+    submittedBy: 'PhotoContributor',
+    uploadedFiles: [{ url: ownUrl('my-mini.jpg'), category: 'car-photos' }],
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    mockRequireAdminAuth.mockResolvedValue({ user: { id: 'admin-123' } });
+
+    mockSelect.mockReturnThis();
+    mockInsert.mockReturnThis();
+    mockUpdate.mockReturnThis();
+    mockEq.mockReturnThis();
+    mockFrom.mockReturnValue(queryBuilder);
+
+    // vi.clearAllMocks() only clears call history, so every default has to be
+    // restored here or it leaks from the previous test.
+    mockSingle.mockResolvedValue({
+      data: { type: 'new_item', target_id: null, data: {}, submitted_by: 'user-abc' },
+      error: null,
+    });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    resolveQuery({ data: null, error: null });
+
+    (readBody as any).mockResolvedValue({ uuid: SUBMISSION_ID, details: details() });
+
+    const mod = await import('~/server/api/colors/queue/save');
+    handler = mod.default;
+  });
+
+  it('throws 400 when uuid is missing', async () => {
+    (readBody as any).mockResolvedValue({ details: details() });
+    await expect(handler(createMockEvent())).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: 'Invalid or missing uuid',
+    });
+  });
+
+  it('throws 400 when details have no name', async () => {
+    (readBody as any).mockResolvedValue({ uuid: SUBMISSION_ID, details: { code: 'WG' } });
+    await expect(handler(createMockEvent())).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: 'Invalid or missing color details',
+    });
+  });
+
+  it('throws 404 when the submission is gone', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'Not found' } });
+    await expect(handler(createMockEvent())).rejects.toMatchObject({
+      statusCode: 404,
+      statusMessage: 'Submission not found',
+    });
+  });
+
+  it('attaches to the named colour instead of inserting a duplicate', async () => {
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({ originalColorId: EXISTING_COLOR_ID }),
+    });
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: null,
+      swatch_path: '/swatches/willow.png',
+      contributor_images: [{ url: '/existing/photo.jpg', contributor: 'SomeoneElse' }],
+    });
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(colorImageUpdate()).toEqual({
+      contributor_images: [
+        { url: '/existing/photo.jpg', contributor: 'SomeoneElse' },
+        { url: ownUrl('my-mini.jpg'), contributor: 'PhotoContributor' },
+      ],
+      submitted_by: 'user-abc',
+    });
+    // A new_item never rewrites the existing colour's fields.
+    expect(colorFieldUpdate()).toBeUndefined();
+  });
+
+  it('appends to contributor_images on an edit suggestion rather than replacing them', async () => {
+    mockSubmission({
+      type: 'edit_suggestion',
+      target_id: EXISTING_COLOR_ID,
+      data: {},
+      submitted_by: 'user-abc',
+    });
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: 'original-owner',
+      swatch_path: '/swatches/willow.png',
+      contributor_images: [{ url: '/existing/photo.jpg', contributor: 'SomeoneElse' }],
+    });
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(colorImageUpdate().contributor_images).toEqual([
+      { url: '/existing/photo.jpg', contributor: 'SomeoneElse' },
+      { url: ownUrl('my-mini.jpg'), contributor: 'PhotoContributor' },
+    ]);
+    // The reviewed field values still land -- this surface is a field review too.
+    expect(colorFieldUpdate()).toMatchObject({ name: 'Willow Green', code: 'WG', hex_value: '#8DB600' });
+  });
+
+  it('does not reassign a colour that already has an owner', async () => {
+    mockSubmission({ type: 'edit_suggestion', target_id: EXISTING_COLOR_ID, data: {}, submitted_by: 'user-abc' });
+    mockExistingColor({
+      id: EXISTING_COLOR_ID,
+      submitted_by: 'original-owner',
+      swatch_path: '/swatches/willow.png',
+      contributor_images: [],
+    });
+
+    await handler(createMockEvent());
+
+    expect(colorImageUpdate()).not.toHaveProperty('submitted_by');
+  });
+
+  it('drops asset URLs that did not come from this submission’s uploads', async () => {
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({
+        uploadedFiles: [
+          { url: 'https://evil.example.com/tracker.png', category: 'car-photos' },
+          { url: ownUrl('stolen.jpg', 'someone-elses-submission'), category: 'car-photos' },
+          { url: ownUrl('mine.jpg'), category: 'car-photos' },
+        ],
+        imageSwatch: 'https://evil.example.com/swatch.png',
+      }),
+    });
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        swatch_path: null,
+        contributor_images: [{ url: ownUrl('mine.jpg'), contributor: 'PhotoContributor' }],
+      })
+    );
+  });
+
+  it('credits the submitter on a newly inserted colour', async () => {
+    await handler(createMockEvent());
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Willow Green',
+        status: 'approved',
+        submitted_by: 'user-abc',
+        legacy_submitted_by: 'PhotoContributor',
+      })
+    );
+  });
+
+  it('inserts when originalColorId no longer resolves', async () => {
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({ originalColorId: EXISTING_COLOR_ID }),
+    });
+    mockExistingColor(null);
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ name: 'Willow Green' }));
+  });
+
+  it('ignores an originalColorId that is not a uuid rather than 500ing on 22P02', async () => {
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({ originalColorId: 'not-a-uuid' }),
+    });
+
+    await handler(createMockEvent());
+
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it('falls back to the stored uploadedFiles when the review table did not round-trip them', async () => {
+    mockSubmission({
+      type: 'new_item',
+      target_id: null,
+      data: { uploadedFiles: [{ url: ownUrl('stored.jpg'), category: 'car-photos' }] },
+      submitted_by: 'user-abc',
+    });
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({ uploadedFiles: undefined }),
+    });
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contributor_images: [{ url: ownUrl('stored.jpg'), contributor: 'PhotoContributor' }],
+      })
+    );
+  });
+
+  it('marks the submission approved with the reviewing admin', async () => {
+    await handler(createMockEvent());
+
+    expect(mockFrom).toHaveBeenCalledWith('submission_queue');
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ status: 'approved', reviewed_by: 'admin-123' }));
+  });
+
+  it('surfaces a colour read failure as a 500', async () => {
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({ originalColorId: EXISTING_COLOR_ID }),
+    });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'colors read failed' } });
+
+    await expect(handler(createMockEvent())).rejects.toMatchObject({
+      statusCode: 500,
+      statusMessage: 'colors read failed',
+    });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server/api/colors/queue-save.test.ts
+++ b/tests/unit/server/api/colors/queue-save.test.ts
@@ -241,6 +241,42 @@ describe('server/api/colors/queue/save', () => {
     );
   });
 
+  it('keeps an own-upload that carries no category', async () => {
+    // upload.ts stamps 'general' when the caller sends no ?category=, but
+    // submission_queue.data is browser-written, so { url } with no category is
+    // reachable -- and it used to match neither arm of the sort and vanish.
+    // Raised by Copilot on PR #699.
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({
+        uploadedFiles: [{ url: ownUrl('no-category.jpg') }, { url: ownUrl('explicit.jpg'), category: 'car-photos' }],
+      }),
+    });
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contributor_images: [
+          { url: ownUrl('no-category.jpg'), contributor: 'PhotoContributor' },
+          { url: ownUrl('explicit.jpg'), contributor: 'PhotoContributor' },
+        ],
+      })
+    );
+  });
+
+  it('still ignores an upload whose category is not a colour category', async () => {
+    // Defaulting a MISSING category must not turn an unknown one into a photo.
+    (readBody as any).mockResolvedValue({
+      uuid: SUBMISSION_ID,
+      details: details({ uploadedFiles: [{ url: ownUrl('thumb.jpg'), category: 'thumbnail' }] }),
+    });
+
+    await handler(createMockEvent());
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ contributor_images: [] }));
+  });
+
   it('credits the submitter on a newly inserted colour', async () => {
     await handler(createMockEvent());
 


### PR DESCRIPTION
Follow-up to #698, which fixed the duplicate-colour bug in the admin inbox. This closes the other door.

## There were two colour approval routes, and they disagreed

`server/api/colors/queue/save.ts` backs `/admin/colors/review`. That page is not linked from any nav — the unified inbox replaced it — but it is reachable by URL, and `/api/colors/queue/list` spreads `...item.data`, so **the same submissions are approvable from it**. It had drifted from `approve.post.ts` on all four decisions that matter:

| decision | inbox (`approve.post.ts`) | legacy (`colors/queue/save.ts`) |
| --- | --- | --- |
| honours `data.originalColorId` | ✅ since #698 | ❌ — still minted the photo-only duplicate |
| `contributor_images` on edit | append, deduped | ❌ **replaced** — dropped every other contributor's photos |
| asset URL validation | `isOwnUploadUrl` | ❌ none — a crafted payload could put an arbitrary external URL on a public row |
| writes `submitted_by` | ✅ | ❌ — approvals credited nobody, moved no trust counter |

I could not determine which of the two doors minted the production duplicates supabase PR #77 had to fold, which is reason enough to close both.

## The actual fix is the deduplication

The duplicate-colour bug *was* a drift bug, and two copies of this logic will drift again. So the shared decisions now live in **`server/utils/archiveApprovals.ts`** and both routes import them:

- `UPLOAD_BUCKETS` + `isOwnUploadUrl` — `submission_queue.data` is browser-written and its INSERT policy only checks `auth.uid() = submitted_by`, never the payload.
- `collectColorAssets` — sorts a submission's own uploads into the swatch slot vs the contributor gallery.
- `mergeContributorImages` — append, deduped by url, so re-approving is not additive.
- `attachToExistingColor` — the merge, with `submitted_by`/`swatch_path` written only when the row has none.
- `resolveColorTarget` — uuid-guards the id (a non-uuid would reach `.eq('id', …)` as a Postgres 22P02) and returns null for a stale one so the caller falls through to INSERT.

`approve.post.ts` moves onto these helpers with **no behaviour change** — its 69 existing tests pass untouched, which is the check that the extraction was faithful.

## One deliberate behaviour change on the legacy route

Its edit path no longer writes `status: 'approved'` onto the target colour. `status` is a moderation column — exactly the class `EDIT_TARGETS` exists to keep client-controlled data away from — and the inbox's edit path does not write it either. Flagging it because it is the one thing here that is not a pure bug fix.

The edit path still applies the admin-reviewed field values (name/code/short_code/paint codes/hex), since that page *is* a field review; it just no longer clobbers the photo gallery and swatch while doing so.

## Testing

13 new tests in `tests/unit/server/api/colors/queue-save.test.ts` — attach-not-insert, append-not-replace, the owner and swatch guards, foreign-URL rejection, the `submitted_by` credit, stale-id and non-uuid fallbacks, the stored-`uploadedFiles` fallback, and read-failure surfacing.

**5 of them fail against the pre-fix route** (verified by stashing it), one per bug above. Server suite: **682 passing**, 32 files. Typecheck on all three touched files is clean — the two pre-existing `queue/save.ts` type errors are gone too.

No migration; nothing to deploy to supabase.

## Still open

Whether `/admin/colors/review` should exist at all. It is unlinked, its functionality is fully covered by `/admin/inbox`, and keeping it means keeping a second write path to `colors` in sync forever. Now that it is correct, deleting it is a safe follow-up whenever you want — say the word.
